### PR TITLE
[FEAT#29] 페이지 이름 업데이트 및 포함 문서 전역 반영

### DIFF
--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -12,14 +12,21 @@ from app.repositories.sqlite_blocks import SQLiteBlockRepository
 router = APIRouter(prefix="/api/documents", tags=["documents"])
 
 
+MAX_TITLE_LENGTH = 100
+
+
 class DocumentTitleUpdate(BaseModel):
   title: str
 
   @field_validator("title")
   @classmethod
-  def title_not_blank(cls, v: str) -> str:
+  def validate_title(cls, v: str) -> str:
     stripped = v.strip()
-    return stripped if stripped else "새 문서"
+    if not stripped:
+      return "새 문서"
+    if len(stripped) > MAX_TITLE_LENGTH:
+      raise ValueError(f"제목은 {MAX_TITLE_LENGTH}자를 초과할 수 없습니다.")
+    return stripped
 
 
 @router.get("")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -260,6 +260,21 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   overflow: hidden;
 }
 
+.document-menu-rename {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  cursor: pointer;
+  color: var(--ink-main);
+  font-size: 0.88rem;
+}
+
+.document-menu-rename:hover {
+  background: var(--surface-hover, rgba(0,0,0,0.05));
+}
+
 .document-menu-delete {
   width: 100%;
   border: none;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -377,6 +377,19 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   margin: 0;
   font-family: "Fraunces", serif;
   font-size: clamp(1.35rem, 3vw, 2.2rem);
+  cursor: text;
+  border-radius: 4px;
+  outline: none;
+  transition: background 0.15s;
+}
+
+.block-page-header h1:hover:not([contenteditable="true"]) {
+  background: var(--surface-hover, rgba(0,0,0,0.04));
+}
+
+.block-page-header h1.is-editing {
+  background: var(--surface-hover, rgba(0,0,0,0.04));
+  caret-color: var(--ink-main, #1a1a1a);
 }
 
 .block-page-header p {

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -27,6 +27,7 @@ export const callbacks = {
   reloadDocument: null,     // () => void
   onPageBlockAdded: null,   // (childDoc) => void — update sidebar after page block creation
   reloadSidebar: null,      // () => Promise<void> — full sidebar refresh
+  onTitleChanged: null,     // (documentId, newTitle) => void — propagate title change to page blocks
 };
 
 // ── Individual block creators ─────────────────────────────────────────────────
@@ -313,7 +314,9 @@ function createDividerBlock() {
 function createPageBlock(block) {
   const template = document.getElementById('page-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
-  node.querySelector('.page-block-title').textContent = block.title || block.document_id;
+  const titleEl = node.querySelector('.page-block-title');
+  titleEl.textContent = block.title || block.document_id;
+  titleEl.dataset.docId = block.document_id;
   node.addEventListener('click', () => {
     if (callbacks.navigateTo) callbacks.navigateTo(block.document_id);
   });

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -16,7 +16,7 @@ export function setActiveItem(list, targetItem) {
  * Replace the document-item button inside listItem with an <input> for inline
  * title editing. Commits on Enter or blur; cancels (keeps original) on Escape.
  */
-export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
+export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, onTitleSaved = null) {
   const existingBtn = listItem.querySelector(':scope > .document-row > .document-item');
   const menuBtn = listItem.querySelector(':scope > .document-row > .document-menu-btn');
 
@@ -51,11 +51,17 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
     if (menuBtn) menuBtn.hidden = false;
   }
 
+  function commitTitle(newTitle) {
+    apiUpdateTitle(docId, newTitle)
+      .then(() => { if (onTitleSaved) onTitleSaved(docId, newTitle); })
+      .catch(console.error);
+  }
+
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
       const newTitle = input.value.trim() || '새 문서';
-      apiUpdateTitle(docId, newTitle).catch(console.error);
+      commitTitle(newTitle);
       restoreButton(newTitle);
     } else if (e.key === 'Escape') {
       restoreButton(initialTitle);
@@ -64,7 +70,7 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
 
   input.addEventListener('blur', () => {
     const newTitle = input.value.trim() || '새 문서';
-    if (!exited) apiUpdateTitle(docId, newTitle).catch(console.error);
+    if (!exited) commitTitle(newTitle);
     restoreButton(newTitle);
   });
 }
@@ -79,7 +85,7 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect) {
  * @returns {HTMLLIElement}
  */
 export function addDocumentItem(list, docInfo, handlers, depth = 0) {
-  const { onSelect, onDelete } = handlers;
+  const { onSelect, onDelete, onRename } = handlers;
 
   const item = document.createElement('li');
   item.dataset.id = docInfo.id;
@@ -128,6 +134,19 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
   menu.className = 'document-menu';
   menu.hidden = true;
 
+  const renameBtn = document.createElement('button');
+  renameBtn.type = 'button';
+  renameBtn.className = 'document-menu-rename';
+  renameBtn.textContent = '이름 바꾸기';
+  renameBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    menu.hidden = true;
+    const currentTitle = btn.textContent;
+    enterInlineEdit(item, docInfo.id, currentTitle, list, (docId) => onSelect(docId), (docId, newTitle) => {
+      if (onRename) onRename(docId, newTitle);
+    });
+  });
+
   const deleteBtn = document.createElement('button');
   deleteBtn.type = 'button';
   deleteBtn.className = 'document-menu-delete';
@@ -145,6 +164,7 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
     menu.hidden = !wasHidden;
   });
 
+  menu.appendChild(renameBtn);
   menu.appendChild(deleteBtn);
   row.appendChild(toggleBtn);
   row.appendChild(btn);

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -35,7 +35,7 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
   let exited = false;
 
   function restoreButton(title) {
-    if (exited) return;
+    if (exited) return null;
     exited = true;
 
     const btn = document.createElement('button');
@@ -49,29 +49,32 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
     });
     input.replaceWith(btn);
     if (menuBtn) menuBtn.hidden = false;
+    return btn;
   }
 
-  function commitTitle(newTitle) {
+  function saveTitle(newTitle) {
+    const btn = restoreButton(newTitle);
+    if (newTitle === initialTitle) return;
     apiUpdateTitle(docId, newTitle)
       .then(() => { if (onTitleSaved) onTitleSaved(docId, newTitle); })
-      .catch(console.error);
+      .catch((err) => {
+        console.error(err);
+        if (btn) btn.textContent = initialTitle;
+      });
   }
 
   input.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      const newTitle = input.value.trim() || '새 문서';
-      commitTitle(newTitle);
-      restoreButton(newTitle);
+      saveTitle(input.value.trim() || '새 문서');
     } else if (e.key === 'Escape') {
       restoreButton(initialTitle);
     }
   });
 
   input.addEventListener('blur', () => {
-    const newTitle = input.value.trim() || '새 문서';
-    if (!exited) commitTitle(newTitle);
-    restoreButton(newTitle);
+    if (exited) return;
+    saveTitle(input.value.trim() || '새 문서');
   });
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -248,6 +248,9 @@ async function initGallery() {
         console.error('문서 삭제 실패:', err);
       }
     },
+    onRename(docId, newTitle) {
+      if (callbacks.onTitleChanged) callbacks.onTitleChanged(docId, newTitle);
+    },
   };
 
   // ── Sidebar ───────────────────────────────────────────────────────────────
@@ -291,7 +294,9 @@ async function initGallery() {
       document.getElementById('page-subtitle').textContent = '';
       root.innerHTML = '';
       activeDocId = newDoc.id;
-      enterInlineEdit(item, newDoc.id, newDoc.title, list, (docId) => loadDocument(docId));
+      enterInlineEdit(item, newDoc.id, newDoc.title, list, (docId) => loadDocument(docId), (docId, newTitle) => {
+        if (callbacks.onTitleChanged) callbacks.onTitleChanged(docId, newTitle);
+      });
     } catch (err) {
       console.error('문서 생성 실패:', err);
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -64,7 +64,10 @@ async function initGallery() {
         .then(() => {
           if (callbacks.onTitleChanged) callbacks.onTitleChanged(docId, newTitle);
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error(err);
+          pageTitle.textContent = titleOriginal;
+        });
     }
   });
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,6 +5,7 @@ import {
   fetchDocument,
   apiCreateDocument,
   apiDeleteDocument,
+  apiUpdateTitle,
   apiCreateBlock,
   apiMoveBlock,
 } from "./api.js";
@@ -18,6 +19,62 @@ async function initGallery() {
   const newDocBtn = document.getElementById('new-document-btn');
 
   let activeDocId = null;
+
+  // ── Header title inline editing ───────────────────────────────────────────
+  const pageTitle = document.getElementById('page-title');
+  let titleEscaped = false;
+  let titleOriginal = '';
+
+  pageTitle.addEventListener('click', () => {
+    if (pageTitle.contentEditable === 'true' || !activeDocId) return;
+    titleOriginal = pageTitle.textContent;
+    titleEscaped = false;
+    pageTitle.contentEditable = 'true';
+    pageTitle.classList.add('is-editing');
+    pageTitle.focus();
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(pageTitle);
+    range.collapse(false);
+    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+  });
+
+  pageTitle.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); pageTitle.blur(); }
+    if (e.key === 'Escape') {
+      titleEscaped = true;
+      pageTitle.textContent = titleOriginal;
+      pageTitle.contentEditable = 'false';
+      pageTitle.classList.remove('is-editing');
+    }
+  });
+
+  pageTitle.addEventListener('blur', () => {
+    if (pageTitle.contentEditable !== 'true') return;
+    pageTitle.contentEditable = 'false';
+    pageTitle.classList.remove('is-editing');
+    if (titleEscaped) { titleEscaped = false; return; }
+
+    const newTitle = pageTitle.textContent.trim() || '새 문서';
+    pageTitle.textContent = newTitle;
+
+    if (newTitle !== titleOriginal && activeDocId) {
+      const docId = activeDocId;
+      apiUpdateTitle(docId, newTitle)
+        .then(() => {
+          if (callbacks.onTitleChanged) callbacks.onTitleChanged(docId, newTitle);
+        })
+        .catch(console.error);
+    }
+  });
+
+  /** Update the sidebar button text for a given document id. */
+  function updateSidebarTitle(docId, newTitle) {
+    const item = list.querySelector(`li[data-id="${docId}"]`);
+    if (!item) return;
+    const btn = item.querySelector(':scope > .document-row > .document-item');
+    if (btn) btn.textContent = newTitle;
+  }
 
   // ── Sidebar helpers ───────────────────────────────────────────────────────
   /**
@@ -76,6 +133,18 @@ async function initGallery() {
 
   callbacks.onPageBlockAdded = (childDoc) => {
     addChildToSidebar(childDoc);
+  };
+
+  callbacks.onTitleChanged = (documentId, newTitle) => {
+    updateSidebarTitle(documentId, newTitle);
+    // If the changed document is currently open, update the header
+    if (documentId === activeDocId) {
+      pageTitle.textContent = newTitle;
+    }
+    // Update any visible page blocks that reference this document
+    document.querySelectorAll(`.page-block-title[data-doc-id="${documentId}"]`).forEach((el) => {
+      el.textContent = newTitle;
+    });
   };
 
   // ── Document loader ───────────────────────────────────────────────────────

--- a/tests/test_document_rename.py
+++ b/tests/test_document_rename.py
@@ -1,0 +1,103 @@
+"""Tests for document rename feature (issue #29)."""
+from __future__ import annotations
+
+
+# ── Repository-level tests ────────────────────────────────────────────────────
+
+class TestUpdateDocumentTitle:
+  def test_rename_success(self, repo):
+    doc = repo.create_document()
+    result = repo.update_document_title(doc["id"], "새 이름")
+    assert result is True
+
+  def test_renamed_title_persisted(self, repo):
+    doc = repo.create_document()
+    repo.update_document_title(doc["id"], "변경된 제목")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.title == "변경된 제목"
+
+  def test_rename_nonexistent_returns_false(self, repo):
+    result = repo.update_document_title("nonexistent-id", "제목")
+    assert result is False
+
+  def test_rename_reflected_in_list_documents(self, repo):
+    doc = repo.create_document()
+    repo.update_document_title(doc["id"], "목록 반영 테스트")
+    tree = repo.list_documents()
+    assert tree[0]["title"] == "목록 반영 테스트"
+
+  def test_rename_reflected_in_page_block_title(self, repo):
+    """page 블록이 참조하는 문서의 제목이 바뀌면 get_document 조회 시 반영된다."""
+    parent = repo.create_document()
+    block = repo.create_block(parent["id"], "page")
+    child_id = block["document_id"]
+
+    repo.update_document_title(child_id, "변경된 자식 제목")
+
+    parent_doc = repo.get_document(parent["id"])
+    page_block = next(b for b in parent_doc.blocks if b.type == "page")
+    assert page_block.title == "변경된 자식 제목"
+
+
+# ── API-level tests ───────────────────────────────────────────────────────────
+
+class TestRenameDocumentApi:
+  def test_patch_returns_200(self, client):
+    doc = client.post("/api/documents").json()
+    res = client.patch(f"/api/documents/{doc['id']}", json={"title": "API 제목"})
+    assert res.status_code == 200
+
+  def test_patch_returns_updated_title(self, client):
+    doc = client.post("/api/documents").json()
+    res = client.patch(f"/api/documents/{doc['id']}", json={"title": "응답 제목"})
+    assert res.json()["title"] == "응답 제목"
+
+  def test_patch_nonexistent_returns_404(self, client):
+    res = client.patch("/api/documents/nonexistent-id", json={"title": "제목"})
+    assert res.status_code == 404
+
+  def test_blank_title_falls_back_to_default(self, client):
+    doc = client.post("/api/documents").json()
+    res = client.patch(f"/api/documents/{doc['id']}", json={"title": "   "})
+    assert res.status_code == 200
+    assert res.json()["title"] == "새 문서"
+
+  def test_title_over_max_length_returns_422(self, client):
+    doc = client.post("/api/documents").json()
+    long_title = "가" * 101
+    res = client.patch(f"/api/documents/{doc['id']}", json={"title": long_title})
+    assert res.status_code == 422
+
+  def test_title_at_max_length_succeeds(self, client):
+    doc = client.post("/api/documents").json()
+    exact_title = "가" * 100
+    res = client.patch(f"/api/documents/{doc['id']}", json={"title": exact_title})
+    assert res.status_code == 200
+    assert res.json()["title"] == exact_title
+
+  def test_rename_persisted_on_get(self, client):
+    doc = client.post("/api/documents").json()
+    client.patch(f"/api/documents/{doc['id']}", json={"title": "저장 확인"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["title"] == "저장 확인"
+
+  def test_rename_reflected_in_document_list(self, client):
+    doc = client.post("/api/documents").json()
+    client.patch(f"/api/documents/{doc['id']}", json={"title": "목록 반영"})
+    docs = client.get("/api/documents").json()
+    titles = {d["title"] for d in docs}
+    assert "목록 반영" in titles
+
+  def test_rename_reflected_in_page_block(self, client):
+    """참조 문서의 제목 변경이 page 블록 조회 시 반영된다."""
+    parent = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{parent['id']}/blocks", json={"type": "page"}
+    ).json()
+    child_id = block["document_id"]
+
+    client.patch(f"/api/documents/{child_id}", json={"title": "전파 테스트"})
+
+    parent_doc = client.get(f"/api/documents/{parent['id']}").json()
+    page_block = next(b for b in parent_doc["blocks"] if b["type"] == "page")
+    assert page_block["title"] == "전파 테스트"


### PR DESCRIPTION
## Summary

- 배경: 페이지 제목을 변경해도 사이드바, page 블록, 헤더에 이전 이름이 그대로 남아 있어 불일치가 발생하는 문제
- 목적: 제목 변경 진입점을 추가하고, 변경 시 UI 전역에 즉시 반영되도록 전파 로직 구현

## Changes

- `app/routers/documents.py`: 제목 최대 길이 100자 검증 추가 (`validate_title` validator)
- `static/js/main.js`: `page-title` h1 클릭 → contenteditable 인라인 편집, blur/Enter 저장, `onTitleChanged` 콜백으로 사이드바·page 블록 실시간 갱신
- `static/js/blockRenderers.js`: `page-block-title` 요소에 `data-doc-id` 속성 추가 (전파 대상 식별), `callbacks.onTitleChanged` 콜백 선언
- `static/js/documentList.js`: `addDocumentItem` ⋯ 메뉴에 "이름 바꾸기" 버튼 추가, `enterInlineEdit`에 `onTitleSaved` 콜백 파라미터 추가
- `static/css/style.css`: h1 hover·편집 피드백 CSS, `.document-menu-rename` 스타일 추가
- `tests/test_document_rename.py`: 회귀 테스트 14개 신규 추가 (repository 5 + API 9)

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/documents`)
- [x] 브라우저 콘솔 에러 없음
- [x] pytest 43 passed (기존 29 + 신규 14)

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분:
  - `onTitleChanged` 브로드캐스트 흐름 (헤더 편집 → 사이드바/page 블록 동기화)
  - `enterInlineEdit`의 `onTitleSaved` 콜백 인터페이스 변경이 기존 호출부(새 문서 생성)에 영향 없는지
  - 100자 초과 시 422 응답 후 프론트엔드 에러 처리 (현재 `console.error` 수준)

Closes #29