### PR TITLE
[FEAT#24] 블록 정렬 및 레이아웃 개선

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,11 +71,6 @@ body.sidebar-collapsed .main-area {
   margin-left: 0;
 }
 
-.topbar {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 2.6rem 1.2rem 1.2rem;
-}
 
 /* ── Sidebar bookmark tab ─────────────────────────────────────────────────── */
 
@@ -151,17 +146,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-weight: 700;
 }
 
-.topbar h1 {
-  margin: 0.25rem 0 0;
-  font-family: "Fraunces", serif;
-  font-size: clamp(1.8rem, 4vw, 3.4rem);
-}
-
-.subcopy {
-  margin: 0.55rem 0 0;
-  max-width: 720px;
-  color: var(--ink-soft);
-}
 
 .document-list-header {
   display: flex;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -294,7 +294,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .block-page {
   max-width: 800px;
   margin: 0 auto;
-  padding: 1.15rem 1.2rem 3rem;
+  padding: 1.15rem 1.2rem 3rem 4rem; /* left: 4rem = 64px, 버튼(48px) + 여백 확보 */
 }
 
 .block-page-header {
@@ -317,7 +317,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .block-root {
   display: grid;
   gap: 0.39rem;
-  padding-left: 48px;
 }
 
 .notion-block {
@@ -557,7 +556,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 
 .block-wrapper {
   position: relative;
-  padding-left: 4px;
 }
 
 .block-actions {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -275,10 +275,16 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   background: #fdeaea;
 }
 
+.block-page-cover {
+  width: 100%;
+  height: 15rem;
+  background: var(--paper-deep);
+}
+
 .block-page {
-  max-width: 800px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 1.15rem 1.2rem 3rem 4rem; /* left: 4rem = 64px, 버튼(48px) + 여백 확보 */
+  padding: 1.5rem 1.2rem 3rem 4rem; /* left: 4rem = 64px, 버튼(48px) + 여백 확보 */
 }
 
 .block-page-header {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -293,7 +293,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   padding-bottom: 0.85rem;
 }
 
-.block-page-header h2 {
+.block-page-header h1 {
   margin: 0;
   font-family: "Fraunces", serif;
   font-size: clamp(1.35rem, 3vw, 2.2rem);

--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -161,7 +161,8 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
     }
   });
 
-  wrapper.addEventListener('dragover', (e) => {
+  // ── Drop target (blockEl only — action buttons excluded) ────────────────
+  blockEl.addEventListener('dragover', (e) => {
     if (!currentDragBlockId) return;
     // Only allow drops from same-parent siblings
     if (currentDragParentBlockId !== (parentBlockId ?? '')) return;
@@ -183,13 +184,13 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
     wrapper.classList.toggle('drop-below', !isAbove);
   });
 
-  wrapper.addEventListener('dragleave', (e) => {
-    if (!wrapper.contains(e.relatedTarget)) {
+  blockEl.addEventListener('dragleave', (e) => {
+    if (!blockEl.contains(e.relatedTarget)) {
       wrapper.classList.remove('drop-above', 'drop-below');
     }
   });
 
-  wrapper.addEventListener('drop', async (e) => {
+  blockEl.addEventListener('drop', async (e) => {
     e.preventDefault();
     e.stopPropagation();
     wrapper.classList.remove('drop-above', 'drop-below');

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="block-page-cover"></div>
 <section class="block-page" aria-live="polite">
   <header class="block-page-header">
     <h2 id="page-title"></h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,11 +18,6 @@
 {% endblock %}
 
 {% block content %}
-<header class="topbar">
-  <h1>Block-based Project Manager</h1>
-  <p class="subcopy">텍스트, 이미지, 컨테이너 블록을 조합해 노션처럼 프로젝트 페이지를 구성합니다.</p>
-</header>
-
 <section class="block-page" aria-live="polite">
   <header class="block-page-header">
     <h2 id="page-title"></h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
 <div class="block-page-cover"></div>
 <section class="block-page" aria-live="polite">
   <header class="block-page-header">
-    <h2 id="page-title"></h2>
+    <h1 id="page-title"></h1>
     <p id="page-subtitle"></p>
   </header>
   <div id="block-root" class="block-root"></div>


### PR DESCRIPTION
## Summary

- 배경: 문서 내 블록 순서를 드래그 앤 드롭으로 변경할 수 있는 기능 구현 및 관련 레이아웃 정리
- 목적: 블록만 드롭 타겟으로 한정하고, 블록 콘텐츠를 페이지 타이틀과 정렬시켜 일관된 시각적 구조 확립

## Changes

- `blockWrapper.js`: `dragover` / `dragleave` / `drop` 이벤트 대상을 `.block-wrapper`에서 `.notion-block`(blockEl)으로 이동 — 액션 버튼 영역을 드롭 타겟에서 제외
- `style.css`: `.block-root`의 `padding-left: 48px` 제거, `.block-page` 좌측 패딩을 `4rem`으로 확장해 블록 콘텐츠가 페이지 타이틀과 동일 선상에 정렬되도록 변경
- `style.css`: `.block-page-cover` 추가 — 페이지 상단에 full-width 배경 영역(15rem) 삽입
- `style.css`: `.block-page` 최대 너비를 `800px → 960px`으로 확장
- `templates/index.html`: 전체 페이지에 표시되던 topbar 헤더 문구 제거, 커버 영역 마크업 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [x] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `blockEl`에 dragover를 붙였을 때 컨테이너 블록 내 중첩 자식들의 드래그 이벤트 버블링이 올바르게 차단되는지 확인