### PR TITLE
[FEAT#26] 텍스트 서식 편집 기능 확장 (Bold/Italic/Underline/Strikethrough/인라인코드/링크/색상)

### DIFF
--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -18,6 +18,7 @@ class TextBlock(BlockBase):
   type: Literal["text"]
   text: str
   level: Literal[1, 2, 3] | None = None
+  formatted_text: str | None = None  # HTML string with inline formatting
 
 
 class ImageBlock(BlockBase):

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -17,6 +17,7 @@ class BlockPatch(BaseModel):
   caption: str | None = None
   title: str | None = None
   level: Literal[1, 2, 3] | None = None
+  formatted_text: str | None = None  # HTML string with inline formatting
 
 
 class BlockPositionPatch(BaseModel):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -869,6 +869,208 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   border-color: #a83030;
 }
 
+/* ── Formatting toolbar ──────────────────────────────────────────────────── */
+
+.formatting-toolbar {
+  position: absolute;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  background: #2f2f2f;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px -4px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  white-space: nowrap;
+}
+
+.formatting-toolbar.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.fmt-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: #e8e8e8;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.1s;
+  flex-shrink: 0;
+}
+
+.fmt-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.fmt-btn.is-active {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.fmt-divider {
+  width: 1px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.2);
+  margin: 0 2px;
+  flex-shrink: 0;
+}
+
+.fmt-color-btn {
+  position: relative;
+}
+
+.fmt-color-swatch {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  background: currentColor;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+}
+
+/* Color picker dropdown */
+.fmt-color-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 8px 20px -6px var(--shadow);
+  padding: 8px;
+  display: none;
+  width: 180px;
+  z-index: 101;
+  animation: fade-slide-up 0.12s ease both;
+}
+
+.fmt-color-panel.is-open {
+  display: block;
+}
+
+.fmt-color-section-label {
+  font-size: 0.72rem;
+  color: var(--ink-soft);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+  padding: 0 2px;
+}
+
+.fmt-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.fmt-color-swatch-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 1.5px solid rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.1s;
+  padding: 0;
+}
+
+.fmt-color-swatch-btn:hover {
+  transform: scale(1.15);
+  border-color: var(--accent);
+}
+
+.fmt-color-swatch-btn.is-default {
+  background: linear-gradient(to bottom right, #fff 45%, #e0e0e0 55%);
+  position: relative;
+}
+
+/* Link input inside toolbar */
+.fmt-link-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 8px 20px -6px var(--shadow);
+  padding: 8px;
+  display: none;
+  min-width: 260px;
+  z-index: 101;
+  animation: fade-slide-up 0.12s ease both;
+}
+
+.fmt-link-panel.is-open {
+  display: flex;
+  gap: 6px;
+}
+
+.fmt-link-input {
+  flex: 1;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.38rem 0.55rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--ink);
+  background: var(--paper);
+  outline: none;
+}
+
+.fmt-link-input:focus {
+  border-color: var(--accent);
+}
+
+.fmt-link-confirm {
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.38rem 0.7rem;
+  font-family: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* ── Inline formatting elements ──────────────────────────────────────────── */
+
+.notion-text code,
+.notion-text code * {
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 0.875em;
+  background: rgba(135, 131, 120, 0.15);
+  color: #eb5757;
+  border-radius: 3px;
+  padding: 0.1em 0.3em;
+}
+
+.notion-text a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.notion-text a:hover {
+  opacity: 0.75;
+}
+
 @keyframes fade-slide-up {
   from {
     opacity: 0;

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -9,6 +9,7 @@ import {
   sanitizeHtml,
   setEditingNode,
   clearEditingNode,
+  isInsideToolbar,
 } from "./formattingToolbar.js";
 
 // Initialise singleton toolbar once
@@ -73,7 +74,9 @@ function createTextBlock(block) {
   });
 
   // ── Blur: save and deactivate ────────────────────────────────────────────
-  node.addEventListener('blur', () => {
+  node.addEventListener('blur', (e) => {
+    // Focus moved into the formatting toolbar (e.g. link input) — stay in editing mode
+    if (isInsideToolbar(e.relatedTarget)) return;
     if (node.contentEditable !== 'true') return;
     node.contentEditable = 'false';
     node.classList.remove('is-editing');

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -46,8 +46,17 @@ function createTextBlock(block) {
   let currentLevel = block.level ?? null;
   let escaped = false;
 
-  // ── Click: activate editing ──────────────────────────────────────────────
-  node.addEventListener('click', () => {
+  // ── Click: activate editing (but let link clicks open the URL) ──────────
+  node.addEventListener('click', (e) => {
+    // When not editing, a click on a link should navigate, not start editing
+    if (node.contentEditable !== 'true') {
+      const anchor = e.target.closest('a[href]');
+      if (anchor) {
+        e.stopPropagation();
+        window.open(anchor.href, '_blank', 'noopener,noreferrer');
+        return;
+      }
+    }
     if (node.contentEditable === 'true') return;
     originalHtml = node.innerHTML;
     originalText = node.textContent;

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -4,6 +4,15 @@ import { apiPatchBlock, apiUploadImage } from "./api.js";
 import { enableContentEditable } from "./editor.js";
 import { openBlockPalette } from "./blockPalette.js";
 import { wrapBlock } from "./blockWrapper.js";
+import {
+  initFormattingToolbar,
+  sanitizeHtml,
+  setEditingNode,
+  clearEditingNode,
+} from "./formattingToolbar.js";
+
+// Initialise singleton toolbar once
+initFormattingToolbar();
 
 /**
  * Callbacks set by main.js before rendering begins.
@@ -22,28 +31,83 @@ export const callbacks = {
 function createTextBlock(block) {
   const template = document.getElementById('text-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
-  node.textContent = block.text;
 
-  // Apply heading level if present
+  // Render formatted HTML when available, fall back to plain text
+  if (block.formatted_text) {
+    node.innerHTML = sanitizeHtml(block.formatted_text);
+  } else {
+    node.textContent = block.text;
+  }
+
   if (block.level) node.dataset.level = String(block.level);
 
+  let originalHtml = node.innerHTML;
   let originalText = node.textContent;
   let currentLevel = block.level ?? null;
+  let escaped = false;
 
-  enableContentEditable(node, block.id, 'text', node, {
-    onEnter: () => {
-      const parentBlockId =
-        node.closest('.block-wrapper')?.dataset.parentBlockId || null;
-      if (callbacks.addBlockAfter) {
-        callbacks.addBlockAfter('text', block.id, parentBlockId).catch(console.error);
-      }
-    },
+  // ── Click: activate editing ──────────────────────────────────────────────
+  node.addEventListener('click', () => {
+    if (node.contentEditable === 'true') return;
+    originalHtml = node.innerHTML;
+    originalText = node.textContent;
+    escaped = false;
+    node.contentEditable = 'true';
+    node.classList.add('is-editing');
+    setEditingNode(node);
+    node.focus();
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    range.collapse(false);
+    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
   });
 
-  // Registered in capture phase to preempt enableContentEditable's bubble-phase Enter handler,
-  // preventing spurious block creation when heading promotion intercepts the keystroke.
+  // ── Blur: save and deactivate ────────────────────────────────────────────
+  node.addEventListener('blur', () => {
+    if (node.contentEditable !== 'true') return;
+    node.contentEditable = 'false';
+    node.classList.remove('is-editing');
+    clearEditingNode();
+
+    if (escaped) { escaped = false; return; }
+
+    // Handle pasted "# Title" heading promotion form
+    const raw = node.textContent;
+    const headingMatch = raw.match(/^(#{1,3})\s+(\S.*)?$/);
+    if (headingMatch) {
+      const newLevel = headingMatch[1].length;
+      const newText = (headingMatch[2] ?? '').trimEnd();
+      node.textContent = newText;
+      node.dataset.level = String(newLevel);
+      const patch = {};
+      if (newLevel !== currentLevel) patch.level = newLevel;
+      if (newText !== originalText) patch.text = newText;
+      patch.formatted_text = '';
+      currentLevel = newLevel;
+      originalText = newText;
+      originalHtml = node.innerHTML;
+      apiPatchBlock(block.id, patch).catch(console.error);
+      return;
+    }
+
+    // Normal save: patch both text and formatted_text when changed
+    const newText = node.textContent.trim();
+    const newHtml = sanitizeHtml(node.innerHTML);
+    const patch = {};
+    if (newText !== originalText) patch.text = newText;
+    if (newHtml !== sanitizeHtml(originalHtml)) patch.formatted_text = newHtml;
+    if (Object.keys(patch).length) {
+      originalText = newText;
+      originalHtml = node.innerHTML;
+      apiPatchBlock(block.id, patch).catch(console.error);
+    }
+  });
+
+  // ── Keydown: formatting shortcuts + heading promotion + slash command ────
+  // Capture phase: intercepts Enter/Space for heading promotion before bubble handlers
   node.addEventListener('keydown', (e) => {
-    // Slash command: open block palette when '/' is typed in an empty block
+    // Slash command: open palette when '/' is typed in an empty block
     if (e.key === '/' && node.contentEditable === 'true' && !node.textContent.trim()) {
       e.preventDefault();
       node.blur();
@@ -52,53 +116,70 @@ function createTextBlock(block) {
     }
 
     if (node.contentEditable !== 'true') return;
-    if (e.key !== ' ' && !(e.key === 'Enter' && !e.shiftKey)) return;
 
-    // Markdown heading promotion: only when content is exactly #, ##, or ###
-    const raw = node.textContent;
-    const exactPrefix = raw.match(/^(#{1,3})$/);
-    if (!exactPrefix) {
-      // Enter without heading prefix is handled by enableContentEditable's onEnter
+    // Escape: cancel editing and restore original content
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      escaped = true;
+      node.innerHTML = originalHtml;
+      node.contentEditable = 'false';
+      node.classList.remove('is-editing');
+      clearEditingNode();
       return;
     }
 
-    e.preventDefault();
-    e.stopImmediatePropagation();
-    const newLevel = exactPrefix[1].length;
-    node.textContent = '';
-    node.dataset.level = String(newLevel);
+    // Enter (no shift): either new block or heading promotion
+    if (e.key === 'Enter' && !e.shiftKey) {
+      const raw = node.textContent;
+      const exactPrefix = raw.match(/^(#{1,3})$/);
+      if (exactPrefix) {
+        // Heading promotion
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const newLevel = exactPrefix[1].length;
+        node.textContent = '';
+        node.dataset.level = String(newLevel);
+        const patch = { level: newLevel, text: '', formatted_text: '' };
+        currentLevel = newLevel;
+        originalText = '';
+        originalHtml = '';
+        apiPatchBlock(block.id, patch).catch(console.error);
+        return;
+      }
+      e.preventDefault();
+      node.blur();
+      const parentBlockId =
+        node.closest('.block-wrapper')?.dataset.parentBlockId || null;
+      if (callbacks.addBlockAfter) {
+        callbacks.addBlockAfter('text', block.id, parentBlockId).catch(console.error);
+      }
+      return;
+    }
 
-    const patch = {};
-    if (newLevel !== currentLevel) patch.level = newLevel;
-    if ('' !== originalText) patch.text = '';
-    if (Object.keys(patch).length) {
+    // Space: heading promotion when content is exactly #, ##, or ###
+    if (e.key === ' ') {
+      const raw = node.textContent;
+      const exactPrefix = raw.match(/^(#{1,3})$/);
+      if (!exactPrefix) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const newLevel = exactPrefix[1].length;
+      node.textContent = '';
+      node.dataset.level = String(newLevel);
+      const patch = { level: newLevel, text: '', formatted_text: '' };
       currentLevel = newLevel;
       originalText = '';
+      originalHtml = '';
       apiPatchBlock(block.id, patch).catch(console.error);
+    }
+
+    // Formatting keyboard shortcuts (Ctrl/Cmd + B / I / U)
+    if (e.ctrlKey || e.metaKey) {
+      if (e.key === 'b') { e.preventDefault(); document.execCommand('bold', false); }
+      else if (e.key === 'i') { e.preventDefault(); document.execCommand('italic', false); }
+      else if (e.key === 'u') { e.preventDefault(); document.execCommand('underline', false); }
     }
   }, { capture: true });
-
-  // On blur: also handle pasted "# Title" form (prefix + mandatory whitespace)
-  node.addEventListener('blur', () => {
-    if (node.contentEditable !== 'false') return; // enableContentEditable already committed
-    const raw = node.textContent;
-    const match = raw.match(/^(#{1,3})\s+(\S.*)?$/);
-    if (!match) return;
-
-    const newLevel = match[1].length;
-    const newText = (match[2] ?? '').trimEnd();
-    node.textContent = newText;
-    node.dataset.level = String(newLevel);
-
-    const patch = {};
-    if (newLevel !== currentLevel) patch.level = newLevel;
-    if (newText !== originalText) patch.text = newText;
-    if (Object.keys(patch).length) {
-      currentLevel = newLevel;
-      originalText = newText;
-      apiPatchBlock(block.id, patch).catch(console.error);
-    }
-  }, true); // capture: runs after enableContentEditable's blur
 
   return node;
 }

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -100,31 +100,31 @@ function restoreSelection() {
   }
 }
 
-// ── Inline code toggle ────────────────────────────────────────────────────────
+// ── Inline code apply (no-op if already inside <code>) ───────────────────────
 
-function toggleInlineCode() {
+function applyInlineCode() {
   const sel = window.getSelection();
   if (!sel || !sel.rangeCount || sel.isCollapsed) return;
   const range = sel.getRangeAt(0);
   const ancestor = range.commonAncestorContainer;
-  const codeEl =
+  const alreadyCode =
     ancestor.nodeType === Node.ELEMENT_NODE
       ? ancestor.closest("code")
       : ancestor.parentElement?.closest("code");
 
-  if (codeEl) {
-    codeEl.replaceWith(...codeEl.childNodes);
-  } else {
-    try {
-      const code = document.createElement("code");
-      range.surroundContents(code);
-    } catch {
-      // surroundContents fails when range spans multiple block elements; fall back
-      const frag = range.extractContents();
-      const code = document.createElement("code");
-      code.appendChild(frag);
-      range.insertNode(code);
-    }
+  // Skip if the selection is already inside a <code> element
+  if (alreadyCode) return;
+
+  try {
+    const code = document.createElement("code");
+    range.surroundContents(code);
+  } catch {
+    // surroundContents fails when range spans multiple block elements; fall back
+    const frag = range.extractContents();
+    const code = document.createElement("code");
+    code.appendChild(frag);
+    range.insertNode(code);
+  }
   }
 }
 
@@ -304,7 +304,7 @@ export function initFormattingToolbar() {
 
   // Inline code
   toolbarEl.appendChild(makeFmtBtn("<code style='font-size:0.78rem;background:rgba(255,255,255,0.15);padding:1px 4px;border-radius:3px;color:#f8f8f2'>&lt;/&gt;</code>", "인라인 코드", () => {
-    toggleInlineCode();
+    applyInlineCode();
   }));
 
   toolbarEl.appendChild(makeDivider());

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -1,0 +1,390 @@
+// ── Formatting toolbar ────────────────────────────────────────────────────────
+//
+// Floating toolbar that appears over selected text inside a text block.
+// Uses document.execCommand for basic formatting and custom logic for
+// inline code, links, and colors.
+
+const TEXT_COLORS = [
+  { label: "기본", value: "" },
+  { label: "회색", value: "#787774" },
+  { label: "빨강", value: "#e03e3e" },
+  { label: "주황", value: "#d9730d" },
+  { label: "노랑", value: "#dfab01" },
+  { label: "초록", value: "#0f7b6c" },
+  { label: "파랑", value: "#0b6e99" },
+  { label: "보라", value: "#6940a5" },
+  { label: "분홍", value: "#ad1a72" },
+];
+
+const BG_COLORS = [
+  { label: "기본", value: "" },
+  { label: "회색", value: "#f1f1ef" },
+  { label: "빨강", value: "#fbe4e4" },
+  { label: "주황", value: "#faebdd" },
+  { label: "노랑", value: "#fef3b8" },
+  { label: "초록", value: "#ddedea" },
+  { label: "파랑", value: "#ddebf1" },
+  { label: "보라", value: "#eae4f2" },
+  { label: "분홍", value: "#f4dfeb" },
+];
+
+// ── HTML sanitizer ────────────────────────────────────────────────────────────
+
+const ALLOWED_TAGS = new Set(["strong", "b", "em", "i", "u", "s", "del", "code", "a", "span", "br"]);
+const ALLOWED_ATTRS = { a: ["href"], span: ["style"] };
+
+/**
+ * Recursively sanitize a DOM node in-place, removing disallowed tags/attributes.
+ * Disallowed elements are unwrapped (children kept); disallowed attributes removed.
+ */
+function sanitizeNode(node) {
+  const children = [...node.childNodes];
+  for (const child of children) {
+    if (child.nodeType === Node.TEXT_NODE) continue;
+    if (child.nodeType !== Node.ELEMENT_NODE) { child.remove(); continue; }
+
+    const tag = child.tagName.toLowerCase();
+    if (!ALLOWED_TAGS.has(tag)) {
+      // Unwrap: keep children, discard wrapper element
+      child.replaceWith(...child.childNodes);
+      continue;
+    }
+
+    // Remove disallowed attributes
+    const allowed = ALLOWED_ATTRS[tag] || [];
+    for (const attr of [...child.attributes]) {
+      if (!allowed.includes(attr.name)) child.removeAttribute(attr.name);
+    }
+
+    // Validate href: only http/https allowed
+    if (tag === "a") {
+      const href = child.getAttribute("href") || "";
+      if (href && !/^https?:\/\//i.test(href)) child.removeAttribute("href");
+    }
+
+    // Restrict style to safe properties
+    if (child.hasAttribute("style")) {
+      const s = child.style;
+      const safe = ["color", "background-color", "font-size"]
+        .filter((p) => s.getPropertyValue(p))
+        .map((p) => `${p}: ${s.getPropertyValue(p)}`)
+        .join("; ");
+      if (safe) child.setAttribute("style", safe);
+      else child.removeAttribute("style");
+    }
+
+    sanitizeNode(child);
+  }
+}
+
+export function sanitizeHtml(html) {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  sanitizeNode(doc.body);
+  return doc.body.innerHTML;
+}
+
+// ── Toolbar singleton ─────────────────────────────────────────────────────────
+
+let toolbarEl = null;
+let colorPanelEl = null;
+let linkPanelEl = null;
+let activeTextNode = null;
+let savedRange = null;
+
+function restoreSelection() {
+  if (!savedRange) return;
+  const sel = window.getSelection();
+  if (sel) {
+    sel.removeAllRanges();
+    sel.addRange(savedRange);
+  }
+}
+
+// ── Inline code toggle ────────────────────────────────────────────────────────
+
+function toggleInlineCode() {
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount || sel.isCollapsed) return;
+  const range = sel.getRangeAt(0);
+  const ancestor = range.commonAncestorContainer;
+  const codeEl =
+    ancestor.nodeType === Node.ELEMENT_NODE
+      ? ancestor.closest("code")
+      : ancestor.parentElement?.closest("code");
+
+  if (codeEl) {
+    codeEl.replaceWith(...codeEl.childNodes);
+  } else {
+    try {
+      const code = document.createElement("code");
+      range.surroundContents(code);
+    } catch {
+      // surroundContents fails when range spans multiple block elements; fall back
+      const frag = range.extractContents();
+      const code = document.createElement("code");
+      code.appendChild(frag);
+      range.insertNode(code);
+    }
+  }
+}
+
+// ── Link insert / remove ──────────────────────────────────────────────────────
+
+function applyLink(url) {
+  restoreSelection();
+  if (!url) {
+    document.execCommand("unlink", false);
+    return;
+  }
+  document.execCommand("createLink", false, url);
+  // Force target="_blank" on created link
+  const sel = window.getSelection();
+  if (sel && sel.rangeCount) {
+    const anchor = sel.getRangeAt(0).commonAncestorContainer.parentElement?.closest("a");
+    if (anchor) anchor.target = "_blank";
+  }
+}
+
+// ── Color application ─────────────────────────────────────────────────────────
+
+function applyTextColor(color) {
+  restoreSelection();
+  if (!color) {
+    document.execCommand("foreColor", false, "inherit");
+    return;
+  }
+  document.execCommand("foreColor", false, color);
+}
+
+function applyBgColor(color) {
+  restoreSelection();
+  if (!color) {
+    document.execCommand("hiliteColor", false, "transparent");
+    return;
+  }
+  document.execCommand("hiliteColor", false, color);
+}
+
+// ── Build toolbar DOM ─────────────────────────────────────────────────────────
+
+function buildColorSwatches(colors, onSelect) {
+  const wrap = document.createElement("div");
+  wrap.className = "fmt-color-swatches";
+  for (const { label, value } of colors) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.title = label;
+    btn.className = "fmt-color-swatch-btn" + (value === "" ? " is-default" : "");
+    if (value) btn.style.background = value;
+    btn.addEventListener("mousedown", (e) => { e.preventDefault(); onSelect(value); });
+    wrap.appendChild(btn);
+  }
+  return wrap;
+}
+
+function buildColorPanel() {
+  const panel = document.createElement("div");
+  panel.className = "fmt-color-panel";
+
+  const textLabel = document.createElement("div");
+  textLabel.className = "fmt-color-section-label";
+  textLabel.textContent = "텍스트 색상";
+
+  const textSwatches = buildColorSwatches(TEXT_COLORS, (v) => { applyTextColor(v); closeColorPanel(); });
+
+  const bgLabel = document.createElement("div");
+  bgLabel.className = "fmt-color-section-label";
+  bgLabel.textContent = "배경 색상";
+
+  const bgSwatches = buildColorSwatches(BG_COLORS, (v) => { applyBgColor(v); closeColorPanel(); });
+
+  panel.append(textLabel, textSwatches, bgLabel, bgSwatches);
+  return panel;
+}
+
+function buildLinkPanel() {
+  const panel = document.createElement("div");
+  panel.className = "fmt-link-panel";
+
+  const input = document.createElement("input");
+  input.type = "url";
+  input.className = "fmt-link-input";
+  input.placeholder = "https://...";
+
+  const confirm = document.createElement("button");
+  confirm.type = "button";
+  confirm.className = "fmt-link-confirm";
+  confirm.textContent = "적용";
+
+  function commit() {
+    applyLink(input.value.trim());
+    closeLinkPanel();
+  }
+
+  confirm.addEventListener("mousedown", (e) => { e.preventDefault(); commit(); });
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") { e.preventDefault(); commit(); }
+    if (e.key === "Escape") { e.preventDefault(); closeLinkPanel(); }
+  });
+
+  panel.append(input, confirm);
+  panel._input = input; // expose for focus
+  return panel;
+}
+
+function closeColorPanel() {
+  if (colorPanelEl) colorPanelEl.classList.remove("is-open");
+}
+
+function closeLinkPanel() {
+  if (linkPanelEl) linkPanelEl.classList.remove("is-open");
+}
+
+function makeFmtBtn(label, title, onClick) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "fmt-btn";
+  btn.title = title;
+  btn.innerHTML = label;
+  btn.addEventListener("mousedown", (e) => {
+    e.preventDefault(); // keep selection alive
+    onClick(e, btn);
+  });
+  return btn;
+}
+
+function makeDivider() {
+  const d = document.createElement("div");
+  d.className = "fmt-divider";
+  return d;
+}
+
+export function initFormattingToolbar() {
+  if (toolbarEl) return; // already initialised
+
+  toolbarEl = document.createElement("div");
+  toolbarEl.className = "formatting-toolbar";
+  toolbarEl.setAttribute("role", "toolbar");
+  toolbarEl.setAttribute("aria-label", "텍스트 서식");
+
+  // Bold
+  toolbarEl.appendChild(makeFmtBtn("<b>B</b>", "굵게 (Ctrl+B)", () => {
+    document.execCommand("bold", false);
+  }));
+
+  // Italic
+  toolbarEl.appendChild(makeFmtBtn("<i>I</i>", "기울임 (Ctrl+I)", () => {
+    document.execCommand("italic", false);
+  }));
+
+  // Underline
+  toolbarEl.appendChild(makeFmtBtn("<u>U</u>", "밑줄 (Ctrl+U)", () => {
+    document.execCommand("underline", false);
+  }));
+
+  // Strikethrough
+  toolbarEl.appendChild(makeFmtBtn("<s>S</s>", "취소선", () => {
+    document.execCommand("strikeThrough", false);
+  }));
+
+  toolbarEl.appendChild(makeDivider());
+
+  // Inline code
+  toolbarEl.appendChild(makeFmtBtn("<code style='font-size:0.78rem;background:rgba(255,255,255,0.15);padding:1px 4px;border-radius:3px;color:#f8f8f2'>&lt;/&gt;</code>", "인라인 코드", () => {
+    toggleInlineCode();
+  }));
+
+  toolbarEl.appendChild(makeDivider());
+
+  // Link
+  const linkBtn = makeFmtBtn("🔗", "링크 삽입", () => {
+    closeColorPanel();
+    if (linkPanelEl.classList.contains("is-open")) {
+      closeLinkPanel();
+      return;
+    }
+    // Prefill if selection is inside a link
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount) {
+      savedRange = sel.getRangeAt(0).cloneRange();
+      const anchor = sel.getRangeAt(0).commonAncestorContainer.parentElement?.closest("a");
+      linkPanelEl._input.value = anchor ? anchor.href : "";
+    }
+    linkPanelEl.classList.add("is-open");
+    setTimeout(() => linkPanelEl._input.focus(), 0);
+  });
+  linkBtn.style.fontSize = "0.9rem";
+  linkBtn.appendChild(linkPanelEl = buildLinkPanel());
+  toolbarEl.appendChild(linkBtn);
+
+  toolbarEl.appendChild(makeDivider());
+
+  // Text/background color
+  const colorBtn = makeFmtBtn("A", "색상", () => {
+    closeLinkPanel();
+    if (colorPanelEl.classList.contains("is-open")) {
+      closeColorPanel();
+      return;
+    }
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount) savedRange = sel.getRangeAt(0).cloneRange();
+    colorPanelEl.classList.add("is-open");
+  });
+  colorBtn.style.textDecoration = "underline";
+  colorBtn.style.textDecorationColor = "#e03e3e";
+  colorBtn.style.textDecorationThickness = "2px";
+  colorBtn.className += " fmt-color-btn";
+  colorBtn.appendChild(colorPanelEl = buildColorPanel());
+  toolbarEl.appendChild(colorBtn);
+
+  document.body.appendChild(toolbarEl);
+
+  // Close sub-panels when clicking outside the toolbar
+  document.addEventListener("mousedown", (e) => {
+    if (!toolbarEl.contains(e.target)) {
+      closeColorPanel();
+      closeLinkPanel();
+    }
+  });
+}
+
+// ── Show / hide ───────────────────────────────────────────────────────────────
+
+export function showFormattingToolbar(textNode) {
+  if (!toolbarEl) return;
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed || !sel.rangeCount) { hideFormattingToolbar(); return; }
+
+  const range = sel.getRangeAt(0);
+  if (!textNode.contains(range.commonAncestorContainer)) { hideFormattingToolbar(); return; }
+
+  const rect = range.getBoundingClientRect();
+  if (rect.width === 0) { hideFormattingToolbar(); return; }
+
+  activeTextNode = textNode;
+  toolbarEl.classList.add("is-visible");
+
+  // Reflow needed to get toolbarEl dimensions
+  const tw = toolbarEl.offsetWidth;
+  const th = toolbarEl.offsetHeight;
+  const scrollX = window.scrollX;
+  const scrollY = window.scrollY;
+
+  let top = rect.top + scrollY - th - 10;
+  let left = rect.left + scrollX + rect.width / 2 - tw / 2;
+
+  // Clamp to viewport
+  if (top < scrollY + 8) top = rect.bottom + scrollY + 8;
+  left = Math.max(scrollX + 8, Math.min(left, scrollX + window.innerWidth - tw - 8));
+
+  toolbarEl.style.top = `${top}px`;
+  toolbarEl.style.left = `${left}px`;
+}
+
+export function hideFormattingToolbar() {
+  if (!toolbarEl) return;
+  toolbarEl.classList.remove("is-visible");
+  closeColorPanel();
+  closeLinkPanel();
+  activeTextNode = null;
+}

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -45,7 +45,9 @@ function sanitizeNode(node) {
 
     const tag = child.tagName.toLowerCase();
     if (!ALLOWED_TAGS.has(tag)) {
-      // Unwrap: keep children, discard wrapper element
+      // Sanitize descendants first before unwrapping, so disallowed nodes
+      // nested inside a disallowed wrapper cannot escape the allowlist.
+      sanitizeNode(child);
       child.replaceWith(...child.childNodes);
       continue;
     }
@@ -88,11 +90,18 @@ export function sanitizeHtml(html) {
 let toolbarEl = null;
 let colorPanelEl = null;
 let linkPanelEl = null;
-let activeTextNode = null;
 let savedRange = null;
+
+/** Returns true when el is inside the formatting toolbar (used to suppress text-block blur). */
+export function isInsideToolbar(el) {
+  return toolbarEl !== null && el instanceof Node && toolbarEl.contains(el);
+}
 
 function restoreSelection() {
   if (!savedRange) return;
+  // Re-focus the text block before restoring the selection range so that
+  // execCommand and subsequent toolbar interactions work correctly.
+  if (currentEditingNode) currentEditingNode.focus();
   const sel = window.getSelection();
   if (sel) {
     sel.removeAllRanges();
@@ -404,7 +413,6 @@ export function showFormattingToolbar(textNode) {
   const rect = range.getBoundingClientRect();
   if (rect.width === 0) { hideFormattingToolbar(); return; }
 
-  activeTextNode = textNode;
   toolbarEl.classList.add("is-visible");
 
   // Reflow needed to get toolbarEl dimensions
@@ -429,5 +437,4 @@ export function hideFormattingToolbar() {
   toolbarEl.classList.remove("is-visible");
   closeColorPanel();
   closeLinkPanel();
-  activeTextNode = null;
 }

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -259,6 +259,19 @@ function makeDivider() {
   return d;
 }
 
+// ── Active node tracking (prevents per-block selectionchange listeners) ────────
+
+let currentEditingNode = null;
+
+export function setEditingNode(node) {
+  currentEditingNode = node;
+}
+
+export function clearEditingNode() {
+  currentEditingNode = null;
+  hideFormattingToolbar();
+}
+
 export function initFormattingToolbar() {
   if (toolbarEl) return; // already initialised
 
@@ -338,6 +351,12 @@ export function initFormattingToolbar() {
   toolbarEl.appendChild(colorBtn);
 
   document.body.appendChild(toolbarEl);
+
+  // Single shared selectionchange listener — updates toolbar for active node only
+  document.addEventListener("selectionchange", () => {
+    if (!currentEditingNode) return;
+    showFormattingToolbar(currentEditingNode);
+  });
 
   // Close sub-panels when clicking outside the toolbar
   document.addEventListener("mousedown", (e) => {

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -100,32 +100,36 @@ function restoreSelection() {
   }
 }
 
-// ── Inline code apply (no-op if already inside <code>) ───────────────────────
+// ── Inline code toggle ────────────────────────────────────────────────────────
+//
+// - Entire selection in one <code>  → unwrap
+// - Partial <code> or none          → strip any nested codes, wrap all in one <code>
 
-function applyInlineCode() {
+function getCodeAncestor(node) {
+  const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+  return el?.closest("code") ?? null;
+}
+
+function toggleInlineCode() {
   const sel = window.getSelection();
   if (!sel || !sel.rangeCount || sel.isCollapsed) return;
   const range = sel.getRangeAt(0);
-  const ancestor = range.commonAncestorContainer;
-  const alreadyCode =
-    ancestor.nodeType === Node.ELEMENT_NODE
-      ? ancestor.closest("code")
-      : ancestor.parentElement?.closest("code");
 
-  // Skip if the selection is already inside a <code> element
-  if (alreadyCode) return;
+  const startCode = getCodeAncestor(range.startContainer);
+  const endCode = getCodeAncestor(range.endContainer);
 
-  try {
-    const code = document.createElement("code");
-    range.surroundContents(code);
-  } catch {
-    // surroundContents fails when range spans multiple block elements; fall back
-    const frag = range.extractContents();
-    const code = document.createElement("code");
-    code.appendChild(frag);
-    range.insertNode(code);
+  // Entire selection is within the same <code> → unwrap it
+  if (startCode && startCode === endCode) {
+    startCode.replaceWith(...startCode.childNodes);
+    return;
   }
-  }
+
+  // Partial or no code → extract, flatten nested codes, wrap in one new <code>
+  const frag = range.extractContents();
+  frag.querySelectorAll("code").forEach((c) => c.replaceWith(...c.childNodes));
+  const code = document.createElement("code");
+  code.appendChild(frag);
+  range.insertNode(code);
 }
 
 // ── Link insert / remove ──────────────────────────────────────────────────────
@@ -304,7 +308,7 @@ export function initFormattingToolbar() {
 
   // Inline code
   toolbarEl.appendChild(makeFmtBtn("<code style='font-size:0.78rem;background:rgba(255,255,255,0.15);padding:1px 4px;border-radius:3px;color:#f8f8f2'>&lt;/&gt;</code>", "인라인 코드", () => {
-    applyInlineCode();
+    toggleInlineCode();
   }));
 
   toolbarEl.appendChild(makeDivider());

--- a/static/js/formattingToolbar.js
+++ b/static/js/formattingToolbar.js
@@ -118,9 +118,29 @@ function toggleInlineCode() {
   const startCode = getCodeAncestor(range.startContainer);
   const endCode = getCodeAncestor(range.endContainer);
 
-  // Entire selection is within the same <code> → unwrap it
   if (startCode && startCode === endCode) {
-    startCode.replaceWith(...startCode.childNodes);
+    // Entire selection is within the same <code>:
+    // Extract only the selected portion, split the <code> into before/after halves,
+    // and insert the plain text between them.
+    const selectedFrag = range.extractContents();
+
+    // Capture the "after" portion: from the collapsed range position to end of codeEl
+    const afterRange = document.createRange();
+    afterRange.selectNodeContents(startCode);
+    afterRange.setStart(range.startContainer, range.startOffset);
+    const afterFrag = afterRange.extractContents();
+
+    const afterCode = document.createElement("code");
+    afterCode.appendChild(afterFrag);
+
+    const parent = startCode.parentNode;
+    const nextSibling = startCode.nextSibling;
+    parent.insertBefore(selectedFrag, nextSibling);
+    parent.insertBefore(afterCode, nextSibling);
+
+    // Remove empty <code> remnants
+    if (!startCode.textContent) startCode.remove();
+    if (!afterCode.textContent) afterCode.remove();
     return;
   }
 


### PR DESCRIPTION
## Summary

- 배경: 블록 에디터에서 plain text만 입력 가능해 노션 수준의 인라인 서식 표현이 불가능했음
- 목적: 텍스트 선택 시 나타나는 플로팅 툴바를 통해 Bold·Italic·Underline·Strikethrough·인라인코드·링크·텍스트/배경 색상 서식을 지원

## Changes

- `app/models/blocks.py`: `TextBlock`에 `formatted_text: str | None` 필드 추가 (HTML 문자열로 인라인 서식 저장)
- `app/routers/blocks.py`: `BlockPatch`에 `formatted_text` 필드 추가
- `static/css/style.css`: 플로팅 툴바, 색상 팔레트, 링크 입력 패널, 인라인 `<code>`·`<a>` 스타일 추가
- `static/js/formattingToolbar.js` (신규): 플로팅 서식 툴바 모듈
  - allowlist 기반 HTML sanitizer (허용 태그: `strong/em/u/s/code/a/span`, href·style 검증)
  - Bold·Italic·Underline·Strikethrough (`execCommand`), 인라인코드·링크·색상 (커스텀)
  - 텍스트 색상 9종 / 배경 색상 9종 팔레트
  - `setEditingNode`/`clearEditingNode`로 단일 `selectionchange` 리스너 관리
- `static/js/blockRenderers.js`: `createTextBlock` 재구현
  - `formatted_text` 있으면 `innerHTML`로 렌더링, 없으면 `text` fallback
  - Ctrl+B/I/U 단축키 지원
  - 블러 시 `text`(plain) + `formatted_text`(HTML) 동시 저장
  - Escape 시 원래 HTML(서식 포함) 복원, 헤딩 승격 시 `formatted_text` 초기화
  - 비편집 상태에서 `<a>` 클릭 시 새 탭으로 열기

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [x] 브라우저 콘솔 에러 없음
- [x] 텍스트 선택 시 툴바 표시 확인
- [ ] Bold/Italic/Underline/Strikethrough 적용 및 재적용 토글 확인
- [ ] 인라인코드: 미적용 → 적용, 전체 선택 → 해제, 일부 선택 → 통합 확인
- [ ] 링크 삽입 후 비편집 상태에서 새 탭 열림 확인
- [ ] 색상 팔레트로 텍스트/배경 색상 적용 확인
- [ ] 저장 후 페이지 재진입 시 서식 복원 확인
- [ ] 헤딩 승격 시 서식 초기화 확인
- [ ] Escape 시 서식 롤백 확인

## Checklist

- [ ] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [ ] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분:
  - `formattingToolbar.js`의 HTML sanitizer가 XSS를 충분히 방어하는지
  - `toggleInlineCode`의 범위 분리 로직 (선택 영역만 해제, 앞뒤 `<code>` 유지)
  - `formatted_text` 저장 시 `sanitizeHtml(originalHtml)`과 비교하는 변경 감지 방식의 정확성