### PR TITLE
[FEAT#28] 페이지 부모-자식 계층 구조 및 하위 페이지 토글/직접 접근

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -9,10 +9,22 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+from sqlalchemy import text
+
 from app.models.orm import Base
 
 _BASE_DIR = Path(__file__).resolve().parent.parent
 _DB_FILE = _BASE_DIR / "data" / "blocks.sqlite3"
+
+
+def _migrate(engine: Engine) -> None:
+  """Run additive schema migrations that create_all cannot handle."""
+  with engine.connect() as conn:
+    try:
+      conn.execute(text("ALTER TABLE documents ADD COLUMN parent_id TEXT"))
+      conn.commit()
+    except Exception:
+      pass  # column already exists
 
 
 @functools.cache
@@ -24,6 +36,7 @@ def _get_engine() -> Engine:
     connect_args={"check_same_thread": False},
   )
   Base.metadata.create_all(engine)
+  _migrate(engine)
   from app.repositories.sqlite_blocks import SQLiteBlockRepository
   with Session(engine) as session:
     SQLiteBlockRepository(session)._seed_if_empty()

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -10,6 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 
 from app.models.orm import Base
 
@@ -23,8 +24,11 @@ def _migrate(engine: Engine) -> None:
     try:
       conn.execute(text("ALTER TABLE documents ADD COLUMN parent_id TEXT"))
       conn.commit()
-    except Exception:
-      pass  # column already exists
+    except OperationalError as e:
+      # SQLite raises OperationalError("duplicate column name") when the column
+      # already exists — that is the only expected error here.
+      if "duplicate column name" not in str(e).lower():
+        raise
 
 
 @functools.cache

--- a/app/models/orm.py
+++ b/app/models/orm.py
@@ -14,6 +14,7 @@ class DocumentRow(Base):
   id: Mapped[str] = mapped_column(String, primary_key=True)
   title: Mapped[str] = mapped_column(String, nullable=False)
   subtitle: Mapped[str] = mapped_column(String, nullable=False, default="")
+  parent_id: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
 
   blocks: Mapped[list[BlockRow]] = relationship(
     back_populates="document",

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -188,18 +188,6 @@ class SQLiteBlockRepository:
 
     Returns the created block data, or None if document not found or type is unsupported.
     """
-    match block_type:
-      case "text":
-        default_content: dict[str, Any] = {"text": ""}
-      case "image":
-        default_content = {"url": "", "caption": ""}
-      case "container":
-        default_content = {"title": "", "layout": "vertical"}
-      case "divider":
-        default_content = {}
-      case _:
-        return None
-
     if self._session.get(DocumentRow, document_id) is None:
       return None
 
@@ -212,6 +200,25 @@ class SQLiteBlockRepository:
       ).scalar_one_or_none()
       if parent_exists is None:
         return None
+
+    # ── Page block: auto-create a child document ──────────────────────────────
+    if block_type == "page":
+      child_doc = self.create_child_document(document_id)
+      if child_doc is None:
+        return None
+      default_content: dict[str, Any] = {"document_id": child_doc["id"]}
+    else:
+      match block_type:
+        case "text":
+          default_content = {"text": ""}
+        case "image":
+          default_content = {"url": "", "caption": ""}
+        case "container":
+          default_content = {"title": "", "layout": "vertical"}
+        case "divider":
+          default_content = {}
+        case _:
+          return None
 
     parent_filter = (
       BlockRow.parent_block_id.is_(None)
@@ -233,13 +240,33 @@ class SQLiteBlockRepository:
       content_json=json.dumps(default_content, ensure_ascii=False),
     ))
     self._session.commit()
-    return {"id": block_id, "type": block_type, **default_content}
+
+    result: dict[str, Any] = {"id": block_id, "type": block_type, **default_content}
+    if block_type == "page":
+      result["title"] = child_doc["title"]
+      result["child_document"] = child_doc
+    return result
 
   def delete_block(self, block_id: str) -> bool:
-    """Delete a block and all its descendants. Compacts sibling positions after deletion."""
+    """Delete a block and all its descendants. Compacts sibling positions after deletion.
+
+    When deleting a page block, the referenced document is promoted to root
+    (parent_id cleared) so it is not orphaned.
+    """
     block_row = self._session.get(BlockRow, block_id)
     if block_row is None:
       return False
+
+    # Promote referenced document if this is a page block
+    if block_row.type == "page":
+      content = json.loads(block_row.content_json)
+      ref_doc_id = content.get("document_id")
+      if ref_doc_id:
+        self._session.execute(
+          update(DocumentRow)
+          .where(DocumentRow.id == ref_doc_id)
+          .values(parent_id=None)
+        )
 
     document_id = block_row.document_id
     parent_block_id = block_row.parent_block_id

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -22,11 +22,31 @@ class SQLiteBlockRepository:
 
   # ── Documents ──────────────────────────────────────────────────────────────
 
-  def list_documents(self) -> list[dict[str, str]]:
+  def list_documents(self) -> list[dict]:
+    """Return all documents as a parent-child tree sorted by title.
+
+    Each root-level document has a ``children`` list; children are sorted
+    alphabetically and may themselves contain further children.
+    """
     rows = self._session.execute(
       select(DocumentRow).order_by(DocumentRow.title)
     ).scalars().all()
-    return [{"id": r.id, "title": r.title, "subtitle": r.subtitle} for r in rows]
+
+    all_docs: list[dict] = [
+      {"id": r.id, "title": r.title, "subtitle": r.subtitle, "parent_id": r.parent_id, "children": []}
+      for r in rows
+    ]
+    by_id = {d["id"]: d for d in all_docs}
+    roots: list[dict] = []
+
+    for doc in all_docs:
+      pid = doc["parent_id"]
+      if pid and pid in by_id:
+        by_id[pid]["children"].append(doc)
+      else:
+        roots.append(doc)
+
+    return roots
 
   def get_document(self, document_id: str) -> BlockDocument | None:
     doc_row = self._session.get(DocumentRow, document_id)
@@ -91,12 +111,37 @@ class SQLiteBlockRepository:
       blocks=build_nodes(None),
     )
 
-  def create_document(self) -> dict[str, str]:
+  def create_document(self) -> dict:
     doc_id = str(uuid.uuid4())
     title = "새 문서"
-    self._session.add(DocumentRow(id=doc_id, title=title, subtitle=""))
+    self._session.add(DocumentRow(id=doc_id, title=title, subtitle="", parent_id=None))
     self._session.commit()
-    return {"id": doc_id, "title": title, "subtitle": ""}
+    return {"id": doc_id, "title": title, "subtitle": "", "parent_id": None, "children": []}
+
+  def create_child_document(self, parent_id: str) -> dict | None:
+    """Create a new document as a direct child of *parent_id*.
+
+    Returns None if *parent_id* does not exist.
+    """
+    if self._session.get(DocumentRow, parent_id) is None:
+      return None
+    doc_id = str(uuid.uuid4())
+    title = "새 문서"
+    self._session.add(DocumentRow(id=doc_id, title=title, subtitle="", parent_id=parent_id))
+    self._session.commit()
+    return {"id": doc_id, "title": title, "subtitle": "", "parent_id": parent_id, "children": []}
+
+  def _is_descendant(self, ancestor_id: str, candidate_id: str) -> bool:
+    """Return True if *candidate_id* is *ancestor_id* or a descendant of it."""
+    current: str | None = candidate_id
+    while current is not None:
+      if current == ancestor_id:
+        return True
+      row = self._session.get(DocumentRow, current)
+      if row is None:
+        break
+      current = row.parent_id
+    return False
 
   def update_document_title(self, document_id: str, title: str) -> bool:
     doc_row = self._session.get(DocumentRow, document_id)
@@ -110,6 +155,12 @@ class SQLiteBlockRepository:
     doc_row = self._session.get(DocumentRow, document_id)
     if doc_row is None:
       return False
+    # Promote direct children to root so they are not orphaned
+    self._session.execute(
+      update(DocumentRow)
+      .where(DocumentRow.parent_id == document_id)
+      .values(parent_id=None)
+    )
     self._session.delete(doc_row)
     self._session.commit()
     return True

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -125,16 +125,33 @@ class SQLiteBlockRepository:
     """
     if self._session.get(DocumentRow, parent_id) is None:
       return None
+    data = self._build_child_document_row(parent_id)
+    self._session.commit()
+    return data
+
+  def _build_child_document_row(self, parent_id: str) -> dict:
+    """Add a child DocumentRow to the session without committing.
+
+    Callers are responsible for the commit so that the operation can be
+    composed into a larger atomic transaction.
+    """
     doc_id = str(uuid.uuid4())
     title = "새 문서"
     self._session.add(DocumentRow(id=doc_id, title=title, subtitle="", parent_id=parent_id))
-    self._session.commit()
     return {"id": doc_id, "title": title, "subtitle": "", "parent_id": parent_id, "children": []}
 
   def _is_descendant(self, ancestor_id: str, candidate_id: str) -> bool:
-    """Return True if *candidate_id* is *ancestor_id* or a descendant of it."""
+    """Return True if *candidate_id* is *ancestor_id* or a descendant of it.
+
+    Guards against pre-existing cycles in the parent_id chain via a visited set
+    so the loop always terminates.
+    """
+    visited: set[str] = set()
     current: str | None = candidate_id
     while current is not None:
+      if current in visited:
+        break  # cycle detected — stop traversal
+      visited.add(current)
       if current == ancestor_id:
         return True
       row = self._session.get(DocumentRow, current)
@@ -201,11 +218,11 @@ class SQLiteBlockRepository:
       if parent_exists is None:
         return None
 
-    # ── Page block: auto-create a child document ──────────────────────────────
+    # ── Page block: auto-create a child document (single transaction) ────────
     if block_type == "page":
-      child_doc = self.create_child_document(document_id)
-      if child_doc is None:
-        return None
+      # Use _build_child_document_row (no commit) so both the new document and
+      # the page block are committed together below, keeping the DB consistent.
+      child_doc = self._build_child_document_row(document_id)
       default_content: dict[str, Any] = {"document_id": child_doc["id"]}
     else:
       match block_type:

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -59,7 +59,7 @@ def update_document_title(
 
 
 class BlockCreate(BaseModel):
-  type: Literal["text", "image", "container", "divider"]
+  type: Literal["text", "image", "container", "divider", "page"]
   parent_block_id: str | None = None
 
 
@@ -69,20 +69,12 @@ def create_block(
   body: BlockCreate,
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict:
-  """Append a new block to a document."""
+  """Append a new block to a document.
+
+  For ``type=page`` a new child document is automatically created and returned
+  inside the ``child_document`` field of the response.
+  """
   result = repo.create_block(document_id, body.type, body.parent_block_id)
-  if result is None:
-    raise HTTPException(status_code=404, detail="Document not found")
-  return result
-
-
-@router.post("/{document_id}/children", status_code=201)
-def create_child_document(
-  document_id: str,
-  repo: SQLiteBlockRepository = Depends(get_repository),
-) -> dict:
-  """Create a new document as a direct child of document_id."""
-  result = repo.create_child_document(document_id)
   if result is None:
     raise HTTPException(status_code=404, detail="Document not found")
   return result

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -23,8 +23,8 @@ class DocumentTitleUpdate(BaseModel):
 
 
 @router.get("")
-def list_documents(repo: SQLiteBlockRepository = Depends(get_repository)) -> list[dict[str, str]]:
-  """Return all available block documents."""
+def list_documents(repo: SQLiteBlockRepository = Depends(get_repository)) -> list[dict]:
+  """Return all available block documents as a parent-child tree."""
   return repo.list_documents()
 
 
@@ -41,7 +41,7 @@ def get_document(
 
 
 @router.post("", status_code=201)
-def create_document(repo: SQLiteBlockRepository = Depends(get_repository)) -> dict[str, str]:
+def create_document(repo: SQLiteBlockRepository = Depends(get_repository)) -> dict:
   """Create a new empty document and return its info."""
   return repo.create_document()
 
@@ -71,6 +71,18 @@ def create_block(
 ) -> dict:
   """Append a new block to a document."""
   result = repo.create_block(document_id, body.type, body.parent_block_id)
+  if result is None:
+    raise HTTPException(status_code=404, detail="Document not found")
+  return result
+
+
+@router.post("/{document_id}/children", status_code=201)
+def create_child_document(
+  document_id: str,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict:
+  """Create a new document as a direct child of document_id."""
+  result = repo.create_child_document(document_id)
   if result is None:
     raise HTTPException(status_code=404, detail="Document not found")
   return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "httpx>=0.28.1",
+    "pytest>=9.0.3",
+    "pytest-anyio>=0.0.0",
 ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -275,6 +275,73 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   background: #fdeaea;
 }
 
+/* ── Document tree: toggle chevron ──────────────────────────────────────────── */
+
+.document-toggle-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 4px;
+  color: var(--ink-soft);
+  opacity: 0;           /* hidden by default; visible on row hover or when has-children */
+  transition: opacity 0.12s, transform 0.2s ease;
+}
+
+.document-toggle-btn::before {
+  content: '›';
+  font-size: 1.1rem;
+  line-height: 1;
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+.document-row:hover .document-toggle-btn,
+.document-toggle-btn.has-children {
+  opacity: 1;
+}
+
+.document-toggle-btn:hover {
+  background: var(--paper-deep);
+}
+
+.document-toggle-btn.is-expanded::before {
+  transform: rotate(90deg);
+}
+
+/* ── Document tree: children list ───────────────────────────────────────────── */
+
+.document-children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.2rem;
+}
+
+/* ── Document menu: non-destructive action ───────────────────────────────────── */
+
+.document-menu-action {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  cursor: pointer;
+  color: var(--ink);
+  font-size: 0.88rem;
+}
+
+.document-menu-action:hover {
+  background: var(--accent-soft);
+}
+
 .block-page-cover {
   width: 100%;
   height: 15rem;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -311,6 +311,13 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   background: var(--paper-deep);
 }
 
+.document-toggle-btn:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 4px;
+}
+
 .document-toggle-btn.is-expanded::before {
   transform: rotate(90deg);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -317,6 +317,12 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 
 /* ── Document tree: children list ───────────────────────────────────────────── */
 
+/* display:grid overrides the UA [hidden]{display:none} rule,
+   so we re-declare it with higher specificity. */
+.document-children[hidden] {
+  display: none;
+}
+
 .document-children {
   margin: 0;
   padding: 0;

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -32,6 +32,12 @@ export async function apiDeleteDocument(documentId) {
   if (!res.ok) throw new Error('Failed to delete document');
 }
 
+export async function apiCreateChildDocument(parentId) {
+  const res = await fetch(`/api/documents/${parentId}/children`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to create child document');
+  return res.json();
+}
+
 export async function apiPatchBlock(blockId, fields) {
   const res = await fetch(`/api/blocks/${blockId}`, {
     method: 'PATCH',

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -32,12 +32,6 @@ export async function apiDeleteDocument(documentId) {
   if (!res.ok) throw new Error('Failed to delete document');
 }
 
-export async function apiCreateChildDocument(parentId) {
-  const res = await fetch(`/api/documents/${parentId}/children`, { method: 'POST' });
-  if (!res.ok) throw new Error('Failed to create child document');
-  return res.json();
-}
-
 export async function apiPatchBlock(blockId, fields) {
   const res = await fetch(`/api/blocks/${blockId}`, {
     method: 'PATCH',

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -7,6 +7,7 @@ export const BLOCK_PALETTE_ITEMS = [
   { type: 'image', label: '이미지', icon: '▣' },
   { type: 'container', label: '컨테이너', icon: '⊞' },
   { type: 'divider', label: '구분선', icon: '—' },
+  { type: 'page', label: '페이지', icon: '⊔' },
 ];
 
 /**

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -114,7 +114,7 @@ export function showBlockDeleteConfirm(wrapperEl, blockId, reloadDocument) {
     close();
     try {
       await apiDeleteBlock(blockId);
-      if (reloadDocument) reloadDocument();
+      if (reloadDocument) await reloadDocument();
     } catch (err) {
       console.error('블록 삭제 실패:', err);
     }

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -21,10 +21,12 @@ initFormattingToolbar();
  * knowing about the active document or load function.
  */
 export const callbacks = {
-  navigateTo: null,       // (documentId) => void
-  addBlock: null,         // (type, parentBlockId?) => Promise<void>
-  addBlockAfter: null,    // (type, afterBlockId, parentBlockId?) => Promise<void>
-  reloadDocument: null,   // () => void
+  navigateTo: null,         // (documentId) => void
+  addBlock: null,           // (type, parentBlockId?) => Promise<void>
+  addBlockAfter: null,      // (type, afterBlockId, parentBlockId?) => Promise<void>
+  reloadDocument: null,     // () => void
+  onPageBlockAdded: null,   // (childDoc) => void — update sidebar after page block creation
+  reloadSidebar: null,      // () => Promise<void> — full sidebar refresh
 };
 
 // ── Individual block creators ─────────────────────────────────────────────────
@@ -488,6 +490,7 @@ export function renderBlock(block, parentBlockId = null) {
   return wrapBlock(blockEl, block, parentBlockId, {
     addBlockAfter: callbacks.addBlockAfter,
     reloadDocument: callbacks.reloadDocument,
+    reloadSidebar: callbacks.reloadSidebar,
   });
 }
 

--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -47,7 +47,9 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
     sectionLabel.textContent = '타입 변경';
     moreMenu.appendChild(sectionLabel);
 
-    BLOCK_PALETTE_ITEMS.forEach(({ type, label, icon }) => {
+    // 'page' is excluded: changing an existing block to page is not supported
+    // (page blocks auto-create a child document on creation; type-change API rejects it).
+    BLOCK_PALETTE_ITEMS.filter((item) => item.type !== 'page').forEach(({ type, label, icon }) => {
       const changeBtn = document.createElement('button');
       changeBtn.type = 'button';
       changeBtn.className = 'block-change-type-btn';

--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -15,7 +15,7 @@ let currentDropTarget = null;
  * @param {string|null} parentBlockId - Parent block id (null for top-level)
  * @param {object}      callbacks     - { addBlockAfter, reloadDocument }
  */
-export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter, reloadDocument } = {}) {
+export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter, reloadDocument, reloadSidebar } = {}) {
   const wrapper = document.createElement('div');
   wrapper.className = 'block-wrapper';
   wrapper.dataset.blockId = block.id;
@@ -121,7 +121,11 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
   deleteBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     moreMenu.hidden = true;
-    showBlockDeleteConfirm(wrapper, block.id, reloadDocument);
+    // Page block deletion also requires a sidebar refresh (referenced doc promoted to root)
+    const afterDelete = (block.type === 'page' && reloadSidebar)
+      ? async () => { await reloadSidebar(); reloadDocument?.(); }
+      : reloadDocument;
+    showBlockDeleteConfirm(wrapper, block.id, afterDelete);
   });
 
   // ── Drag and Drop ─────────────────────────────────────────────────────────

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -8,7 +8,7 @@ export function closeAllMenus(list) {
 
 export function setActiveItem(list, targetItem) {
   list.querySelectorAll('.document-item').forEach((btn) => btn.classList.remove('is-active'));
-  const btn = targetItem.querySelector('.document-item');
+  const btn = targetItem.querySelector(':scope > .document-row > .document-item');
   if (btn) btn.classList.add('is-active');
 }
 
@@ -17,12 +17,12 @@ export function setActiveItem(list, targetItem) {
  * title editing. Commits on Enter or blur; cancels (keeps original) on Escape.
  */
 export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
-  const existingBtn = listItem.querySelector('.document-item');
-  const menuBtn = listItem.querySelector('.document-menu-btn');
+  const existingBtn = listItem.querySelector(':scope > .document-row > .document-item');
+  const menuBtn = listItem.querySelector(':scope > .document-row > .document-menu-btn');
 
   const input = document.createElement('input');
   input.type = 'text';
-  input.setAttribute('size', '1'); // prevent browser default intrinsic width
+  input.setAttribute('size', '1');
   input.className = 'document-title-input';
   input.value = initialTitle;
   existingBtn.replaceWith(input);
@@ -58,7 +58,7 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
       apiUpdateTitle(docId, newTitle).catch(console.error);
       restoreButton(newTitle);
     } else if (e.key === 'Escape') {
-      restoreButton(initialTitle); // cancel: no API call, restore original title
+      restoreButton(initialTitle);
     }
   });
 
@@ -70,16 +70,37 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
 }
 
 /**
- * Build and append a single document list item.
- * Returns the <li> element.
+ * Build and append a single document list item (and its children recursively).
+ *
+ * @param {HTMLElement} list        - Parent <ul> to append into
+ * @param {object}      docInfo     - Document data including .children[]
+ * @param {object}      handlers    - { onSelect, onDelete, onAddChild }
+ * @param {number}      depth       - Nesting depth (0 = root)
+ * @returns {HTMLLIElement}
  */
-export function addDocumentItem(list, docInfo, { onSelect, onDelete }) {
+export function addDocumentItem(list, docInfo, handlers, depth = 0) {
+  const { onSelect, onDelete, onAddChild } = handlers;
+
   const item = document.createElement('li');
   item.dataset.id = docInfo.id;
 
   const row = document.createElement('div');
   row.className = 'document-row';
+  row.style.paddingLeft = depth > 0 ? `${depth * 14}px` : '0';
 
+  // ── Toggle button (> chevron) ─────────────────────────────────────────────
+  const toggleBtn = document.createElement('button');
+  toggleBtn.type = 'button';
+  toggleBtn.className = 'document-toggle-btn';
+  toggleBtn.setAttribute('aria-label', '하위 페이지 펼치기/접기');
+  toggleBtn.setAttribute('aria-expanded', 'false');
+  // Visibility: always present for layout stability; visually shown only when
+  // there are children or on hover (via CSS).
+  if (docInfo.children && docInfo.children.length > 0) {
+    toggleBtn.classList.add('has-children');
+  }
+
+  // ── Document select button ────────────────────────────────────────────────
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'document-item';
@@ -90,6 +111,7 @@ export function addDocumentItem(list, docInfo, { onSelect, onDelete }) {
     onSelect(docInfo.id);
   });
 
+  // ── More (⋯) menu button ──────────────────────────────────────────────────
   const menuBtn = document.createElement('button');
   menuBtn.type = 'button';
   menuBtn.className = 'document-menu-btn';
@@ -99,6 +121,16 @@ export function addDocumentItem(list, docInfo, { onSelect, onDelete }) {
   const menu = document.createElement('div');
   menu.className = 'document-menu';
   menu.hidden = true;
+
+  const addChildBtn = document.createElement('button');
+  addChildBtn.type = 'button';
+  addChildBtn.className = 'document-menu-action';
+  addChildBtn.textContent = '하위 페이지 추가';
+  addChildBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    menu.hidden = true;
+    onAddChild(docInfo.id, item, childrenList, depth + 1);
+  });
 
   const deleteBtn = document.createElement('button');
   deleteBtn.type = 'button';
@@ -117,12 +149,36 @@ export function addDocumentItem(list, docInfo, { onSelect, onDelete }) {
     menu.hidden = !wasHidden;
   });
 
+  menu.appendChild(addChildBtn);
   menu.appendChild(deleteBtn);
+  row.appendChild(toggleBtn);
   row.appendChild(btn);
   row.appendChild(menuBtn);
   row.appendChild(menu);
   item.appendChild(row);
-  list.appendChild(item);
 
+  // ── Children list ─────────────────────────────────────────────────────────
+  const childrenList = document.createElement('ul');
+  childrenList.className = 'document-children';
+  childrenList.hidden = true;
+  item.appendChild(childrenList);
+
+  // Render existing children (collapsed by default)
+  if (docInfo.children && docInfo.children.length > 0) {
+    docInfo.children.forEach((child) =>
+      addDocumentItem(childrenList, child, handlers, depth + 1)
+    );
+  }
+
+  // ── Toggle expand/collapse ────────────────────────────────────────────────
+  toggleBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const willExpand = !toggleBtn.classList.contains('is-expanded');
+    toggleBtn.classList.toggle('is-expanded', willExpand);
+    toggleBtn.setAttribute('aria-expanded', String(willExpand));
+    childrenList.hidden = !willExpand;
+  });
+
+  list.appendChild(item);
   return item;
 }

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -74,15 +74,16 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
  *
  * @param {HTMLElement} list        - Parent <ul> to append into
  * @param {object}      docInfo     - Document data including .children[]
- * @param {object}      handlers    - { onSelect, onDelete, onAddChild }
+ * @param {object}      handlers    - { onSelect, onDelete }
  * @param {number}      depth       - Nesting depth (0 = root)
  * @returns {HTMLLIElement}
  */
 export function addDocumentItem(list, docInfo, handlers, depth = 0) {
-  const { onSelect, onDelete, onAddChild } = handlers;
+  const { onSelect, onDelete } = handlers;
 
   const item = document.createElement('li');
   item.dataset.id = docInfo.id;
+  item.dataset.depth = String(depth);
 
   const row = document.createElement('div');
   row.className = 'document-row';
@@ -122,16 +123,6 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
   menu.className = 'document-menu';
   menu.hidden = true;
 
-  const addChildBtn = document.createElement('button');
-  addChildBtn.type = 'button';
-  addChildBtn.className = 'document-menu-action';
-  addChildBtn.textContent = '하위 페이지 추가';
-  addChildBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    menu.hidden = true;
-    onAddChild(docInfo.id, item, childrenList, depth + 1);
-  });
-
   const deleteBtn = document.createElement('button');
   deleteBtn.type = 'button';
   deleteBtn.className = 'document-menu-delete';
@@ -149,7 +140,6 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
     menu.hidden = !wasHidden;
   });
 
-  menu.appendChild(addChildBtn);
   menu.appendChild(deleteBtn);
   row.appendChild(toggleBtn);
   row.appendChild(btn);

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -95,10 +95,15 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
   toggleBtn.className = 'document-toggle-btn';
   toggleBtn.setAttribute('aria-label', '하위 페이지 펼치기/접기');
   toggleBtn.setAttribute('aria-expanded', 'false');
-  // Visibility: always present for layout stability; visually shown only when
-  // there are children or on hover (via CSS).
-  if (docInfo.children && docInfo.children.length > 0) {
+
+  const hasChildren = !!(docInfo.children && docInfo.children.length > 0);
+  if (hasChildren) {
     toggleBtn.classList.add('has-children');
+  } else {
+    // No children: keep button in DOM for layout stability but remove from
+    // tab order and hide from assistive technology.
+    toggleBtn.tabIndex = -1;
+    toggleBtn.setAttribute('aria-hidden', 'true');
   }
 
   // ── Document select button ────────────────────────────────────────────────

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,6 +4,7 @@ import {
   fetchDocuments,
   fetchDocument,
   apiCreateDocument,
+  apiCreateChildDocument,
   apiDeleteDocument,
   apiCreateBlock,
   apiMoveBlock,
@@ -43,7 +44,6 @@ async function initGallery() {
       if (afterWrapper) {
         const newWrapper = renderBlock(newBlock, parentBlockId);
         afterWrapper.after(newWrapper);
-        // 서버 순서도 DOM과 일치시킴: 삽입된 위치의 다음 형제 앞으로 이동
         const nextWrapper = newWrapper.nextElementSibling;
         if (nextWrapper?.dataset?.blockId) {
           await apiMoveBlock(newBlock.id, nextWrapper.dataset.blockId);
@@ -52,7 +52,6 @@ async function initGallery() {
       }
     };
 
-    // Also keep a plain addBlock for appending to a container or root
     const addBlock = async (type, parentBlockId = null) => {
       const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId);
       const containerEl = parentBlockId
@@ -64,13 +63,11 @@ async function initGallery() {
         focusBlock(newWrapper);
       }
     };
-    // Expose addBlock via callbacks so blockPalette's fallback path works
     callbacks.addBlock = addBlock;
 
     try {
       const payload = await fetchDocument(documentId);
 
-      // Ensure the last root-level block is always a text block
       const rootBlocks = payload.blocks;
       const lastBlock = rootBlocks[rootBlocks.length - 1];
       if (!lastBlock || lastBlock.type !== 'text') {
@@ -108,6 +105,7 @@ async function initGallery() {
     root.replaceChildren(p);
   }
 
+  // ── Shared document action handlers ──────────────────────────────────────
   const handlers = {
     onSelect(docId) {
       loadDocument(docId);
@@ -131,6 +129,30 @@ async function initGallery() {
         console.error('문서 삭제 실패:', err);
       }
     },
+    async onAddChild(parentId, parentItem, childrenList, childDepth) {
+      try {
+        const newDoc = await apiCreateChildDocument(parentId);
+
+        // Mark toggle button as having children and expand
+        const toggleBtn = parentItem.querySelector(':scope > .document-row > .document-toggle-btn');
+        if (toggleBtn) {
+          toggleBtn.classList.add('has-children', 'is-expanded');
+          toggleBtn.setAttribute('aria-expanded', 'true');
+        }
+        childrenList.hidden = false;
+
+        const childItem = addDocumentItem(childrenList, newDoc, handlers, childDepth);
+        closeAllMenus(list);
+        setActiveItem(list, childItem);
+        activeDocId = newDoc.id;
+        document.getElementById('page-title').textContent = newDoc.title;
+        document.getElementById('page-subtitle').textContent = '';
+        root.innerHTML = '';
+        enterInlineEdit(childItem, newDoc.id, newDoc.title, list, (docId) => loadDocument(docId));
+      } catch (err) {
+        console.error('하위 문서 생성 실패:', err);
+      }
+    },
   };
 
   // ── Sidebar ───────────────────────────────────────────────────────────────
@@ -139,20 +161,20 @@ async function initGallery() {
     document.getElementById('sidebar-panel'),
   );
 
-  // Close document menus and block more-menus when clicking outside
   document.addEventListener('click', () => {
     closeAllMenus(list);
     document.querySelectorAll('.block-more-menu').forEach((m) => (m.hidden = true));
   });
 
-  // ── Load initial document list ────────────────────────────────────────────
+  // ── Load initial document tree ────────────────────────────────────────────
   try {
     const documents = await fetchDocuments();
 
     if (documents.length === 0) {
       showEmptyState();
     } else {
-      documents.forEach((doc) => addDocumentItem(list, doc, handlers));
+      // documents is already a tree (root nodes with .children arrays)
+      documents.forEach((doc) => addDocumentItem(list, doc, handlers, 0));
       const firstItem = list.querySelector('li');
       setActiveItem(list, firstItem);
       await loadDocument(documents[0].id);
@@ -168,15 +190,13 @@ async function initGallery() {
   newDocBtn.addEventListener('click', async () => {
     try {
       const newDoc = await apiCreateDocument();
-      const item = addDocumentItem(list, newDoc, handlers);
+      const item = addDocumentItem(list, newDoc, handlers, 0);
       closeAllMenus(list);
       setActiveItem(list, item);
-      // Show blank page immediately
       document.getElementById('page-title').textContent = newDoc.title;
       document.getElementById('page-subtitle').textContent = '';
       root.innerHTML = '';
       activeDocId = newDoc.id;
-      // Enter inline title edit mode
       enterInlineEdit(item, newDoc.id, newDoc.title, list, (docId) => loadDocument(docId));
     } catch (err) {
       console.error('문서 생성 실패:', err);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -50,6 +50,9 @@ async function initGallery() {
 
     toggleBtn.classList.add('has-children', 'is-expanded');
     toggleBtn.setAttribute('aria-expanded', 'true');
+    // Restore focusability — button was aria-hidden / tabIndex=-1 when childless
+    toggleBtn.removeAttribute('aria-hidden');
+    toggleBtn.tabIndex = 0;
     childrenList.hidden = false;
 
     addDocumentItem(childrenList, childDoc, handlers, parentDepth + 1);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,7 +4,6 @@ import {
   fetchDocuments,
   fetchDocument,
   apiCreateDocument,
-  apiCreateChildDocument,
   apiDeleteDocument,
   apiCreateBlock,
   apiMoveBlock,
@@ -20,6 +19,42 @@ async function initGallery() {
 
   let activeDocId = null;
 
+  // ── Sidebar helpers ───────────────────────────────────────────────────────
+  /**
+   * Full sidebar re-render: re-fetches document tree and rebuilds the list.
+   * Preserves active highlight for the currently open document.
+   */
+  async function reloadSidebar() {
+    const docs = await fetchDocuments();
+    list.innerHTML = '';
+    docs.forEach((doc) => addDocumentItem(list, doc, handlers, 0));
+    if (activeDocId) {
+      const activeItem = list.querySelector(`li[data-id="${activeDocId}"]`);
+      if (activeItem) setActiveItem(list, activeItem);
+    }
+  }
+
+  /**
+   * Add a newly created child document to the sidebar under its parent item
+   * without a full reload. The parent's toggle is expanded automatically.
+   */
+  function addChildToSidebar(childDoc) {
+    const parentItem = list.querySelector(`li[data-id="${childDoc.parent_id}"]`);
+    if (!parentItem) return;
+
+    const parentDepth = parseInt(parentItem.dataset.depth ?? '0', 10);
+    const childrenList = parentItem.querySelector(':scope > .document-children');
+    const toggleBtn = parentItem.querySelector(':scope > .document-row > .document-toggle-btn');
+
+    if (!childrenList || !toggleBtn) return;
+
+    toggleBtn.classList.add('has-children', 'is-expanded');
+    toggleBtn.setAttribute('aria-expanded', 'true');
+    childrenList.hidden = false;
+
+    addDocumentItem(childrenList, childDoc, handlers, parentDepth + 1);
+  }
+
   // ── Wire up renderer callbacks ────────────────────────────────────────────
   callbacks.navigateTo = (documentId) => {
     const targetItem = list.querySelector(`li[data-id="${documentId}"]`);
@@ -32,6 +67,12 @@ async function initGallery() {
 
   callbacks.reloadDocument = () => {
     if (activeDocId) loadDocument(activeDocId);
+  };
+
+  callbacks.reloadSidebar = reloadSidebar;
+
+  callbacks.onPageBlockAdded = (childDoc) => {
+    addChildToSidebar(childDoc);
   };
 
   // ── Document loader ───────────────────────────────────────────────────────
@@ -50,6 +91,9 @@ async function initGallery() {
         }
         focusBlock(newWrapper);
       }
+      if (newBlock.child_document && callbacks.onPageBlockAdded) {
+        callbacks.onPageBlockAdded(newBlock.child_document);
+      }
     };
 
     const addBlock = async (type, parentBlockId = null) => {
@@ -61,6 +105,9 @@ async function initGallery() {
         const newWrapper = renderBlock(newBlock, parentBlockId);
         containerEl.appendChild(newWrapper);
         focusBlock(newWrapper);
+      }
+      if (newBlock.child_document && callbacks.onPageBlockAdded) {
+        callbacks.onPageBlockAdded(newBlock.child_document);
       }
     };
     callbacks.addBlock = addBlock;
@@ -129,30 +176,6 @@ async function initGallery() {
         console.error('문서 삭제 실패:', err);
       }
     },
-    async onAddChild(parentId, parentItem, childrenList, childDepth) {
-      try {
-        const newDoc = await apiCreateChildDocument(parentId);
-
-        // Mark toggle button as having children and expand
-        const toggleBtn = parentItem.querySelector(':scope > .document-row > .document-toggle-btn');
-        if (toggleBtn) {
-          toggleBtn.classList.add('has-children', 'is-expanded');
-          toggleBtn.setAttribute('aria-expanded', 'true');
-        }
-        childrenList.hidden = false;
-
-        const childItem = addDocumentItem(childrenList, newDoc, handlers, childDepth);
-        closeAllMenus(list);
-        setActiveItem(list, childItem);
-        activeDocId = newDoc.id;
-        document.getElementById('page-title').textContent = newDoc.title;
-        document.getElementById('page-subtitle').textContent = '';
-        root.innerHTML = '';
-        enterInlineEdit(childItem, newDoc.id, newDoc.title, list, (docId) => loadDocument(docId));
-      } catch (err) {
-        console.error('하위 문서 생성 실패:', err);
-      }
-    },
   };
 
   // ── Sidebar ───────────────────────────────────────────────────────────────
@@ -173,7 +196,6 @@ async function initGallery() {
     if (documents.length === 0) {
       showEmptyState();
     } else {
-      // documents is already a tree (root nodes with .children arrays)
       documents.forEach((doc) => addDocumentItem(list, doc, handlers, 0));
       const firstItem = list.querySelector('li');
       setActiveItem(list, firstItem);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared pytest fixtures."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.models.orm import Base
+from app.repositories.sqlite_blocks import SQLiteBlockRepository
+
+
+@pytest.fixture()
+def engine():
+  """In-memory SQLite engine, fresh per test.
+
+  StaticPool ensures all sessions share a single connection so that tables
+  created by create_all() are visible to subsequent sessions.
+  """
+  eng = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+  )
+  Base.metadata.create_all(eng)
+  return eng
+
+
+@pytest.fixture()
+def session(engine):
+  with Session(engine) as s:
+    yield s
+
+
+@pytest.fixture()
+def repo(session):
+  return SQLiteBlockRepository(session)
+
+
+@pytest.fixture()
+def client(engine):
+  """TestClient with in-memory DB injected via dependency override."""
+  from main import app
+  from app.dependencies import get_repository
+
+  def _override():
+    with Session(engine) as s:
+      yield SQLiteBlockRepository(s)
+
+  app.dependency_overrides[get_repository] = _override
+  with TestClient(app) as c:
+    yield c
+  app.dependency_overrides.clear()

--- a/tests/test_document_hierarchy.py
+++ b/tests/test_document_hierarchy.py
@@ -1,0 +1,180 @@
+"""Tests for document parent-child hierarchy (issue #28)."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Repository-level tests ────────────────────────────────────────────────────
+
+class TestListDocuments:
+  def test_returns_empty_list_when_no_documents(self, repo):
+    assert repo.list_documents() == []
+
+  def test_root_documents_have_empty_children(self, repo):
+    repo.create_document()
+    docs = repo.list_documents()
+    assert len(docs) == 1
+    assert docs[0]["children"] == []
+    assert docs[0]["parent_id"] is None
+
+  def test_child_nested_under_parent(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+
+    tree = repo.list_documents()
+    assert len(tree) == 1  # only root
+    assert tree[0]["id"] == parent["id"]
+    assert len(tree[0]["children"]) == 1
+    assert tree[0]["children"][0]["id"] == child["id"]
+
+  def test_deep_nesting(self, repo):
+    grandparent = repo.create_document()
+    parent = repo.create_child_document(grandparent["id"])
+    child = repo.create_child_document(parent["id"])
+
+    tree = repo.list_documents()
+    assert len(tree) == 1
+    gp_node = tree[0]
+    assert gp_node["id"] == grandparent["id"]
+    p_node = gp_node["children"][0]
+    assert p_node["id"] == parent["id"]
+    c_node = p_node["children"][0]
+    assert c_node["id"] == child["id"]
+
+  def test_multiple_roots_and_children(self, repo):
+    root1 = repo.create_document()
+    root2 = repo.create_document()
+    child1 = repo.create_child_document(root1["id"])
+    child2 = repo.create_child_document(root1["id"])
+
+    tree = repo.list_documents()
+    root_ids = {d["id"] for d in tree}
+    assert root_ids == {root1["id"], root2["id"]}
+
+    root1_node = next(d for d in tree if d["id"] == root1["id"])
+    child_ids = {c["id"] for c in root1_node["children"]}
+    assert child_ids == {child1["id"], child2["id"]}
+
+
+class TestCreateChildDocument:
+  def test_returns_none_for_missing_parent(self, repo):
+    result = repo.create_child_document("nonexistent-id")
+    assert result is None
+
+  def test_child_has_correct_parent_id(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+    assert child["parent_id"] == parent["id"]
+
+  def test_child_appears_in_tree(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+    tree = repo.list_documents()
+    assert tree[0]["children"][0]["id"] == child["id"]
+
+
+class TestDeleteDocumentWithChildren:
+  def test_children_promoted_to_root_on_parent_delete(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+
+    repo.delete_document(parent["id"])
+
+    tree = repo.list_documents()
+    ids = {d["id"] for d in tree}
+    assert parent["id"] not in ids
+    assert child["id"] in ids
+
+  def test_grandchildren_promoted_when_parent_deleted(self, repo):
+    gp = repo.create_document()
+    parent = repo.create_child_document(gp["id"])
+    child = repo.create_child_document(parent["id"])
+
+    # Delete middle node → child promoted to root; gp still exists
+    repo.delete_document(parent["id"])
+    tree = repo.list_documents()
+    root_ids = {d["id"] for d in tree}
+    assert gp["id"] in root_ids
+    assert parent["id"] not in root_ids
+    assert child["id"] in root_ids
+
+
+class TestIsDescendant:
+  def test_self_is_descendant(self, repo):
+    doc = repo.create_document()
+    assert repo._is_descendant(doc["id"], doc["id"]) is True
+
+  def test_child_is_descendant(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+    assert repo._is_descendant(parent["id"], child["id"]) is True
+
+  def test_grandchild_is_descendant(self, repo):
+    gp = repo.create_document()
+    parent = repo.create_child_document(gp["id"])
+    child = repo.create_child_document(parent["id"])
+    assert repo._is_descendant(gp["id"], child["id"]) is True
+
+  def test_unrelated_document_not_descendant(self, repo):
+    doc1 = repo.create_document()
+    doc2 = repo.create_document()
+    assert repo._is_descendant(doc1["id"], doc2["id"]) is False
+
+  def test_parent_not_descendant_of_child(self, repo):
+    parent = repo.create_document()
+    child = repo.create_child_document(parent["id"])
+    assert repo._is_descendant(child["id"], parent["id"]) is False
+
+
+# ── API-level tests ───────────────────────────────────────────────────────────
+
+class TestDocumentListApi:
+  def test_returns_tree_structure(self, client):
+    r1 = client.post("/api/documents").json()
+    r2 = client.post("/api/documents").json()
+    client.post(f"/api/documents/{r1['id']}/children")
+
+    docs = client.get("/api/documents").json()
+    root_ids = {d["id"] for d in docs}
+    assert r2["id"] in root_ids
+    r1_node = next(d for d in docs if d["id"] == r1["id"])
+    assert len(r1_node["children"]) == 1
+
+  def test_root_documents_have_children_field(self, client):
+    client.post("/api/documents")
+    docs = client.get("/api/documents").json()
+    assert "children" in docs[0]
+
+
+class TestCreateChildDocumentApi:
+  def test_success_returns_201(self, client):
+    parent = client.post("/api/documents").json()
+    res = client.post(f"/api/documents/{parent['id']}/children")
+    assert res.status_code == 201
+
+  def test_response_contains_parent_id(self, client):
+    parent = client.post("/api/documents").json()
+    child = client.post(f"/api/documents/{parent['id']}/children").json()
+    assert child["parent_id"] == parent["id"]
+
+  def test_child_has_children_field(self, client):
+    parent = client.post("/api/documents").json()
+    child = client.post(f"/api/documents/{parent['id']}/children").json()
+    assert "children" in child
+
+  def test_returns_404_for_missing_parent(self, client):
+    res = client.post("/api/documents/nonexistent/children")
+    assert res.status_code == 404
+
+
+class TestDeleteDocumentApi:
+  def test_children_become_roots_after_delete(self, client):
+    parent = client.post("/api/documents").json()
+    child = client.post(f"/api/documents/{parent['id']}/children").json()
+
+    client.delete(f"/api/documents/{parent['id']}")
+
+    docs = client.get("/api/documents").json()
+    root_ids = {d["id"] for d in docs}
+    assert parent["id"] not in root_ids
+    assert child["id"] in root_ids

--- a/tests/test_document_hierarchy.py
+++ b/tests/test_document_hierarchy.py
@@ -126,13 +126,90 @@ class TestIsDescendant:
     assert repo._is_descendant(child["id"], parent["id"]) is False
 
 
+# ── Page block → child document (issue #28 core feature) ─────────────────────
+
+class TestPageBlockCreatesChildDocument:
+  def test_page_block_auto_creates_child_document(self, repo):
+    parent_doc = repo.create_document()
+    result = repo.create_block(parent_doc["id"], "page")
+
+    assert result is not None
+    assert result["type"] == "page"
+    assert "document_id" in result
+    assert "child_document" in result
+
+  def test_child_document_has_correct_parent_id(self, repo):
+    parent_doc = repo.create_document()
+    result = repo.create_block(parent_doc["id"], "page")
+
+    child = result["child_document"]
+    assert child["parent_id"] == parent_doc["id"]
+
+  def test_child_document_appears_in_sidebar_tree(self, repo):
+    parent_doc = repo.create_document()
+    result = repo.create_block(parent_doc["id"], "page")
+    child_id = result["document_id"]
+
+    tree = repo.list_documents()
+    parent_node = next(d for d in tree if d["id"] == parent_doc["id"])
+    child_ids = {c["id"] for c in parent_node["children"]}
+    assert child_id in child_ids
+
+  def test_page_block_contains_child_doc_id(self, repo):
+    parent_doc = repo.create_document()
+    result = repo.create_block(parent_doc["id"], "page")
+
+    assert result["document_id"] == result["child_document"]["id"]
+
+  def test_page_block_returns_404_for_missing_document(self, repo):
+    result = repo.create_block("nonexistent-id", "page")
+    assert result is None
+
+
+class TestPageBlockDeletePromotesChildDocument:
+  def test_deleting_page_block_promotes_child_to_root(self, repo):
+    parent_doc = repo.create_document()
+    block = repo.create_block(parent_doc["id"], "page")
+    child_id = block["document_id"]
+    block_id = block["id"]
+
+    # Child should currently be under parent
+    tree = repo.list_documents()
+    parent_node = next(d for d in tree if d["id"] == parent_doc["id"])
+    assert any(c["id"] == child_id for c in parent_node["children"])
+
+    # Delete the page block
+    repo.delete_block(block_id)
+
+    # Child should now be at root
+    tree = repo.list_documents()
+    root_ids = {d["id"] for d in tree}
+    assert child_id in root_ids
+
+    parent_node = next(d for d in tree if d["id"] == parent_doc["id"])
+    assert not any(c["id"] == child_id for c in parent_node["children"])
+
+  def test_child_document_content_preserved_after_block_delete(self, repo):
+    parent_doc = repo.create_document()
+    block = repo.create_block(parent_doc["id"], "page")
+    child_id = block["document_id"]
+
+    repo.delete_block(block["id"])
+
+    # Child document still exists
+    child = repo.get_document(child_id)
+    assert child is not None
+    assert child.id == child_id
+
+
 # ── API-level tests ───────────────────────────────────────────────────────────
 
 class TestDocumentListApi:
   def test_returns_tree_structure(self, client):
     r1 = client.post("/api/documents").json()
     r2 = client.post("/api/documents").json()
-    client.post(f"/api/documents/{r1['id']}/children")
+    # Create a child via page block
+    client.post(f"/api/documents/{r1['id']}/blocks", json={"type": "page"})
 
     docs = client.get("/api/documents").json()
     root_ids = {d["id"] for d in docs}
@@ -146,35 +223,50 @@ class TestDocumentListApi:
     assert "children" in docs[0]
 
 
-class TestCreateChildDocumentApi:
-  def test_success_returns_201(self, client):
-    parent = client.post("/api/documents").json()
-    res = client.post(f"/api/documents/{parent['id']}/children")
+class TestPageBlockApi:
+  def test_create_page_block_returns_201(self, client):
+    doc = client.post("/api/documents").json()
+    res = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "page"})
     assert res.status_code == 201
 
-  def test_response_contains_parent_id(self, client):
-    parent = client.post("/api/documents").json()
-    child = client.post(f"/api/documents/{parent['id']}/children").json()
-    assert child["parent_id"] == parent["id"]
+  def test_response_contains_child_document(self, client):
+    doc = client.post("/api/documents").json()
+    block = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "page"}).json()
+    assert "child_document" in block
+    assert block["child_document"]["parent_id"] == doc["id"]
 
-  def test_child_has_children_field(self, client):
-    parent = client.post("/api/documents").json()
-    child = client.post(f"/api/documents/{parent['id']}/children").json()
-    assert "children" in child
+  def test_child_document_visible_in_tree(self, client):
+    doc = client.post("/api/documents").json()
+    block = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "page"}).json()
+    child_id = block["document_id"]
 
-  def test_returns_404_for_missing_parent(self, client):
-    res = client.post("/api/documents/nonexistent/children")
-    assert res.status_code == 404
+    docs = client.get("/api/documents").json()
+    parent_node = next(d for d in docs if d["id"] == doc["id"])
+    child_ids = {c["id"] for c in parent_node["children"]}
+    assert child_id in child_ids
+
+  def test_deleting_page_block_promotes_child_to_root(self, client):
+    doc = client.post("/api/documents").json()
+    block = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "page"}).json()
+    child_id = block["document_id"]
+    block_id = block["id"]
+
+    client.delete(f"/api/blocks/{block_id}")
+
+    docs = client.get("/api/documents").json()
+    root_ids = {d["id"] for d in docs}
+    assert child_id in root_ids
 
 
 class TestDeleteDocumentApi:
   def test_children_become_roots_after_delete(self, client):
     parent = client.post("/api/documents").json()
-    child = client.post(f"/api/documents/{parent['id']}/children").json()
+    block = client.post(f"/api/documents/{parent['id']}/blocks", json={"type": "page"}).json()
+    child_id = block["document_id"]
 
     client.delete(f"/api/documents/{parent['id']}")
 
     docs = client.get("/api/documents").json()
     root_ids = {d["id"] for d in docs}
     assert parent["id"] not in root_ids
-    assert child["id"] in root_ids
+    assert child_id in root_ids

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +282,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,6 +360,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "projects-display"
 version = "0.1.0"
 source = { virtual = "." }
@@ -358,6 +385,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-anyio" },
 ]
 
 [package.metadata]
@@ -372,7 +401,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "httpx", specifier = ">=0.28.1" }]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-anyio", specifier = ">=0.0.0" },
+]
 
 [[package]]
 name = "pydantic"
@@ -458,6 +491,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-anyio"
+version = "0.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/44/a02e5877a671b0940f21a7a0d9704c22097b123ed5cdbcca9cab39f17acc/pytest-anyio-0.0.0.tar.gz", hash = "sha256:b41234e9e9ad7ea1dbfefcc1d6891b23d5ef7c9f07ccf804c13a9cc338571fd3", size = 1560, upload-time = "2021-06-29T22:57:30.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/25/bd6493ae85d0a281b6a0f248d0fdb1d9aa2b31f18bcd4a8800cf397d8209/pytest_anyio-0.0.0-py2.py3-none-any.whl", hash = "sha256:dc8b5c4741cb16ff90be37fddd585ca943ed12bbeb563de7ace6cd94441d8746", size = 1999, upload-time = "2021-06-29T22:57:29.158Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- 배경: 문서 간 부모-자식 관계가 없어 평면적인 문서 목록만 제공되던 상황
- 목적: 노션 스타일의 계층형 문서 구조를 지원하여, 페이지 블록 추가 시 하위 페이지로 자동 연결되고 사이드바에서 트리 형태로 탐색할 수 있도록 개선

## Changes

**Backend**
- `DocumentRow`에 `parent_id` 필드 추가 및 기존 DB `ALTER TABLE` 자동 마이그레이션
- `list_documents()`: 평면 목록 → 부모-자식 트리 구조 반환 (children 중첩)
- `create_block(type="page")`: 호출 시 하위 문서 자동 생성, 응답에 `child_document` 포함
- `delete_block`: page 블록 삭제 시 참조 문서의 `parent_id`를 `None`으로 초기화 (루트 승격)
- `delete_document`: 부모 삭제 시 자식 문서를 루트로 승격 (고아 방지)
- `_is_descendant()`: 순환 참조 탐지 헬퍼 추가

**API**
- `BlockCreate` 스키마에 `"page"` 타입 추가
- `POST /api/documents/{id}/children` 엔드포인트 제거 → page 블록 방식으로 통합

**Frontend**
- 블록 팔레트(`/` 슬래시 커맨드 및 `+` 버튼)에 `페이지 (⊔)` 항목 추가
- page 블록 생성 후 응답의 `child_document`로 사이드바 인라인 갱신 (전체 리로드 없음)
- page 블록 삭제 시 `reloadSidebar` 콜백으로 사이드바 자동 갱신
- 사이드바 각 문서 항목에 `›` 토글 버튼 추가: 클릭 시 하위 목록 펼치기/접기 (90도 회전 애니메이션)
- 하위 페이지는 depth 기반 indent로 구분, 형제/상위 항목을 아래로 밀며 펼쳐짐
- CSS `display: grid` 와 `[hidden]` 속성 충돌 수정 (`.document-children[hidden]` 재선언)

## Test

- [x] `pytest tests/test_document_hierarchy.py` — 29개 전체 통과
- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 브라우저 콘솔 에러 없음
- [x] 슬래시 커맨드 `/` → 페이지 선택 → 하위 문서 생성 및 사이드바 반영 확인
- [x] `›` 토글 버튼 펼치기/접기 동작 확인
- [x] page 블록 삭제 후 하위 문서 루트 승격 확인

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- `create_block(type="page")`가 문서 생성과 블록 생성을 하나의 트랜잭션처럼 처리하는 구조 — 원자성 보장 여부 확인 필요
- CSS `[hidden]` 속성 충돌 수정 방식 (`display: grid` 선언이 UA 스타일시트의 `[hidden]` 을 덮어쓰는 문제) — 클래스 기반 토글 전환 여부 논의 가능
- page 블록 삭제 시 하위 문서 삭제가 아닌 루트 승격 정책 — 요구사항과 일치 여부 확인