### PR TITLE
[REFACTOR] Jinja2 템플릿 아키텍처 개선

### DIFF
--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -52,6 +52,7 @@ function createImageBlock(block) {
   const caption = node.querySelector('.notion-caption');
 
   image.src = block.url;
+  image.alt = block.caption || '';
   caption.textContent = block.caption || '';
 
   if (!block.caption) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,6 @@
 
   {% block templates %}{% endblock %}
 
-  <script src="/static/js/gallery.js" defer></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,3 +23,7 @@
 {% block templates %}
 {% include "partials/block_templates.html" %}
 {% endblock %}
+
+{% block scripts %}
+<script src="/static/js/gallery.js" defer></script>
+{% endblock %}

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -4,7 +4,7 @@
 
 <template id="image-block-template">
   <figure class="notion-block notion-image-wrap">
-    <img class="notion-image" alt="block image" loading="lazy" />
+    <img class="notion-image" alt="" loading="lazy" />
     <figcaption class="notion-caption"></figcaption>
   </figure>
 </template>


### PR DESCRIPTION
## Summary

- 배경: `templates/index.html` 한 파일에 레이아웃, 블록 `<template>` 태그, 스크립트 로드가 모두 혼재되어 블록 타입이 늘어날수록 파일이 비대해지고 재사용이 어려운 상황
- 목적: Jinja2의 `extends`·`include` 구조로 템플릿을 분리해 유지보수성 향상

## Changes

- `templates/base.html` 신규 생성 — 공통 레이아웃(head, topbar, 정적 파일 링크) 및 `{% block %}` 슬롯 정의
- `templates/partials/block_templates.html` 신규 생성 — 4종 `<template>` 태그(text, image, container, page) 분리
- `templates/index.html` 슬림화 — `base.html` `extends` 후 `content` 블록에 main 영역, `templates` 블록에서 `partials/block_templates.html` `include`
- `gallery.js` 로드를 `base.html`에서 `index.html`의 `{% block scripts %}`로 이동 — base를 다른 페이지가 extend할 때 index 전용 스크립트로 인한 오류 방지
- 이미지 블록 `alt` 속성을 정적 텍스트(`"block image"`)에서 caption 기반 동적 할당으로 변경 (접근성 개선)

## Test

- [ ] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [ ] 주요 경로 확인 (`/`, `/api/documents`)
- [ ] 브라우저 콘솔 에러 없음

## Checklist

- [ ] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [ ] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `partials/block_templates.html` include 경로가 Jinja2Templates 루트(`templates/`) 기준으로 올바르게 해석되는지 확인
- `base.html`의 `{% block %}` 슬롯 구조가 향후 블록 타입 추가 시 확장성 있게 설계되었는지 확인

Closes #9