### PR TITLE
[FEAT#27] ContainerBlock 리팩토링, 토글/코드 블록 편집 기능 강화 및 Highlight.js 적용

### DIFF
--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -42,9 +42,9 @@ class ToggleBlock(BlockBase):
   """Collapsible block with a title and nested child blocks."""
 
   type: Literal["toggle"]
-  title: str = ""
-  formatted_title: str | None = None  # HTML string with inline formatting
-  level: Literal[1, 2, 3] | None = None  # heading level for the title
+  text: str = ""
+  formatted_text: str | None = None
+  level: Literal[1, 2, 3] | None = None
   is_open: bool = False
   children: list["Block"] = Field(default_factory=list)
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -44,6 +44,7 @@ class ToggleBlock(BlockBase):
   type: Literal["toggle"]
   title: str = ""
   formatted_title: str | None = None  # HTML string with inline formatting
+  level: Literal[1, 2, 3] | None = None  # heading level for the title
   is_open: bool = False
   children: list["Block"] = Field(default_factory=list)
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -43,6 +43,7 @@ class ToggleBlock(BlockBase):
 
   type: Literal["toggle"]
   title: str = ""
+  formatted_title: str | None = None  # HTML string with inline formatting
   is_open: bool = False
   children: list["Block"] = Field(default_factory=list)
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -38,6 +38,41 @@ class ContainerBlock(BlockBase):
   children: list["Block"] = Field(default_factory=list)
 
 
+class ToggleBlock(BlockBase):
+  """Collapsible block with a title and nested child blocks."""
+
+  type: Literal["toggle"]
+  title: str = ""
+  is_open: bool = False
+  children: list["Block"] = Field(default_factory=list)
+
+
+class QuoteBlock(BlockBase):
+  """Blockquote with optional nested child blocks."""
+
+  type: Literal["quote"]
+  text: str = ""
+  children: list["Block"] = Field(default_factory=list)
+
+
+class CodeBlock(BlockBase):
+  """Code block with language selection and a copy action."""
+
+  type: Literal["code"]
+  code: str = ""
+  language: str = "plain"
+
+
+class CalloutBlock(BlockBase):
+  """Highlighted callout box with an emoji icon and background colour."""
+
+  type: Literal["callout"]
+  text: str = ""
+  emoji: str = "💡"
+  color: Literal["yellow", "blue", "green", "red", "gray"] = "yellow"
+  children: list["Block"] = Field(default_factory=list)
+
+
 class DividerBlock(BlockBase):
   """Horizontal divider block."""
 
@@ -53,7 +88,7 @@ class PageBlock(BlockBase):
 
 
 Block = Annotated[
-  TextBlock | ImageBlock | ContainerBlock | DividerBlock | PageBlock,
+  TextBlock | ImageBlock | ContainerBlock | ToggleBlock | QuoteBlock | CodeBlock | CalloutBlock | DividerBlock | PageBlock,
   Field(discriminator="type"),
 ]
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -12,13 +12,23 @@ class BlockBase(BaseModel):
   type: str
 
 
+class ContainerBlockBase(BlockBase):
+  """Internal base for blocks that can contain child blocks.
+
+  Not a user-visible block type — not included in the Block discriminated union.
+  Blocks that accept child blocks (toggle, quote, callout) inherit from this base.
+  """
+
+  children: list["Block"] = Field(default_factory=list)
+
+
 class TextBlock(BlockBase):
   """Plain text paragraph, optionally promoted to a heading via level."""
 
   type: Literal["text"]
   text: str
   level: Literal[1, 2, 3] | None = None
-  formatted_text: str | None = None  # HTML string with inline formatting
+  formatted_text: str | None = None
 
 
 class ImageBlock(BlockBase):
@@ -29,16 +39,7 @@ class ImageBlock(BlockBase):
   caption: str = ""
 
 
-class ContainerBlock(BlockBase):
-  """Container block that groups other blocks."""
-
-  type: Literal["container"]
-  title: str = ""
-  layout: Literal["vertical", "grid"] = "vertical"
-  children: list["Block"] = Field(default_factory=list)
-
-
-class ToggleBlock(BlockBase):
+class ToggleBlock(ContainerBlockBase):
   """Collapsible block with a title and nested child blocks."""
 
   type: Literal["toggle"]
@@ -46,15 +47,13 @@ class ToggleBlock(BlockBase):
   formatted_text: str | None = None
   level: Literal[1, 2, 3] | None = None
   is_open: bool = False
-  children: list["Block"] = Field(default_factory=list)
 
 
-class QuoteBlock(BlockBase):
+class QuoteBlock(ContainerBlockBase):
   """Blockquote with optional nested child blocks."""
 
   type: Literal["quote"]
   text: str = ""
-  children: list["Block"] = Field(default_factory=list)
 
 
 class CodeBlock(BlockBase):
@@ -65,14 +64,13 @@ class CodeBlock(BlockBase):
   language: str = "plain"
 
 
-class CalloutBlock(BlockBase):
+class CalloutBlock(ContainerBlockBase):
   """Highlighted callout box with an emoji icon and background colour."""
 
   type: Literal["callout"]
   text: str = ""
   emoji: str = "💡"
   color: Literal["yellow", "blue", "green", "red", "gray"] = "yellow"
-  children: list["Block"] = Field(default_factory=list)
 
 
 class DividerBlock(BlockBase):
@@ -90,7 +88,7 @@ class PageBlock(BlockBase):
 
 
 Block = Annotated[
-  TextBlock | ImageBlock | ContainerBlock | ToggleBlock | QuoteBlock | CodeBlock | CalloutBlock | DividerBlock | PageBlock,
+  TextBlock | ImageBlock | ToggleBlock | QuoteBlock | CodeBlock | CalloutBlock | DividerBlock | PageBlock,
   Field(discriminator="type"),
 ]
 

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -8,7 +8,16 @@ from pydantic import TypeAdapter
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.orm import Session
 
-from app.models.blocks import Block, BlockDocument, ContainerBlock, DividerBlock, PageBlock
+from app.models.blocks import (
+  Block,
+  BlockDocument,
+  CalloutBlock,
+  ContainerBlock,
+  DividerBlock,
+  PageBlock,
+  QuoteBlock,
+  ToggleBlock,
+)
 from app.models.orm import BlockRow, DocumentRow
 
 
@@ -90,6 +99,12 @@ class SQLiteBlockRepository:
       for item in children_by_parent.get(parent_id, []):
         if item["type"] == "container":
           nodes.append(ContainerBlock.model_validate({**item, "children": build_nodes(item["id"])}))
+        elif item["type"] == "toggle":
+          nodes.append(ToggleBlock.model_validate({**item, "children": build_nodes(item["id"])}))
+        elif item["type"] == "quote":
+          nodes.append(QuoteBlock.model_validate({**item, "children": build_nodes(item["id"])}))
+        elif item["type"] == "callout":
+          nodes.append(CalloutBlock.model_validate({**item, "children": build_nodes(item["id"])}))
         elif item["type"] == "heading":
           # heading은 TextBlock으로 통합 — 기존 DB 데이터 하위 호환
           nodes.append(self._block_adapter.validate_python({**item, "type": "text"}))
@@ -232,6 +247,14 @@ class SQLiteBlockRepository:
           default_content = {"url": "", "caption": ""}
         case "container":
           default_content = {"title": "", "layout": "vertical"}
+        case "toggle":
+          default_content = {"title": "", "is_open": False}
+        case "quote":
+          default_content = {"text": ""}
+        case "code":
+          default_content = {"code": "", "language": "plain"}
+        case "callout":
+          default_content = {"text": "", "emoji": "💡", "color": "yellow"}
         case "divider":
           default_content = {}
         case _:
@@ -334,6 +357,14 @@ class SQLiteBlockRepository:
         default_content = {"url": "", "caption": ""}
       case "container":
         default_content = {"title": "", "layout": "vertical"}
+      case "toggle":
+        default_content = {"title": "", "is_open": False}
+      case "quote":
+        default_content = {"text": ""}
+      case "code":
+        default_content = {"code": "", "language": "plain"}
+      case "callout":
+        default_content = {"text": "", "emoji": "💡", "color": "yellow"}
       case "divider":
         default_content = {}
       case _:

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -251,7 +251,7 @@ class SQLiteBlockRepository:
         case "container":
           default_content = {"title": "", "layout": "vertical"}
         case "toggle":
-          default_content = {"title": "", "is_open": True}
+          default_content = {"text": "", "is_open": True}
         case "quote":
           default_content = {"text": ""}
         case "code":
@@ -389,7 +389,7 @@ class SQLiteBlockRepository:
       case "container":
         default_content = {"title": "", "layout": "vertical"}
       case "toggle":
-        default_content = {"title": "", "is_open": True}
+        default_content = {"text": "", "is_open": True}
       case "quote":
         default_content = {"text": ""}
       case "code":

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -12,7 +12,6 @@ from app.models.blocks import (
   Block,
   BlockDocument,
   CalloutBlock,
-  ContainerBlock,
   DividerBlock,
   PageBlock,
   QuoteBlock,
@@ -21,7 +20,9 @@ from app.models.blocks import (
 from app.models.orm import BlockRow, DocumentRow
 
 
-_CONTAINER_TYPES: frozenset[str] = frozenset({"container", "toggle", "quote", "callout"})
+# Block types that act as containers: auto-create one child text block on creation
+# and cascade-delete upward when their last child is removed.
+_CHILD_BEARING_TYPES: frozenset[str] = frozenset({"toggle", "quote", "callout"})
 
 
 class SQLiteBlockRepository:
@@ -100,14 +101,9 @@ class SQLiteBlockRepository:
     def build_nodes(parent_id: str | None) -> list[Block]:
       nodes: list[Block] = []
       for item in children_by_parent.get(parent_id, []):
-        if item["type"] == "container":
-          nodes.append(ContainerBlock.model_validate({**item, "children": build_nodes(item["id"])}))
-        elif item["type"] == "toggle":
-          nodes.append(ToggleBlock.model_validate({**item, "children": build_nodes(item["id"])}))
-        elif item["type"] == "quote":
-          nodes.append(QuoteBlock.model_validate({**item, "children": build_nodes(item["id"])}))
-        elif item["type"] == "callout":
-          nodes.append(CalloutBlock.model_validate({**item, "children": build_nodes(item["id"])}))
+        if item["type"] in _CHILD_BEARING_TYPES:
+          model_cls = {"toggle": ToggleBlock, "quote": QuoteBlock, "callout": CalloutBlock}[item["type"]]
+          nodes.append(model_cls.model_validate({**item, "children": build_nodes(item["id"])}))
         elif item["type"] == "heading":
           # heading은 TextBlock으로 통합 — 기존 DB 데이터 하위 호환
           nodes.append(self._block_adapter.validate_python({**item, "type": "text"}))
@@ -248,8 +244,6 @@ class SQLiteBlockRepository:
           default_content = {"text": ""}
         case "image":
           default_content = {"url": "", "caption": ""}
-        case "container":
-          default_content = {"title": "", "layout": "vertical"}
         case "toggle":
           default_content = {"text": "", "is_open": True}
         case "quote":
@@ -285,7 +279,7 @@ class SQLiteBlockRepository:
 
     # ── Container blocks: auto-create one child text block ────────────────────
     child_text_row: dict[str, Any] | None = None
-    if block_type in _CONTAINER_TYPES:
+    if block_type in _CHILD_BEARING_TYPES:
       child_id = str(uuid.uuid4())
       self._session.add(BlockRow(
         id=child_id,
@@ -350,7 +344,7 @@ class SQLiteBlockRepository:
     # ── Cascade: if parent container is now empty, delete it too ─────────────
     if parent_block_id is not None:
       parent_row = self._session.get(BlockRow, parent_block_id)
-      if parent_row is not None and parent_row.type in _CONTAINER_TYPES:
+      if parent_row is not None and parent_row.type in _CHILD_BEARING_TYPES:
         remaining = self._session.execute(
           select(func.count()).where(BlockRow.parent_block_id == parent_block_id)
         ).scalar_one()
@@ -386,8 +380,6 @@ class SQLiteBlockRepository:
         default_content: dict[str, Any] = {"text": ""}
       case "image":
         default_content = {"url": "", "caption": ""}
-      case "container":
-        default_content = {"title": "", "layout": "vertical"}
       case "toggle":
         default_content = {"text": "", "is_open": True}
       case "quote":
@@ -417,7 +409,7 @@ class SQLiteBlockRepository:
     block_row.content_json = json.dumps(default_content, ensure_ascii=False)
 
     # Container types: auto-create one child text block
-    if new_type in _CONTAINER_TYPES:
+    if new_type in _CHILD_BEARING_TYPES:
       child_id = str(uuid.uuid4())
       self._session.add(BlockRow(
         id=child_id,
@@ -492,35 +484,27 @@ class SQLiteBlockRepository:
 
     self._session.add_all([
       # ── intro document ──────────────────────────────────────────────────────
-      BlockRow(id="b-overview", document_id=intro_id, parent_block_id=None, type="container", position=1,
-               content_json=json.dumps({"title": "개요", "layout": "vertical"})),
-      BlockRow(id="b-overview-text", document_id=intro_id, parent_block_id="b-overview", type="text", position=1,
+      BlockRow(id="b-overview-text", document_id=intro_id, parent_block_id=None, type="text", position=1,
                content_json=json.dumps({"text": "Project Manager는 노션 스타일의 블록 인터페이스로 프로젝트와 문서를 관리하는 도구입니다."})),
-      BlockRow(id="b-overview-image", document_id=intro_id, parent_block_id="b-overview", type="image", position=2,
+      BlockRow(id="b-overview-image", document_id=intro_id, parent_block_id=None, type="image", position=2,
                content_json=json.dumps({
                  "url": "https://images.unsplash.com/photo-1611532736597-de2d4265fba3?auto=format&fit=crop&w=1200&q=80",
                  "caption": "블록으로 구성하는 프로젝트 문서",
                })),
-      BlockRow(id="b-block-types", document_id=intro_id, parent_block_id=None, type="container", position=2,
-               content_json=json.dumps({"title": "블록 타입", "layout": "grid"})),
-      BlockRow(id="b-block-text", document_id=intro_id, parent_block_id="b-block-types", type="text", position=1,
+      BlockRow(id="b-block-text", document_id=intro_id, parent_block_id=None, type="text", position=3,
                content_json=json.dumps({"text": "텍스트 블록: 프로젝트 설명, 요구사항, 메모 등 텍스트 콘텐츠를 기록합니다."})),
-      BlockRow(id="b-block-image", document_id=intro_id, parent_block_id="b-block-types", type="text", position=2,
+      BlockRow(id="b-block-image", document_id=intro_id, parent_block_id=None, type="text", position=4,
                content_json=json.dumps({"text": "이미지 블록: 스크린샷, 다이어그램, 참고 이미지를 문서에 삽입합니다."})),
-      BlockRow(id="b-block-container", document_id=intro_id, parent_block_id="b-block-types", type="text", position=3,
-               content_json=json.dumps({"text": "컨테이너 블록: 블록 묶음에 레이아웃(vertical / grid)을 적용해 섹션을 구조화합니다."})),
-      BlockRow(id="b-page-stack", document_id=intro_id, parent_block_id=None, type="page", position=3,
+      BlockRow(id="b-page-stack", document_id=intro_id, parent_block_id=None, type="page", position=5,
                content_json=json.dumps({"document_id": stack_id})),
       # ── tech-stack document ─────────────────────────────────────────────────
-      BlockRow(id="b-stack-overview", document_id=stack_id, parent_block_id=None, type="container", position=1,
-               content_json=json.dumps({"title": "백엔드", "layout": "grid"})),
-      BlockRow(id="b-stack-fastapi", document_id=stack_id, parent_block_id="b-stack-overview", type="text", position=1,
+      BlockRow(id="b-stack-fastapi", document_id=stack_id, parent_block_id=None, type="text", position=1,
                content_json=json.dumps({"text": "FastAPI — Python 기반 비동기 웹 프레임워크"})),
-      BlockRow(id="b-stack-sqlite", document_id=stack_id, parent_block_id="b-stack-overview", type="text", position=2,
+      BlockRow(id="b-stack-sqlite", document_id=stack_id, parent_block_id=None, type="text", position=2,
                content_json=json.dumps({"text": "SQLite — 경량 내장형 관계형 데이터베이스"})),
-      BlockRow(id="b-stack-pydantic", document_id=stack_id, parent_block_id="b-stack-overview", type="text", position=3,
+      BlockRow(id="b-stack-pydantic", document_id=stack_id, parent_block_id=None, type="text", position=3,
                content_json=json.dumps({"text": "Pydantic v2 — 타입 기반 데이터 검증"})),
-      BlockRow(id="b-page-intro", document_id=stack_id, parent_block_id=None, type="page", position=2,
+      BlockRow(id="b-page-intro", document_id=stack_id, parent_block_id=None, type="page", position=4,
                content_json=json.dumps({"document_id": intro_id})),
     ])
     self._session.commit()

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -104,6 +104,15 @@ class SQLiteBlockRepository:
         if item["type"] in _CHILD_BEARING_TYPES:
           model_cls = {"toggle": ToggleBlock, "quote": QuoteBlock, "callout": CalloutBlock}[item["type"]]
           nodes.append(model_cls.model_validate({**item, "children": build_nodes(item["id"])}))
+        elif item["type"] == "container":
+          # 레거시 container 블록 역호환 — toggle로 매핑하여 children 유지
+          nodes.append(ToggleBlock.model_validate({
+            **item,
+            "type": "toggle",
+            "text": item.get("title") or item.get("text") or "",
+            "is_open": True,
+            "children": build_nodes(item["id"]),
+          }))
         elif item["type"] == "heading":
           # heading은 TextBlock으로 통합 — 기존 DB 데이터 하위 호환
           nodes.append(self._block_adapter.validate_python({**item, "type": "text"}))

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -389,7 +389,7 @@ class SQLiteBlockRepository:
       case "container":
         default_content = {"title": "", "layout": "vertical"}
       case "toggle":
-        default_content = {"title": "", "is_open": False}
+        default_content = {"title": "", "is_open": True}
       case "quote":
         default_content = {"text": ""}
       case "code":
@@ -405,6 +405,8 @@ class SQLiteBlockRepository:
     if block_row is None:
       return False
 
+    document_id = block_row.document_id
+
     # Delete all descendants (covers container children)
     all_ids = self._collect_subtree_ids(block_id)
     descendant_ids = [i for i in all_ids if i != block_id]
@@ -413,6 +415,19 @@ class SQLiteBlockRepository:
 
     block_row.type = new_type
     block_row.content_json = json.dumps(default_content, ensure_ascii=False)
+
+    # Container types: auto-create one child text block
+    if new_type in _CONTAINER_TYPES:
+      child_id = str(uuid.uuid4())
+      self._session.add(BlockRow(
+        id=child_id,
+        document_id=document_id,
+        parent_block_id=block_id,
+        type="text",
+        position=1,
+        content_json=json.dumps({"text": ""}, ensure_ascii=False),
+      ))
+
     self._session.commit()
     return True
 

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -21,6 +21,9 @@ from app.models.blocks import (
 from app.models.orm import BlockRow, DocumentRow
 
 
+_CONTAINER_TYPES: frozenset[str] = frozenset({"container", "toggle", "quote", "callout"})
+
+
 class SQLiteBlockRepository:
   """SQLAlchemy-backed repository for notion-style block documents."""
 
@@ -248,7 +251,7 @@ class SQLiteBlockRepository:
         case "container":
           default_content = {"title": "", "layout": "vertical"}
         case "toggle":
-          default_content = {"title": "", "is_open": False}
+          default_content = {"title": "", "is_open": True}
         case "quote":
           default_content = {"text": ""}
         case "code":
@@ -279,12 +282,29 @@ class SQLiteBlockRepository:
       position=max_pos + 1,
       content_json=json.dumps(default_content, ensure_ascii=False),
     ))
+
+    # ── Container blocks: auto-create one child text block ────────────────────
+    child_text_row: dict[str, Any] | None = None
+    if block_type in _CONTAINER_TYPES:
+      child_id = str(uuid.uuid4())
+      self._session.add(BlockRow(
+        id=child_id,
+        document_id=document_id,
+        parent_block_id=block_id,
+        type="text",
+        position=1,
+        content_json=json.dumps({"text": ""}, ensure_ascii=False),
+      ))
+      child_text_row = {"id": child_id, "type": "text", "text": ""}
+
     self._session.commit()
 
     result: dict[str, Any] = {"id": block_id, "type": block_type, **default_content}
     if block_type == "page":
       result["title"] = child_doc["title"]
       result["child_document"] = child_doc
+    if child_text_row is not None:
+      result["children"] = [child_text_row]
     return result
 
   def delete_block(self, block_id: str) -> bool:
@@ -326,6 +346,17 @@ class SQLiteBlockRepository:
       .values(position=BlockRow.position - 1)
     )
     self._session.commit()
+
+    # ── Cascade: if parent container is now empty, delete it too ─────────────
+    if parent_block_id is not None:
+      parent_row = self._session.get(BlockRow, parent_block_id)
+      if parent_row is not None and parent_row.type in _CONTAINER_TYPES:
+        remaining = self._session.execute(
+          select(func.count()).where(BlockRow.parent_block_id == parent_block_id)
+        ).scalar_one()
+        if remaining == 0:
+          self.delete_block(parent_block_id)
+
     return True
 
   def _collect_subtree_ids(self, root_id: str) -> list[str]:

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -19,9 +19,8 @@ class BlockPatch(BaseModel):
   # image
   url: str | None = None
   caption: str | None = None
-  # container / toggle
+  # container
   title: str | None = None
-  formatted_title: str | None = None  # HTML string with inline formatting for toggle title
   # toggle
   is_open: bool | None = None
   # code

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -21,6 +21,7 @@ class BlockPatch(BaseModel):
   caption: str | None = None
   # container / toggle
   title: str | None = None
+  formatted_title: str | None = None  # HTML string with inline formatting for toggle title
   # toggle
   is_open: bool | None = None
   # code

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -19,8 +19,6 @@ class BlockPatch(BaseModel):
   # image
   url: str | None = None
   caption: str | None = None
-  # container
-  title: str | None = None
   # toggle
   is_open: bool | None = None
   # code
@@ -36,7 +34,7 @@ class BlockPositionPatch(BaseModel):
 
 
 class BlockTypeChange(BaseModel):
-  type: Literal["text", "image", "container", "toggle", "quote", "code", "callout", "divider"]
+  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider"]
 
 
 @router.patch("/{block_id}")

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -12,12 +12,23 @@ router = APIRouter(prefix="/api/blocks", tags=["blocks"])
 
 
 class BlockPatch(BaseModel):
+  # text / heading
   text: str | None = None
-  url: str | None = None
-  caption: str | None = None
-  title: str | None = None
   level: Literal[1, 2, 3] | None = None
   formatted_text: str | None = None  # HTML string with inline formatting
+  # image
+  url: str | None = None
+  caption: str | None = None
+  # container / toggle
+  title: str | None = None
+  # toggle
+  is_open: bool | None = None
+  # code
+  code: str | None = None
+  language: str | None = None
+  # callout
+  emoji: str | None = None
+  color: Literal["yellow", "blue", "green", "red", "gray"] | None = None
 
 
 class BlockPositionPatch(BaseModel):
@@ -25,7 +36,7 @@ class BlockPositionPatch(BaseModel):
 
 
 class BlockTypeChange(BaseModel):
-  type: Literal["text", "image", "container", "divider"]
+  type: Literal["text", "image", "container", "toggle", "quote", "code", "callout", "divider"]
 
 
 @router.patch("/{block_id}")

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -66,7 +66,7 @@ def update_document_title(
 
 
 class BlockCreate(BaseModel):
-  type: Literal["text", "image", "container", "divider", "page"]
+  type: Literal["text", "image", "container", "toggle", "quote", "code", "callout", "divider", "page"]
   parent_block_id: str | None = None
 
 

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -66,7 +66,7 @@ def update_document_title(
 
 
 class BlockCreate(BaseModel):
-  type: Literal["text", "image", "container", "toggle", "quote", "code", "callout", "divider", "page"]
+  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "page"]
   parent_block_id: str | None = None
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -694,6 +694,13 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .notion-callout[data-color="red"]    { background: #fee2e2; border-color: #fca5a5; }
 .notion-callout[data-color="gray"]   { background: #f3f4f6; border-color: #d1d5db; }
 
+.callout-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .callout-emoji {
   font-size: 1.1rem;
   line-height: 1.6;
@@ -701,7 +708,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 }
 
 .callout-text {
-  flex: 1;
   margin: 0;
   line-height: 1.6;
   color: var(--ink);
@@ -715,6 +721,36 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   cursor: text;
   background: rgba(0, 0, 0, 0.03);
   border-radius: 4px;
+}
+
+/* ── Add-content button (inside container blocks) ───────────────────────── */
+
+.block-add-content-btn {
+  display: block;
+  width: 100%;
+  padding: 0.28rem 0.5rem;
+  margin-top: 0.15rem;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--ink-muted, #aaa);
+  font-size: 0.78rem;
+  text-align: left;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.1s;
+}
+
+.notion-container:hover .block-add-content-btn,
+.notion-toggle:hover .block-add-content-btn,
+.notion-quote:hover .block-add-content-btn,
+.notion-callout:hover .block-add-content-btn {
+  opacity: 1;
+}
+
+.block-add-content-btn:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--ink-soft);
 }
 
 /* ── Inline editing ──────────────────────────────────────────────────────── */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -549,6 +549,174 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   margin: 0.25rem 0;
 }
 
+/* ── Toggle block ───────────────────────────────────────────────────────── */
+
+.notion-toggle {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toggle-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.32rem 0.4rem;
+  cursor: pointer;
+  border-radius: 4px;
+  list-style: none;
+  user-select: none;
+}
+
+.toggle-summary::-webkit-details-marker { display: none; }
+
+.toggle-summary::before {
+  content: '▶';
+  font-size: 0.6rem;
+  color: var(--ink-soft);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+
+.notion-toggle[open] > .toggle-summary::before {
+  transform: rotate(90deg);
+}
+
+.toggle-summary:hover { background: rgba(0, 0, 0, 0.03); }
+
+.toggle-title {
+  flex: 1;
+  font-weight: 500;
+  color: var(--ink);
+  line-height: 1.5;
+  outline: none;
+}
+
+.toggle-children {
+  padding-left: 1.4rem;
+  padding-top: 0.25rem;
+}
+
+/* ── Quote block ─────────────────────────────────────────────────────────── */
+
+.notion-quote {
+  border: none;
+  border-left: 3px solid var(--accent);
+  margin: 0;
+  padding: 0.4rem 0 0.4rem 1rem;
+  background: transparent;
+}
+
+.quote-text {
+  margin: 0;
+  color: var(--ink);
+  line-height: 1.6;
+  font-style: italic;
+  outline: none;
+}
+
+.quote-children {
+  margin-top: 0.25rem;
+}
+
+/* ── Code block ──────────────────────────────────────────────────────────── */
+
+.notion-code {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--surface, #f8f8f8);
+}
+
+.code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.3rem 0.6rem;
+  background: rgba(0, 0, 0, 0.04);
+  border-bottom: 1px solid var(--line);
+  gap: 0.5rem;
+}
+
+.code-language-select {
+  font-size: 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  outline: none;
+  padding: 0.1rem 0.2rem;
+}
+
+.code-copy-btn {
+  font-size: 0.72rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.code-copy-btn:hover { background: rgba(0, 0, 0, 0.05); }
+
+.code-body {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+}
+
+.code-content {
+  display: block;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  white-space: pre;
+  outline: none;
+  min-height: 1.4em;
+}
+
+/* ── Callout block ───────────────────────────────────────────────────────── */
+
+.notion-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.notion-callout[data-color="yellow"] { background: #fef9c3; border-color: #fde047; }
+.notion-callout[data-color="blue"]   { background: #dbeafe; border-color: #93c5fd; }
+.notion-callout[data-color="green"]  { background: #dcfce7; border-color: #86efac; }
+.notion-callout[data-color="red"]    { background: #fee2e2; border-color: #fca5a5; }
+.notion-callout[data-color="gray"]   { background: #f3f4f6; border-color: #d1d5db; }
+
+.callout-emoji {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  flex-shrink: 0;
+}
+
+.callout-text {
+  flex: 1;
+  margin: 0;
+  line-height: 1.6;
+  color: var(--ink);
+  outline: none;
+}
+
+/* Hover hint for new editable targets */
+.toggle-title:not([contenteditable="true"]):hover,
+.quote-text:not([contenteditable="true"]):hover,
+.callout-text:not([contenteditable="true"]):hover {
+  cursor: text;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 4px;
+}
+
 /* ── Inline editing ──────────────────────────────────────────────────────── */
 
 .notion-block.is-editing {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -723,36 +723,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   border-radius: 4px;
 }
 
-/* ── Add-content button (inside container blocks) ───────────────────────── */
-
-.block-add-content-btn {
-  display: block;
-  width: 100%;
-  padding: 0.28rem 0.5rem;
-  margin-top: 0.15rem;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--ink-muted, #aaa);
-  font-size: 0.78rem;
-  text-align: left;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s, background 0.1s;
-}
-
-.notion-container:hover .block-add-content-btn,
-.notion-toggle:hover .block-add-content-btn,
-.notion-quote:hover .block-add-content-btn,
-.notion-callout:hover .block-add-content-btn {
-  opacity: 1;
-}
-
-.block-add-content-btn:hover {
-  background: rgba(0, 0, 0, 0.04);
-  color: var(--ink-soft);
-}
-
 /* ── Inline editing ──────────────────────────────────────────────────────── */
 
 .notion-block.is-editing {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -966,6 +966,13 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   opacity: 1;
 }
 
+/* Hide parent actions while a child block is hovered or focused */
+.block-wrapper:has(.block-wrapper:hover) > .block-actions,
+.block-wrapper:has(.block-wrapper:focus-within) > .block-actions {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .block-drag-handle,
 .block-insert-btn {
   border: none;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -552,37 +552,38 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 /* ── Toggle block ───────────────────────────────────────────────────────── */
 
 .notion-toggle {
-  border: none;
   padding: 0;
   margin: 0;
 }
 
-.toggle-summary {
+.toggle-header {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.3rem;
   padding: 0.32rem 0.4rem;
-  cursor: pointer;
   border-radius: 4px;
-  list-style: none;
-  user-select: none;
 }
 
-.toggle-summary::-webkit-details-marker { display: none; }
-
-.toggle-summary::before {
-  content: '▶';
-  font-size: 0.6rem;
-  color: var(--ink-soft);
-  transition: transform 0.15s ease;
+.toggle-arrow-btn {
   flex-shrink: 0;
+  width: 1.2rem;
+  height: 1.2rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 0.6rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.notion-toggle[open] > .toggle-summary::before {
+.toggle-arrow-btn.is-open {
   transform: rotate(90deg);
 }
-
-.toggle-summary:hover { background: rgba(0, 0, 0, 0.03); }
 
 .toggle-title {
   flex: 1;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -519,23 +519,26 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   color: #6f3f37;
 }
 
-/* ── Heading via TextBlock (data-level) ──────────────────────────────────── */
+/* ── Heading via TextBlock / toggle title (data-level) ───────────────────── */
 
-.notion-text[data-level="1"] {
+.notion-text[data-level="1"],
+.toggle-title[data-level="1"] {
   font-family: "Fraunces", serif;
   font-size: 1.75rem;
   font-weight: 700;
   color: var(--ink);
 }
 
-.notion-text[data-level="2"] {
+.notion-text[data-level="2"],
+.toggle-title[data-level="2"] {
   font-family: "Fraunces", serif;
   font-size: 1.3rem;
   font-weight: 700;
   color: var(--ink);
 }
 
-.notion-text[data-level="3"] {
+.notion-text[data-level="3"],
+.toggle-title[data-level="3"] {
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--ink-soft);
@@ -594,6 +597,8 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   outline: none;
   cursor: text;
   min-height: calc(1.6em + 0.64rem);
+  display: flex;
+  align-items: center;
 }
 
 .toggle-children {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -593,6 +593,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   line-height: 1.5;
   outline: none;
   cursor: text;
+  min-height: calc(1.6em + 0.64rem);
 }
 
 .toggle-children {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -452,31 +452,6 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   padding: 0.66rem 0.74rem;
 }
 
-.notion-container {
-  border: none;
-  border-left: 2px solid var(--line);
-  border-radius: 0;
-  background: transparent;
-  padding: 0.4rem 0 0.4rem 1rem;
-}
-
-.container-title {
-  margin: 0 0 0.7rem;
-  font-size: 0.95rem;
-  letter-spacing: 0.02em;
-  color: #745f3c;
-  font-weight: 700;
-}
-
-.container-children {
-  display: grid;
-  gap: 0.34rem;
-  padding-left: 48px;
-}
-
-.container-children.is-grid {
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-}
 
 .notion-page {
   display: flex;
@@ -740,9 +715,8 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   border-radius: 6px;
 }
 
-/* Hover hint: text and container title indicate they're editable */
-.notion-text:not([contenteditable="true"]):hover,
-.container-title:not([contenteditable="true"]):hover {
+/* Hover hint: editable text blocks */
+.notion-text:not([contenteditable="true"]):hover {
   cursor: text;
   background: rgba(0, 0, 0, 0.03);
   border-radius: 4px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -587,10 +587,12 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 
 .toggle-title {
   flex: 1;
+  margin: 0;
   font-weight: 500;
   color: var(--ink);
   line-height: 1.5;
   outline: none;
+  cursor: text;
 }
 
 .toggle-children {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -643,12 +643,19 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   transition: background 0.1s;
 }
 
-.code-copy-btn:hover { background: rgba(0, 0, 0, 0.05); }
 
 .code-body {
   margin: 0;
-  padding: 0.75rem 1rem;
+  padding: 0;
   overflow-x: auto;
+  background: #282c34; /* atom-one-dark background */
+  border-radius: 0 0 6px 6px;
+}
+
+/* Override hljs default padding so our pre controls it */
+.code-body .hljs {
+  background: transparent;
+  padding: 0.75rem 1rem;
 }
 
 .code-content {
@@ -659,6 +666,28 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   white-space: pre;
   outline: none;
   min-height: 1.4em;
+  padding: 0.75rem 1rem;
+  color: #abb2bf; /* atom-one-dark default text */
+  cursor: text;
+}
+
+.code-content[contenteditable="true"] {
+  caret-color: #abb2bf;
+}
+
+.notion-code .code-header {
+  background: #21252b; /* slightly darker header */
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.code-language-select,
+.code-copy-btn {
+  color: #9da5b4;
+}
+
+.code-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #abb2bf;
 }
 
 /* ── Callout block ───────────────────────────────────────────────────────── */

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -7,7 +7,7 @@ export const BLOCK_PALETTE_ITEMS = [
   { type: 'image', label: '이미지', icon: '▣' },
   { type: 'toggle', label: '토글', icon: '▶' },
   { type: 'quote', label: '인용', icon: '"' },
-  { type: 'code', label: '코드', icon: '</>' },
+  { type: 'code', label: '코드', icon: '⟨⟩' },
   { type: 'callout', label: '콜아웃', icon: '💡' },
   { type: 'divider', label: '구분선', icon: '—' },
   { type: 'page', label: '페이지', icon: '⊔' },

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -6,6 +6,10 @@ export const BLOCK_PALETTE_ITEMS = [
   { type: 'text', label: '텍스트', icon: 'T' },
   { type: 'image', label: '이미지', icon: '▣' },
   { type: 'container', label: '컨테이너', icon: '⊞' },
+  { type: 'toggle', label: '토글', icon: '▶' },
+  { type: 'quote', label: '인용', icon: '"' },
+  { type: 'code', label: '코드', icon: '</>' },
+  { type: 'callout', label: '콜아웃', icon: '💡' },
   { type: 'divider', label: '구분선', icon: '—' },
   { type: 'page', label: '페이지', icon: '⊔' },
 ];

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -5,7 +5,6 @@ import { apiDeleteBlock } from "./api.js";
 export const BLOCK_PALETTE_ITEMS = [
   { type: 'text', label: '텍스트', icon: 'T' },
   { type: 'image', label: '이미지', icon: '▣' },
-  { type: 'container', label: '컨테이너', icon: '⊞' },
   { type: 'toggle', label: '토글', icon: '▶' },
   { type: 'quote', label: '인용', icon: '"' },
   { type: 'code', label: '코드', icon: '</>' },

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -283,6 +283,23 @@ function createImageBlock(block) {
   return node;
 }
 
+/**
+ * Create a "내용 추가" button for container-type blocks.
+ * Clicking opens the block palette and adds a child block via callbacks.addBlock.
+ */
+function createAddContentBtn(blockId) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'block-add-content-btn';
+  btn.textContent = '+ 내용 추가';
+  btn.addEventListener('mousedown', (e) => e.preventDefault());
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    openBlockPalette(btn, blockId, null, callbacks.addBlock);
+  });
+  return btn;
+}
+
 function createContainerBlock(block) {
   const template = document.getElementById('container-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
@@ -303,6 +320,8 @@ function createContainerBlock(block) {
   block.children.forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
+
+  node.appendChild(createAddContentBtn(block.id));
 
   return node;
 }
@@ -325,6 +344,8 @@ function createToggleBlock(block) {
   block.children.forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
+
+  node.appendChild(createAddContentBtn(block.id));
 
   return node;
 }
@@ -399,6 +420,8 @@ function createQuoteBlock(block) {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
 
+  node.appendChild(createAddContentBtn(block.id));
+
   return node;
 }
 
@@ -417,6 +440,8 @@ function createCalloutBlock(block) {
   (block.children || []).forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
+
+  node.querySelector('.callout-body').appendChild(createAddContentBtn(block.id));
 
   return node;
 }

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -311,22 +311,71 @@ function createContainerBlock(block) {
 function createToggleBlock(block) {
   const template = document.getElementById('toggle-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
+  const summaryEl = node.querySelector('.toggle-summary');
   const titleEl = node.querySelector('.toggle-title');
   const childrenRoot = node.querySelector('.toggle-children');
 
   if (block.is_open) node.open = true;
   titleEl.textContent = block.title || '';
-  enableContentEditable(titleEl, block.id, 'title', node);
 
-  // Persist open/closed state on toggle
-  node.addEventListener('toggle', () => {
-    apiPatchBlock(block.id, { is_open: node.open }).catch(console.error);
+  // ── Title editing ────────────────────────────────────────────────────────
+  // Clicking the title text enters edit mode; clicking anywhere else on the
+  // summary toggles open/closed. Without this split, <summary>'s default
+  // click handling would steal the event before the title could become editable.
+  let originalTitle = block.title || '';
+  let titleEscaped = false;
+
+  titleEl.addEventListener('click', (e) => {
+    if (titleEl.contentEditable === 'true') return;
+    e.preventDefault(); // prevent <details> toggle while editing
+    e.stopPropagation();
+    originalTitle = titleEl.textContent;
+    titleEscaped = false;
+    titleEl.contentEditable = 'true';
+    titleEl.focus();
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(titleEl);
+    range.collapse(false);
+    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+  });
+
+  titleEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); titleEl.blur(); }
+    if (e.key === 'Escape') {
+      titleEscaped = true;
+      titleEl.textContent = originalTitle;
+      titleEl.contentEditable = 'false';
+    }
+  });
+
+  titleEl.addEventListener('blur', () => {
+    if (titleEl.contentEditable !== 'true') return;
+    titleEl.contentEditable = 'false';
+    if (titleEscaped) { titleEscaped = false; return; }
+    const newTitle = titleEl.textContent.trim();
+    if (newTitle !== originalTitle) {
+      originalTitle = newTitle;
+      apiPatchBlock(block.id, { title: newTitle }).catch(console.error);
+    }
+  });
+
+  // ── Open/close toggle (summary click outside title) ───────────────────────
+  summaryEl.addEventListener('click', (e) => {
+    if (titleEl.contentEditable === 'true') {
+      e.preventDefault(); // don't close while typing
+      return;
+    }
+    if (titleEl.contains(e.target)) return; // title click handled above
+    // Let default <details> toggle happen, then persist
+    setTimeout(() => {
+      apiPatchBlock(block.id, { is_open: node.open }).catch(console.error);
+    }, 0);
   });
 
   block.children.forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
-
 
   return node;
 }

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -406,11 +406,16 @@ function createCalloutBlock(block) {
   const node = template.content.firstElementChild.cloneNode(true);
   const emojiEl = node.querySelector('.callout-emoji');
   const textEl = node.querySelector('.callout-text');
+  const childrenRoot = node.querySelector('.callout-children');
 
   node.dataset.color = block.color || 'yellow';
   emojiEl.textContent = block.emoji || '💡';
   textEl.textContent = block.text || '';
   enableContentEditable(textEl, block.id, 'text', node);
+
+  (block.children || []).forEach((child) => {
+    childrenRoot.appendChild(renderBlock(child, block.id));
+  });
 
   return node;
 }

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -348,11 +348,11 @@ function createToggleBlock(block) {
 
   applyOpen(isOpen);
 
-  // Render formatted HTML when available, fall back to plain text
-  if (block.formatted_title) {
-    titleEl.innerHTML = sanitizeHtml(block.formatted_title);
+  // Render: identical to text block (formatted_text / text / level)
+  if (block.formatted_text) {
+    titleEl.innerHTML = sanitizeHtml(block.formatted_text);
   } else {
-    titleEl.textContent = block.title || '';
+    titleEl.textContent = block.text || '';
   }
   if (block.level) titleEl.dataset.level = String(block.level);
 
@@ -363,12 +363,9 @@ function createToggleBlock(block) {
     apiPatchBlock(block.id, { is_open: isOpen }).catch(console.error);
   });
 
-  // ── Title editing: same interface as text block ──────────────────────────
+  // ── Title editing: identical interface to text block ─────────────────────
   makeTextEditable(titleEl, block.id, {
-    textField: 'title',
-    htmlField: 'formatted_title',
     enableSlash: false,
-    enableHeading: true,
     onEnter: () => titleEl.blur(),
   });
 

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -283,23 +283,6 @@ function createImageBlock(block) {
   return node;
 }
 
-/**
- * Create a "내용 추가" button for container-type blocks.
- * Clicking opens the block palette and adds a child block via callbacks.addBlock.
- */
-function createAddContentBtn(blockId) {
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'block-add-content-btn';
-  btn.textContent = '+ 내용 추가';
-  btn.addEventListener('mousedown', (e) => e.preventDefault());
-  btn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    openBlockPalette(btn, blockId, null, callbacks.addBlock);
-  });
-  return btn;
-}
-
 function createContainerBlock(block) {
   const template = document.getElementById('container-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
@@ -321,7 +304,6 @@ function createContainerBlock(block) {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
 
-  node.appendChild(createAddContentBtn(block.id));
 
   return node;
 }
@@ -345,7 +327,6 @@ function createToggleBlock(block) {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
 
-  node.appendChild(createAddContentBtn(block.id));
 
   return node;
 }
@@ -420,7 +401,6 @@ function createQuoteBlock(block) {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
 
-  node.appendChild(createAddContentBtn(block.id));
 
   return node;
 }
@@ -440,8 +420,6 @@ function createCalloutBlock(block) {
   (block.children || []).forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));
   });
-
-  node.querySelector('.callout-body').appendChild(createAddContentBtn(block.id));
 
   return node;
 }

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -60,6 +60,10 @@ function makeTextEditable(node, blockId, {
   let currentLevel = node.dataset.level ? Number(node.dataset.level) : null;
   let escaped = false;
 
+  // is-editing은 가장 가까운 .notion-block에 적용 (toggle-title처럼 node 자체가
+  // .notion-block이 아닌 경우에도 편집 상태 스타일이 일관되게 동작하도록)
+  const editingTarget = node.closest('.notion-block') ?? node;
+
   // ── Click: activate editing (but let link clicks open the URL) ──────────
   node.addEventListener('click', (e) => {
     if (node.contentEditable !== 'true') {
@@ -75,7 +79,7 @@ function makeTextEditable(node, blockId, {
     originalText = node.textContent;
     escaped = false;
     node.contentEditable = 'true';
-    node.classList.add('is-editing');
+    editingTarget.classList.add('is-editing');
     setEditingNode(node);
     node.focus();
     const sel = window.getSelection();
@@ -90,7 +94,7 @@ function makeTextEditable(node, blockId, {
     if (isInsideToolbar(e.relatedTarget)) return;
     if (node.contentEditable !== 'true') return;
     node.contentEditable = 'false';
-    node.classList.remove('is-editing');
+    editingTarget.classList.remove('is-editing');
     clearEditingNode();
 
     if (escaped) { escaped = false; return; }
@@ -145,7 +149,7 @@ function makeTextEditable(node, blockId, {
       escaped = true;
       node.innerHTML = originalHtml;
       node.contentEditable = 'false';
-      node.classList.remove('is-editing');
+      editingTarget.classList.remove('is-editing');
       clearEditingNode();
       return;
     }
@@ -458,6 +462,18 @@ function createCodeBlock(block) {
 
   applyHighlight(plainCode);
 
+  // ── IME 조합 상태 추적 (한국어 등 조합형 입력 중 innerHTML 교체 방지) ────────
+  let isComposing = false;
+  codeEl.addEventListener('compositionstart', () => { isComposing = true; });
+  codeEl.addEventListener('compositionend', () => {
+    isComposing = false;
+    // 조합 완료 후 한 번 하이라이팅 적용
+    const offset = getCaretOffset(codeEl);
+    plainCode = codeEl.textContent;
+    applyHighlight(plainCode);
+    setCaretOffset(codeEl, offset);
+  });
+
   // ── Click → activate editing ─────────────────────────────────────────────
   codeEl.addEventListener('click', () => {
     if (codeEl.contentEditable === 'true') return;
@@ -474,6 +490,11 @@ function createCodeBlock(block) {
 
   // ── Input → live highlight with cursor preservation ──────────────────────
   codeEl.addEventListener('input', () => {
+    if (isComposing) {
+      // 조합 중에는 plainCode만 갱신하고 innerHTML 교체는 compositionend에서 수행
+      plainCode = codeEl.textContent;
+      return;
+    }
     const offset = getCaretOffset(codeEl);
     plainCode = codeEl.textContent;
     applyHighlight(plainCode);

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -325,7 +325,13 @@ function createToggleBlock(block) {
   }
 
   applyOpen(isOpen);
-  titleEl.textContent = block.title || '';
+
+  // Render formatted HTML when available, fall back to plain text
+  if (block.formatted_title) {
+    titleEl.innerHTML = sanitizeHtml(block.formatted_title);
+  } else {
+    titleEl.textContent = block.title || '';
+  }
 
   // ── Arrow button: only way to open/close ────────────────────────────────
   arrowBtn.addEventListener('click', (e) => {
@@ -334,8 +340,71 @@ function createToggleBlock(block) {
     apiPatchBlock(block.id, { is_open: isOpen }).catch(console.error);
   });
 
-  // ── Title editing ────────────────────────────────────────────────────────
-  enableContentEditable(titleEl, block.id, 'title', node);
+  // ── Title editing (mirrors text block: formatting toolbar + shortcuts) ───
+  let originalHtml = titleEl.innerHTML;
+  let originalText = titleEl.textContent;
+  let titleEscaped = false;
+
+  titleEl.addEventListener('click', (e) => {
+    if (e.target === arrowBtn) return;
+    if (titleEl.contentEditable === 'true') return;
+    originalHtml = titleEl.innerHTML;
+    originalText = titleEl.textContent;
+    titleEscaped = false;
+    titleEl.contentEditable = 'true';
+    titleEl.classList.add('is-editing');
+    setEditingNode(titleEl);
+    titleEl.focus();
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(titleEl);
+    range.collapse(false);
+    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+  });
+
+  titleEl.addEventListener('blur', (e) => {
+    if (isInsideToolbar(e.relatedTarget)) return;
+    if (titleEl.contentEditable !== 'true') return;
+    titleEl.contentEditable = 'false';
+    titleEl.classList.remove('is-editing');
+    clearEditingNode();
+    if (titleEscaped) { titleEscaped = false; return; }
+    const newText = titleEl.textContent.trim();
+    const newHtml = sanitizeHtml(titleEl.innerHTML);
+    const patch = {};
+    if (newText !== originalText) patch.title = newText;
+    if (newHtml !== sanitizeHtml(originalHtml)) patch.formatted_title = newHtml;
+    if (Object.keys(patch).length) {
+      originalText = newText;
+      originalHtml = titleEl.innerHTML;
+      apiPatchBlock(block.id, patch).catch(console.error);
+    }
+  });
+
+  titleEl.addEventListener('keydown', (e) => {
+    if (titleEl.contentEditable !== 'true') return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      titleEscaped = true;
+      titleEl.innerHTML = originalHtml;
+      titleEl.contentEditable = 'false';
+      titleEl.classList.remove('is-editing');
+      clearEditingNode();
+      return;
+    }
+    // Enter: stop editing (title is single-line)
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      titleEl.blur();
+      return;
+    }
+    // Formatting shortcuts
+    if (e.ctrlKey || e.metaKey) {
+      if (e.key === 'b') { e.preventDefault(); document.execCommand('bold', false); }
+      else if (e.key === 'i') { e.preventDefault(); document.execCommand('italic', false); }
+      else if (e.key === 'u') { e.preventDefault(); document.execCommand('underline', false); }
+    }
+  });
 
   block.children.forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -1,6 +1,6 @@
 // ── Block renderers ──────────────────────────────────────────────────────────
 
-import { apiPatchBlock, apiUploadImage } from "./api.js";
+import { apiPatchBlock, apiUploadImage, apiChangeBlockType } from "./api.js";
 import { enableContentEditable } from "./editor.js";
 import { openBlockPalette } from "./blockPalette.js";
 import { wrapBlock } from "./blockWrapper.js";
@@ -44,6 +44,7 @@ export const callbacks = {
  * @param {Function} [opts.onEnter]                    - Called on Enter instead of default (add block after)
  * @param {boolean}  [opts.enableSlash=true]           - Enable '/' block palette trigger
  * @param {boolean}  [opts.enableHeading=true]         - Enable '# ' heading promotion
+ * @param {boolean}  [opts.enableTypeShortcuts=true]   - Enable '> ' → toggle conversion
  */
 function makeTextEditable(node, blockId, {
   textField = 'text',
@@ -52,6 +53,7 @@ function makeTextEditable(node, blockId, {
   onEnter = null,
   enableSlash = true,
   enableHeading = true,
+  enableTypeShortcuts = true,
 } = {}) {
   let originalHtml = node.innerHTML;
   let originalText = node.textContent;
@@ -179,20 +181,37 @@ function makeTextEditable(node, blockId, {
       return;
     }
 
-    if (enableHeading && e.key === ' ') {
+    if (e.key === ' ') {
       const raw = node.textContent;
-      const exactPrefix = raw.match(/^(#{1,3})$/);
-      if (!exactPrefix) return;
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const newLevel = exactPrefix[1].length;
-      node.textContent = '';
-      node.dataset.level = String(newLevel);
-      const patch = { level: newLevel, [textField]: '', [htmlField]: '' };
-      currentLevel = newLevel;
-      originalText = '';
-      originalHtml = '';
-      apiPatchBlock(blockId, patch).catch(console.error);
+
+      // '> ' → convert block to toggle
+      if (enableTypeShortcuts && raw === '>') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        node.contentEditable = 'false';
+        node.classList.remove('is-editing');
+        clearEditingNode();
+        apiChangeBlockType(blockId, 'toggle')
+          .then(() => callbacks.reloadDocument?.())
+          .catch(console.error);
+        return;
+      }
+
+      // '# ' / '## ' / '### ' → heading promotion
+      if (enableHeading) {
+        const exactPrefix = raw.match(/^(#{1,3})$/);
+        if (!exactPrefix) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const newLevel = exactPrefix[1].length;
+        node.textContent = '';
+        node.dataset.level = String(newLevel);
+        const patch = { [levelField]: newLevel, [textField]: '', [htmlField]: '' };
+        currentLevel = newLevel;
+        originalText = '';
+        originalHtml = '';
+        apiPatchBlock(blockId, patch).catch(console.error);
+      }
     }
 
     if (e.ctrlKey || e.metaKey) {
@@ -366,6 +385,7 @@ function createToggleBlock(block) {
   // ── Title editing: identical interface to text block ─────────────────────
   makeTextEditable(titleEl, block.id, {
     enableSlash: false,
+    enableTypeShortcuts: false,
     onEnter: () => {
       titleEl.blur();
       // Open toggle if closed, then focus first child block

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -346,6 +346,7 @@ function createToggleBlock(block) {
   let titleEscaped = false;
 
   titleEl.addEventListener('click', (e) => {
+    e.stopPropagation();
     if (e.target === arrowBtn) return;
     if (titleEl.contentEditable === 'true') return;
     originalHtml = titleEl.innerHTML;

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -30,29 +30,36 @@ export const callbacks = {
   onTitleChanged: null,     // (documentId, newTitle) => void — propagate title change to page blocks
 };
 
-// ── Individual block creators ─────────────────────────────────────────────────
+// ── Shared text-editing behaviour ────────────────────────────────────────────
 
-function createTextBlock(block) {
-  const template = document.getElementById('text-block-template');
-  const node = template.content.firstElementChild.cloneNode(true);
-
-  // Render formatted HTML when available, fall back to plain text
-  if (block.formatted_text) {
-    node.innerHTML = sanitizeHtml(block.formatted_text);
-  } else {
-    node.textContent = block.text;
-  }
-
-  if (block.level) node.dataset.level = String(block.level);
-
+/**
+ * Attach text-block–style editing behaviour to any element.
+ *
+ * @param {HTMLElement} node      - Element to make editable
+ * @param {string}      blockId   - Block ID for PATCH calls
+ * @param {object}      opts
+ * @param {string}   [opts.textField='text']           - Plain-text field name
+ * @param {string}   [opts.htmlField='formatted_text'] - Rich-HTML field name
+ * @param {string}   [opts.levelField='level']         - Heading level field name
+ * @param {Function} [opts.onEnter]                    - Called on Enter instead of default (add block after)
+ * @param {boolean}  [opts.enableSlash=true]           - Enable '/' block palette trigger
+ * @param {boolean}  [opts.enableHeading=true]         - Enable '# ' heading promotion
+ */
+function makeTextEditable(node, blockId, {
+  textField = 'text',
+  htmlField = 'formatted_text',
+  levelField = 'level',
+  onEnter = null,
+  enableSlash = true,
+  enableHeading = true,
+} = {}) {
   let originalHtml = node.innerHTML;
   let originalText = node.textContent;
-  let currentLevel = block.level ?? null;
+  let currentLevel = node.dataset.level ? Number(node.dataset.level) : null;
   let escaped = false;
 
   // ── Click: activate editing (but let link clicks open the URL) ──────────
   node.addEventListener('click', (e) => {
-    // When not editing, a click on a link should navigate, not start editing
     if (node.contentEditable !== 'true') {
       const anchor = e.target.closest('a[href]');
       if (anchor) {
@@ -78,7 +85,6 @@ function createTextBlock(block) {
 
   // ── Blur: save and deactivate ────────────────────────────────────────────
   node.addEventListener('blur', (e) => {
-    // Focus moved into the formatting toolbar (e.g. link input) — stay in editing mode
     if (isInsideToolbar(e.relatedTarget)) return;
     if (node.contentEditable !== 'true') return;
     node.contentEditable = 'false';
@@ -87,43 +93,42 @@ function createTextBlock(block) {
 
     if (escaped) { escaped = false; return; }
 
-    // Handle pasted "# Title" heading promotion form
-    const raw = node.textContent;
-    const headingMatch = raw.match(/^(#{1,3})\s+(\S.*)?$/);
-    if (headingMatch) {
-      const newLevel = headingMatch[1].length;
-      const newText = (headingMatch[2] ?? '').trimEnd();
-      node.textContent = newText;
-      node.dataset.level = String(newLevel);
-      const patch = {};
-      if (newLevel !== currentLevel) patch.level = newLevel;
-      if (newText !== originalText) patch.text = newText;
-      patch.formatted_text = '';
-      currentLevel = newLevel;
-      originalText = newText;
-      originalHtml = node.innerHTML;
-      apiPatchBlock(block.id, patch).catch(console.error);
-      return;
+    if (enableHeading) {
+      const raw = node.textContent;
+      const headingMatch = raw.match(/^(#{1,3})\s+(\S.*)?$/);
+      if (headingMatch) {
+        const newLevel = headingMatch[1].length;
+        const newText = (headingMatch[2] ?? '').trimEnd();
+        node.textContent = newText;
+        node.dataset.level = String(newLevel);
+        const patch = {};
+        if (newLevel !== currentLevel) patch[levelField] = newLevel;
+        if (newText !== originalText) patch[textField] = newText;
+        patch[htmlField] = '';
+        currentLevel = newLevel;
+        originalText = newText;
+        originalHtml = node.innerHTML;
+        apiPatchBlock(blockId, patch).catch(console.error);
+        return;
+      }
     }
 
-    // Normal save: patch both text and formatted_text when changed
     const newText = node.textContent.trim();
     const newHtml = sanitizeHtml(node.innerHTML);
     const patch = {};
-    if (newText !== originalText) patch.text = newText;
-    if (newHtml !== sanitizeHtml(originalHtml)) patch.formatted_text = newHtml;
+    if (newText !== originalText) patch[textField] = newText;
+    if (newHtml !== sanitizeHtml(originalHtml)) patch[htmlField] = newHtml;
     if (Object.keys(patch).length) {
       originalText = newText;
       originalHtml = node.innerHTML;
-      apiPatchBlock(block.id, patch).catch(console.error);
+      apiPatchBlock(blockId, patch).catch(console.error);
     }
   });
 
   // ── Keydown: formatting shortcuts + heading promotion + slash command ────
   // Capture phase: intercepts Enter/Space for heading promotion before bubble handlers
   node.addEventListener('keydown', (e) => {
-    // Slash command: open palette when '/' is typed in an empty block
-    if (e.key === '/' && node.contentEditable === 'true' && !node.textContent.trim()) {
+    if (enableSlash && e.key === '/' && node.contentEditable === 'true' && !node.textContent.trim()) {
       e.preventDefault();
       node.blur();
       const slashParentId = node.closest('.block-wrapper')?.dataset.parentBlockId || null;
@@ -133,7 +138,6 @@ function createTextBlock(block) {
 
     if (node.contentEditable !== 'true') return;
 
-    // Escape: cancel editing and restore original content
     if (e.key === 'Escape') {
       e.preventDefault();
       escaped = true;
@@ -144,36 +148,38 @@ function createTextBlock(block) {
       return;
     }
 
-    // Enter (no shift): either new block or heading promotion
     if (e.key === 'Enter' && !e.shiftKey) {
-      const raw = node.textContent;
-      const exactPrefix = raw.match(/^(#{1,3})$/);
-      if (exactPrefix) {
-        // Heading promotion
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        const newLevel = exactPrefix[1].length;
-        node.textContent = '';
-        node.dataset.level = String(newLevel);
-        const patch = { level: newLevel, text: '', formatted_text: '' };
-        currentLevel = newLevel;
-        originalText = '';
-        originalHtml = '';
-        apiPatchBlock(block.id, patch).catch(console.error);
-        return;
+      if (enableHeading) {
+        const raw = node.textContent;
+        const exactPrefix = raw.match(/^(#{1,3})$/);
+        if (exactPrefix) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          const newLevel = exactPrefix[1].length;
+          node.textContent = '';
+          node.dataset.level = String(newLevel);
+          const patch = { [levelField]: newLevel, [textField]: '', [htmlField]: '' };
+          currentLevel = newLevel;
+          originalText = '';
+          originalHtml = '';
+          apiPatchBlock(blockId, patch).catch(console.error);
+          return;
+        }
       }
       e.preventDefault();
-      node.blur();
-      const parentBlockId =
-        node.closest('.block-wrapper')?.dataset.parentBlockId || null;
-      if (callbacks.addBlockAfter) {
-        callbacks.addBlockAfter('text', block.id, parentBlockId).catch(console.error);
+      if (onEnter) {
+        onEnter();
+      } else {
+        node.blur();
+        const parentBlockId = node.closest('.block-wrapper')?.dataset.parentBlockId || null;
+        if (callbacks.addBlockAfter) {
+          callbacks.addBlockAfter('text', blockId, parentBlockId).catch(console.error);
+        }
       }
       return;
     }
 
-    // Space: heading promotion when content is exactly #, ##, or ###
-    if (e.key === ' ') {
+    if (enableHeading && e.key === ' ') {
       const raw = node.textContent;
       const exactPrefix = raw.match(/^(#{1,3})$/);
       if (!exactPrefix) return;
@@ -182,20 +188,36 @@ function createTextBlock(block) {
       const newLevel = exactPrefix[1].length;
       node.textContent = '';
       node.dataset.level = String(newLevel);
-      const patch = { level: newLevel, text: '', formatted_text: '' };
+      const patch = { level: newLevel, [textField]: '', [htmlField]: '' };
       currentLevel = newLevel;
       originalText = '';
       originalHtml = '';
-      apiPatchBlock(block.id, patch).catch(console.error);
+      apiPatchBlock(blockId, patch).catch(console.error);
     }
 
-    // Formatting keyboard shortcuts (Ctrl/Cmd + B / I / U)
     if (e.ctrlKey || e.metaKey) {
       if (e.key === 'b') { e.preventDefault(); document.execCommand('bold', false); }
       else if (e.key === 'i') { e.preventDefault(); document.execCommand('italic', false); }
       else if (e.key === 'u') { e.preventDefault(); document.execCommand('underline', false); }
     }
   }, { capture: true });
+}
+
+// ── Individual block creators ─────────────────────────────────────────────────
+
+function createTextBlock(block) {
+  const template = document.getElementById('text-block-template');
+  const node = template.content.firstElementChild.cloneNode(true);
+
+  if (block.formatted_text) {
+    node.innerHTML = sanitizeHtml(block.formatted_text);
+  } else {
+    node.textContent = block.text;
+  }
+
+  if (block.level) node.dataset.level = String(block.level);
+
+  makeTextEditable(node, block.id);
 
   return node;
 }
@@ -332,6 +354,7 @@ function createToggleBlock(block) {
   } else {
     titleEl.textContent = block.title || '';
   }
+  if (block.level) titleEl.dataset.level = String(block.level);
 
   // ── Arrow button: only way to open/close ────────────────────────────────
   arrowBtn.addEventListener('click', (e) => {
@@ -340,71 +363,13 @@ function createToggleBlock(block) {
     apiPatchBlock(block.id, { is_open: isOpen }).catch(console.error);
   });
 
-  // ── Title editing (mirrors text block: formatting toolbar + shortcuts) ───
-  let originalHtml = titleEl.innerHTML;
-  let originalText = titleEl.textContent;
-  let titleEscaped = false;
-
-  titleEl.addEventListener('click', (e) => {
-    e.stopPropagation();
-    if (e.target === arrowBtn) return;
-    if (titleEl.contentEditable === 'true') return;
-    originalHtml = titleEl.innerHTML;
-    originalText = titleEl.textContent;
-    titleEscaped = false;
-    titleEl.contentEditable = 'true';
-    titleEl.classList.add('is-editing');
-    setEditingNode(titleEl);
-    titleEl.focus();
-    const sel = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(titleEl);
-    range.collapse(false);
-    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
-  });
-
-  titleEl.addEventListener('blur', (e) => {
-    if (isInsideToolbar(e.relatedTarget)) return;
-    if (titleEl.contentEditable !== 'true') return;
-    titleEl.contentEditable = 'false';
-    titleEl.classList.remove('is-editing');
-    clearEditingNode();
-    if (titleEscaped) { titleEscaped = false; return; }
-    const newText = titleEl.textContent.trim();
-    const newHtml = sanitizeHtml(titleEl.innerHTML);
-    const patch = {};
-    if (newText !== originalText) patch.title = newText;
-    if (newHtml !== sanitizeHtml(originalHtml)) patch.formatted_title = newHtml;
-    if (Object.keys(patch).length) {
-      originalText = newText;
-      originalHtml = titleEl.innerHTML;
-      apiPatchBlock(block.id, patch).catch(console.error);
-    }
-  });
-
-  titleEl.addEventListener('keydown', (e) => {
-    if (titleEl.contentEditable !== 'true') return;
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      titleEscaped = true;
-      titleEl.innerHTML = originalHtml;
-      titleEl.contentEditable = 'false';
-      titleEl.classList.remove('is-editing');
-      clearEditingNode();
-      return;
-    }
-    // Enter: stop editing (title is single-line)
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      titleEl.blur();
-      return;
-    }
-    // Formatting shortcuts
-    if (e.ctrlKey || e.metaKey) {
-      if (e.key === 'b') { e.preventDefault(); document.execCommand('bold', false); }
-      else if (e.key === 'i') { e.preventDefault(); document.execCommand('italic', false); }
-      else if (e.key === 'u') { e.preventDefault(); document.execCommand('underline', false); }
-    }
+  // ── Title editing: same interface as text block ──────────────────────────
+  makeTextEditable(titleEl, block.id, {
+    textField: 'title',
+    htmlField: 'formatted_title',
+    enableSlash: false,
+    enableHeading: true,
+    onEnter: () => titleEl.blur(),
   });
 
   block.children.forEach((child) => {

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -366,7 +366,16 @@ function createToggleBlock(block) {
   // ── Title editing: identical interface to text block ─────────────────────
   makeTextEditable(titleEl, block.id, {
     enableSlash: false,
-    onEnter: () => titleEl.blur(),
+    onEnter: () => {
+      titleEl.blur();
+      // Open toggle if closed, then focus first child block
+      if (!isOpen) {
+        applyOpen(true);
+        apiPatchBlock(block.id, { is_open: true }).catch(console.error);
+      }
+      const firstChild = childrenRoot.querySelector(':scope > .block-wrapper');
+      if (firstChild) focusBlock(firstChild);
+    },
   });
 
   block.children.forEach((child) => {

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -385,6 +385,41 @@ const CODE_LANGUAGES = [
   'json', 'sql', 'java', 'go', 'rust', 'c', 'cpp',
 ];
 
+// ── Caret offset helpers for contenteditable (plain-text character index) ────
+
+function getCaretOffset(el) {
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount) return 0;
+  const range = sel.getRangeAt(0).cloneRange();
+  range.selectNodeContents(el);
+  range.setEnd(sel.getRangeAt(0).endContainer, sel.getRangeAt(0).endOffset);
+  return range.toString().length;
+}
+
+function setCaretOffset(el, offset) {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let remaining = offset;
+  let node;
+  while ((node = walker.nextNode())) {
+    if (remaining <= node.textContent.length) {
+      const range = document.createRange();
+      range.setStart(node, remaining);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      return;
+    }
+    remaining -= node.textContent.length;
+  }
+  // Fallback: place cursor at end
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  range.collapse(false);
+  window.getSelection()?.removeAllRanges();
+  window.getSelection()?.addRange(range);
+}
+
 function createCodeBlock(block) {
   const template = document.getElementById('code-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
@@ -392,43 +427,87 @@ function createCodeBlock(block) {
   const codeEl = node.querySelector('.code-content');
   const copyBtn = node.querySelector('.code-copy-btn');
 
+  let currentLanguage = block.language || 'plain';
+  let plainCode = block.code || '';
+  let originalCode = plainCode;
+
   CODE_LANGUAGES.forEach((lang) => {
     const opt = document.createElement('option');
     opt.value = lang;
     opt.textContent = lang;
-    if (lang === (block.language || 'plain')) opt.selected = true;
+    if (lang === currentLanguage) opt.selected = true;
     select.appendChild(opt);
   });
 
-  codeEl.textContent = block.code || '';
+  // ── Syntax highlighting ──────────────────────────────────────────────────
+  function applyHighlight(code) {
+    if (!window.hljs || currentLanguage === 'plain') {
+      codeEl.textContent = code;
+      return;
+    }
+    try {
+      const result = window.hljs.highlight(code, {
+        language: currentLanguage,
+        ignoreIllegals: true,
+      });
+      codeEl.innerHTML = result.value;
+    } catch {
+      codeEl.textContent = code;
+    }
+  }
 
-  let originalCode = block.code || '';
+  applyHighlight(plainCode);
 
-  codeEl.addEventListener('focus', () => { node.classList.add('is-editing'); });
+  // ── Click → activate editing ─────────────────────────────────────────────
+  codeEl.addEventListener('click', () => {
+    if (codeEl.contentEditable === 'true') return;
+    codeEl.contentEditable = 'true';
+    node.classList.add('is-editing');
+    codeEl.focus();
+    // Place cursor at end
+    const range = document.createRange();
+    range.selectNodeContents(codeEl);
+    range.collapse(false);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+  });
+
+  // ── Input → live highlight with cursor preservation ──────────────────────
+  codeEl.addEventListener('input', () => {
+    const offset = getCaretOffset(codeEl);
+    plainCode = codeEl.textContent;
+    applyHighlight(plainCode);
+    setCaretOffset(codeEl, offset);
+  });
+
+  // ── Blur → save ──────────────────────────────────────────────────────────
   codeEl.addEventListener('blur', () => {
+    if (codeEl.contentEditable !== 'true') return;
+    codeEl.contentEditable = 'false';
     node.classList.remove('is-editing');
-    const newCode = codeEl.textContent;
-    if (newCode !== originalCode) {
-      originalCode = newCode;
-      apiPatchBlock(block.id, { code: newCode }).catch(console.error);
+    if (plainCode !== originalCode) {
+      originalCode = plainCode;
+      apiPatchBlock(block.id, { code: plainCode }).catch(console.error);
     }
   });
+
   codeEl.addEventListener('keydown', (e) => {
-    // Tab → insert two spaces instead of moving focus
     if (e.key === 'Tab') {
       e.preventDefault();
       document.execCommand('insertText', false, '  ');
     }
-    // Escape → blur
     if (e.key === 'Escape') codeEl.blur();
   });
 
+  // ── Language change → re-highlight ──────────────────────────────────────
   select.addEventListener('change', () => {
-    apiPatchBlock(block.id, { language: select.value }).catch(console.error);
+    currentLanguage = select.value;
+    apiPatchBlock(block.id, { language: currentLanguage }).catch(console.error);
+    applyHighlight(plainCode);
   });
 
   copyBtn.addEventListener('click', () => {
-    navigator.clipboard.writeText(codeEl.textContent).then(() => {
+    navigator.clipboard.writeText(plainCode).then(() => {
       copyBtn.textContent = '복사됨';
       setTimeout(() => { copyBtn.textContent = '복사'; }, 1500);
     }).catch(console.error);

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -126,7 +126,8 @@ function createTextBlock(block) {
     if (e.key === '/' && node.contentEditable === 'true' && !node.textContent.trim()) {
       e.preventDefault();
       node.blur();
-      openBlockPalette(node, null, null, callbacks.addBlock);
+      const slashParentId = node.closest('.block-wrapper')?.dataset.parentBlockId || null;
+      openBlockPalette(node, slashParentId, null, callbacks.addBlock);
       return;
     }
 

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -306,6 +306,115 @@ function createContainerBlock(block) {
   return node;
 }
 
+function createToggleBlock(block) {
+  const template = document.getElementById('toggle-block-template');
+  const node = template.content.firstElementChild.cloneNode(true);
+  const titleEl = node.querySelector('.toggle-title');
+  const childrenRoot = node.querySelector('.toggle-children');
+
+  if (block.is_open) node.open = true;
+  titleEl.textContent = block.title || '';
+  enableContentEditable(titleEl, block.id, 'title', node);
+
+  // Persist open/closed state on toggle
+  node.addEventListener('toggle', () => {
+    apiPatchBlock(block.id, { is_open: node.open }).catch(console.error);
+  });
+
+  block.children.forEach((child) => {
+    childrenRoot.appendChild(renderBlock(child, block.id));
+  });
+
+  return node;
+}
+
+const CODE_LANGUAGES = [
+  'plain', 'javascript', 'typescript', 'python', 'bash', 'html', 'css',
+  'json', 'sql', 'java', 'go', 'rust', 'c', 'cpp',
+];
+
+function createCodeBlock(block) {
+  const template = document.getElementById('code-block-template');
+  const node = template.content.firstElementChild.cloneNode(true);
+  const select = node.querySelector('.code-language-select');
+  const codeEl = node.querySelector('.code-content');
+  const copyBtn = node.querySelector('.code-copy-btn');
+
+  CODE_LANGUAGES.forEach((lang) => {
+    const opt = document.createElement('option');
+    opt.value = lang;
+    opt.textContent = lang;
+    if (lang === (block.language || 'plain')) opt.selected = true;
+    select.appendChild(opt);
+  });
+
+  codeEl.textContent = block.code || '';
+
+  let originalCode = block.code || '';
+
+  codeEl.addEventListener('focus', () => { node.classList.add('is-editing'); });
+  codeEl.addEventListener('blur', () => {
+    node.classList.remove('is-editing');
+    const newCode = codeEl.textContent;
+    if (newCode !== originalCode) {
+      originalCode = newCode;
+      apiPatchBlock(block.id, { code: newCode }).catch(console.error);
+    }
+  });
+  codeEl.addEventListener('keydown', (e) => {
+    // Tab → insert two spaces instead of moving focus
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      document.execCommand('insertText', false, '  ');
+    }
+    // Escape → blur
+    if (e.key === 'Escape') codeEl.blur();
+  });
+
+  select.addEventListener('change', () => {
+    apiPatchBlock(block.id, { language: select.value }).catch(console.error);
+  });
+
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(codeEl.textContent).then(() => {
+      copyBtn.textContent = '복사됨';
+      setTimeout(() => { copyBtn.textContent = '복사'; }, 1500);
+    }).catch(console.error);
+  });
+
+  return node;
+}
+
+function createQuoteBlock(block) {
+  const template = document.getElementById('quote-block-template');
+  const node = template.content.firstElementChild.cloneNode(true);
+  const textEl = node.querySelector('.quote-text');
+  const childrenRoot = node.querySelector('.quote-children');
+
+  textEl.textContent = block.text || '';
+  enableContentEditable(textEl, block.id, 'text', node);
+
+  block.children.forEach((child) => {
+    childrenRoot.appendChild(renderBlock(child, block.id));
+  });
+
+  return node;
+}
+
+function createCalloutBlock(block) {
+  const template = document.getElementById('callout-block-template');
+  const node = template.content.firstElementChild.cloneNode(true);
+  const emojiEl = node.querySelector('.callout-emoji');
+  const textEl = node.querySelector('.callout-text');
+
+  node.dataset.color = block.color || 'yellow';
+  emojiEl.textContent = block.emoji || '💡';
+  textEl.textContent = block.text || '';
+  enableContentEditable(textEl, block.id, 'text', node);
+
+  return node;
+}
+
 function createDividerBlock() {
   const template = document.getElementById('divider-block-template');
   return template.content.firstElementChild.cloneNode(true);
@@ -477,6 +586,18 @@ export function renderBlock(block, parentBlockId = null) {
     case 'container':
       blockEl = createContainerBlock(block);
       break;
+    case 'toggle':
+      blockEl = createToggleBlock(block);
+      break;
+    case 'quote':
+      blockEl = createQuoteBlock(block);
+      break;
+    case 'code':
+      blockEl = createCodeBlock(block);
+      break;
+    case 'callout':
+      blockEl = createCalloutBlock(block);
+      break;
     case 'divider':
       blockEl = createDividerBlock();
       break;
@@ -504,7 +625,7 @@ export function focusBlock(wrapperEl) {
   if (!blockEl) return;
   const target = blockEl.classList.contains('notion-text')
     ? blockEl
-    : (blockEl.querySelector('.notion-caption, .container-title') ?? blockEl);
+    : (blockEl.querySelector('.notion-caption, .container-title, .toggle-title, .quote-text, .code-content, .callout-text') ?? blockEl);
   target.click();
 }
 

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -311,67 +311,31 @@ function createContainerBlock(block) {
 function createToggleBlock(block) {
   const template = document.getElementById('toggle-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
-  const summaryEl = node.querySelector('.toggle-summary');
+  const arrowBtn = node.querySelector('.toggle-arrow-btn');
   const titleEl = node.querySelector('.toggle-title');
   const childrenRoot = node.querySelector('.toggle-children');
 
-  if (block.is_open) node.open = true;
+  let isOpen = !!block.is_open;
+
+  function applyOpen(open) {
+    isOpen = open;
+    childrenRoot.hidden = !open;
+    arrowBtn.setAttribute('aria-expanded', String(open));
+    arrowBtn.classList.toggle('is-open', open);
+  }
+
+  applyOpen(isOpen);
   titleEl.textContent = block.title || '';
 
-  // ── Title editing ────────────────────────────────────────────────────────
-  // Clicking the title text enters edit mode; clicking anywhere else on the
-  // summary toggles open/closed. Without this split, <summary>'s default
-  // click handling would steal the event before the title could become editable.
-  let originalTitle = block.title || '';
-  let titleEscaped = false;
-
-  titleEl.addEventListener('click', (e) => {
-    if (titleEl.contentEditable === 'true') return;
-    e.preventDefault(); // prevent <details> toggle while editing
+  // ── Arrow button: only way to open/close ────────────────────────────────
+  arrowBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    originalTitle = titleEl.textContent;
-    titleEscaped = false;
-    titleEl.contentEditable = 'true';
-    titleEl.focus();
-    const sel = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(titleEl);
-    range.collapse(false);
-    if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+    applyOpen(!isOpen);
+    apiPatchBlock(block.id, { is_open: isOpen }).catch(console.error);
   });
 
-  titleEl.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); titleEl.blur(); }
-    if (e.key === 'Escape') {
-      titleEscaped = true;
-      titleEl.textContent = originalTitle;
-      titleEl.contentEditable = 'false';
-    }
-  });
-
-  titleEl.addEventListener('blur', () => {
-    if (titleEl.contentEditable !== 'true') return;
-    titleEl.contentEditable = 'false';
-    if (titleEscaped) { titleEscaped = false; return; }
-    const newTitle = titleEl.textContent.trim();
-    if (newTitle !== originalTitle) {
-      originalTitle = newTitle;
-      apiPatchBlock(block.id, { title: newTitle }).catch(console.error);
-    }
-  });
-
-  // ── Open/close toggle (summary click outside title) ───────────────────────
-  summaryEl.addEventListener('click', (e) => {
-    if (titleEl.contentEditable === 'true') {
-      e.preventDefault(); // don't close while typing
-      return;
-    }
-    if (titleEl.contains(e.target)) return; // title click handled above
-    // Let default <details> toggle happen, then persist
-    setTimeout(() => {
-      apiPatchBlock(block.id, { is_open: node.open }).catch(console.error);
-    }, 0);
-  });
+  // ── Title editing ────────────────────────────────────────────────────────
+  enableContentEditable(titleEl, block.id, 'title', node);
 
   block.children.forEach((child) => {
     childrenRoot.appendChild(renderBlock(child, block.id));

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -324,31 +324,6 @@ function createImageBlock(block) {
   return node;
 }
 
-function createContainerBlock(block) {
-  const template = document.getElementById('container-block-template');
-  const node = template.content.firstElementChild.cloneNode(true);
-  const titleNode = node.querySelector('.container-title');
-  const childrenRoot = node.querySelector('.container-children');
-
-  if (block.title) {
-    titleNode.textContent = block.title;
-    enableContentEditable(titleNode, block.id, 'title', node);
-  } else {
-    titleNode.remove();
-  }
-
-  if (block.layout === 'grid') {
-    childrenRoot.classList.add('is-grid');
-  }
-
-  block.children.forEach((child) => {
-    childrenRoot.appendChild(renderBlock(child, block.id));
-  });
-
-
-  return node;
-}
-
 function createToggleBlock(block) {
   const template = document.getElementById('toggle-block-template');
   const node = template.content.firstElementChild.cloneNode(true);
@@ -666,9 +641,6 @@ export function renderBlock(block, parentBlockId = null) {
     case 'image':
       blockEl = createImageBlock(block);
       break;
-    case 'container':
-      blockEl = createContainerBlock(block);
-      break;
     case 'toggle':
       blockEl = createToggleBlock(block);
       break;
@@ -708,7 +680,7 @@ export function focusBlock(wrapperEl) {
   if (!blockEl) return;
   const target = blockEl.classList.contains('notion-text')
     ? blockEl
-    : (blockEl.querySelector('.notion-caption, .container-title, .toggle-title, .quote-text, .code-content, .callout-text') ?? blockEl);
+    : (blockEl.querySelector('.notion-caption, .toggle-title, .quote-text, .code-content, .callout-text') ?? blockEl);
   target.click();
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -164,7 +164,9 @@ async function initGallery() {
         if (nextWrapper?.dataset?.blockId) {
           await apiMoveBlock(newBlock.id, nextWrapper.dataset.blockId);
         }
-        focusBlock(newWrapper);
+        // For container blocks with an auto-created child, focus that child
+        const firstChildWrapper = newWrapper.querySelector('[data-block-children] > .block-wrapper');
+        focusBlock(firstChildWrapper ?? newWrapper);
       }
       if (newBlock.child_document && callbacks.onPageBlockAdded) {
         callbacks.onPageBlockAdded(newBlock.child_document);
@@ -179,7 +181,9 @@ async function initGallery() {
       if (containerEl) {
         const newWrapper = renderBlock(newBlock, parentBlockId);
         containerEl.appendChild(newWrapper);
-        focusBlock(newWrapper);
+        // For container blocks with an auto-created child, focus that child
+        const firstChildWrapper = newWrapper.querySelector('[data-block-children] > .block-wrapper');
+        focusBlock(firstChildWrapper ?? newWrapper);
       }
       if (newBlock.child_document && callbacks.onPageBlockAdded) {
         callbacks.onPageBlockAdded(newBlock.child_document);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -209,7 +209,7 @@ async function initGallery() {
         if (targetBlock) {
           const focusTarget = targetBlock.classList.contains('notion-text')
             ? targetBlock
-            : (targetBlock.querySelector('.notion-caption, .toggle-title, .quote-text, .callout-text') ?? targetBlock);
+            : (targetBlock.querySelector('.notion-caption, .toggle-title, .quote-text, .callout-text, .code-content') ?? targetBlock);
           focusTarget.click();
         }
       }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -174,7 +174,7 @@ async function initGallery() {
     const addBlock = async (type, parentBlockId = null) => {
       const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId);
       const containerEl = parentBlockId
-        ? document.querySelector(`[data-block-id="${parentBlockId}"] .container-children`)
+        ? document.querySelector(`[data-block-id="${parentBlockId}"] [data-block-children]`)
         : root;
       if (containerEl) {
         const newWrapper = renderBlock(newBlock, parentBlockId);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -209,7 +209,7 @@ async function initGallery() {
         if (targetBlock) {
           const focusTarget = targetBlock.classList.contains('notion-text')
             ? targetBlock
-            : (targetBlock.querySelector('.notion-caption, .container-title') ?? targetBlock);
+            : (targetBlock.querySelector('.notion-caption, .toggle-title, .quote-text, .callout-text') ?? targetBlock);
           focusTarget.click();
         }
       }

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600&family=SUIT:wght@400;500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/static/css/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
   {% block head %}{% endblock %}
 </head>
 <body>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -26,3 +26,36 @@
 <template id="divider-block-template">
   <hr class="notion-block notion-divider" />
 </template>
+
+<template id="toggle-block-template">
+  <details class="notion-block notion-toggle">
+    <summary class="toggle-summary">
+      <span class="toggle-title"></span>
+    </summary>
+    <div class="toggle-children"></div>
+  </details>
+</template>
+
+<template id="quote-block-template">
+  <blockquote class="notion-block notion-quote">
+    <p class="quote-text"></p>
+    <div class="quote-children"></div>
+  </blockquote>
+</template>
+
+<template id="code-block-template">
+  <div class="notion-block notion-code">
+    <div class="code-header">
+      <select class="code-language-select"></select>
+      <button type="button" class="code-copy-btn">복사</button>
+    </div>
+    <pre class="code-body"><code class="code-content" spellcheck="false"></code></pre>
+  </div>
+</template>
+
+<template id="callout-block-template">
+  <div class="notion-block notion-callout">
+    <span class="callout-emoji"></span>
+    <p class="callout-text"></p>
+  </div>
+</template>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -56,6 +56,9 @@
 <template id="callout-block-template">
   <div class="notion-block notion-callout">
     <span class="callout-emoji"></span>
-    <p class="callout-text"></p>
+    <div class="callout-body">
+      <p class="callout-text"></p>
+      <div class="callout-children"></div>
+    </div>
   </div>
 </template>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -31,7 +31,7 @@
   <div class="notion-block notion-toggle">
     <div class="toggle-header">
       <button type="button" class="toggle-arrow-btn" aria-label="토글 열기/닫기" aria-expanded="false">▶</button>
-      <span class="toggle-title"></span>
+      <p class="toggle-title" tabindex="0"></p>
     </div>
     <div class="toggle-children" data-block-children hidden></div>
   </div>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -28,12 +28,13 @@
 </template>
 
 <template id="toggle-block-template">
-  <details class="notion-block notion-toggle">
-    <summary class="toggle-summary">
+  <div class="notion-block notion-toggle">
+    <div class="toggle-header">
+      <button type="button" class="toggle-arrow-btn" aria-label="토글 열기/닫기" aria-expanded="false">▶</button>
       <span class="toggle-title"></span>
-    </summary>
-    <div class="toggle-children" data-block-children></div>
-  </details>
+    </div>
+    <div class="toggle-children" data-block-children hidden></div>
+  </div>
 </template>
 
 <template id="quote-block-template">

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -9,12 +9,6 @@
   </figure>
 </template>
 
-<template id="container-block-template">
-  <section class="notion-block notion-container">
-    <header class="container-title"></header>
-    <div class="container-children" data-block-children></div>
-  </section>
-</template>
 
 <template id="page-block-template">
   <button type="button" class="notion-block notion-page">

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -12,7 +12,7 @@
 <template id="container-block-template">
   <section class="notion-block notion-container">
     <header class="container-title"></header>
-    <div class="container-children"></div>
+    <div class="container-children" data-block-children></div>
   </section>
 </template>
 
@@ -32,14 +32,14 @@
     <summary class="toggle-summary">
       <span class="toggle-title"></span>
     </summary>
-    <div class="toggle-children"></div>
+    <div class="toggle-children" data-block-children></div>
   </details>
 </template>
 
 <template id="quote-block-template">
   <blockquote class="notion-block notion-quote">
     <p class="quote-text"></p>
-    <div class="quote-children"></div>
+    <div class="quote-children" data-block-children></div>
   </blockquote>
 </template>
 
@@ -58,7 +58,7 @@
     <span class="callout-emoji"></span>
     <div class="callout-body">
       <p class="callout-text"></p>
-      <div class="callout-children"></div>
+      <div class="callout-children" data-block-children></div>
     </div>
   </div>
 </template>

--- a/tests/test_container_blocks.py
+++ b/tests/test_container_blocks.py
@@ -31,7 +31,16 @@ class TestCreateContainerBlocks:
     doc = repo.create_document()
     block = repo.create_block(doc["id"], "toggle")
     assert block["title"] == ""
-    assert block["is_open"] is False
+    assert block["is_open"] is True  # default open so user can type immediately
+
+  def test_container_types_include_one_child_on_create(self, repo):
+    """All container-type blocks are created with exactly one auto text child."""
+    doc = repo.create_document()
+    for block_type in ("container", "toggle", "quote", "callout"):
+      block = repo.create_block(doc["id"], block_type)
+      assert "children" in block, f"{block_type} missing children in response"
+      assert len(block["children"]) == 1
+      assert block["children"][0]["type"] == "text"
 
   def test_code_defaults(self, repo):
     doc = repo.create_document()
@@ -97,7 +106,7 @@ class TestToggleChildNesting:
     fetched = repo.get_document(doc["id"])
     toggle = fetched.blocks[0]
     assert toggle.type == "toggle"
-    assert len(toggle.children) == 2
+    assert len(toggle.children) == 3  # 1 auto-created + 2 manually added
 
   def test_quote_children_loaded(self, repo):
     doc = repo.create_document()
@@ -107,7 +116,7 @@ class TestToggleChildNesting:
     fetched = repo.get_document(doc["id"])
     quote = fetched.blocks[0]
     assert quote.type == "quote"
-    assert len(quote.children) == 1
+    assert len(quote.children) == 2  # 1 auto-created + 1 manually added
 
   def test_callout_children_loaded(self, repo):
     doc = repo.create_document()
@@ -117,7 +126,7 @@ class TestToggleChildNesting:
     fetched = repo.get_document(doc["id"])
     callout = fetched.blocks[0]
     assert callout.type == "callout"
-    assert len(callout.children) == 1
+    assert len(callout.children) == 2  # 1 auto-created + 1 manually added
 
   def test_code_block_has_no_children_field(self, repo):
     from app.models.blocks import CodeBlock
@@ -167,12 +176,73 @@ class TestDeleteContainerBlocks:
   def test_delete_toggle_removes_children(self, repo):
     doc = repo.create_document()
     parent = repo.create_block(doc["id"], "toggle")
+    # toggle already has 1 auto-created child; add 2 more
     repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
     repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
 
     assert repo.delete_block(parent["id"])
     fetched = repo.get_document(doc["id"])
     assert len(fetched.blocks) == 0
+
+  def test_deleting_last_child_cascades_container_delete(self, repo):
+    """When the last child of a container is deleted, the container is also deleted."""
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "toggle")
+    # Only the 1 auto-created child exists
+    auto_child_id = parent["children"][0]["id"]
+
+    repo.delete_block(auto_child_id)
+
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 0  # container cascaded away
+
+  def test_cascade_stops_when_siblings_remain(self, repo):
+    """Container is kept alive as long as at least one child remains."""
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "toggle")
+    extra = repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    # Delete the extra child — auto-created one still remains
+    repo.delete_block(extra["id"])
+
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 1
+    assert fetched.blocks[0].type == "toggle"
+    assert len(fetched.blocks[0].children) == 1
+
+  def test_cascade_delete_propagates_through_nested_containers(self, repo):
+    """Cascade deletion propagates upward through nested containers."""
+    doc = repo.create_document()
+    outer = repo.create_block(doc["id"], "toggle")
+    outer_auto_child_id = outer["children"][0]["id"]
+
+    # Replace the outer's auto-child with an inner container
+    repo.delete_block(outer_auto_child_id)
+    # Outer is now empty and was cascade-deleted. Verify and recreate scenario:
+    # Actually this would cascade-delete outer too. Let's test differently:
+    # Create outer, add an inner container as explicit child, then outer auto child still exists.
+    doc2 = repo.create_document()
+    outer2 = repo.create_block(doc2["id"], "toggle")
+    inner = repo.create_block(doc2["id"], "quote", parent_block_id=outer2["id"])
+    inner_auto_child_id = inner["children"][0]["id"]
+
+    # outer2 has: [auto-text, inner-quote]
+    # inner-quote has: [auto-text]
+    # Delete the outer2's auto text child — outer2 still has inner-quote
+    outer2_auto_child_id = outer2["children"][0]["id"]
+    repo.delete_block(outer2_auto_child_id)
+
+    fetched = repo.get_document(doc2["id"])
+    assert len(fetched.blocks) == 1
+    assert fetched.blocks[0].type == "toggle"
+    # inner quote still alive with its auto child
+    assert len(fetched.blocks[0].children) == 1
+    assert fetched.blocks[0].children[0].type == "quote"
+
+    # Now delete inner-quote's only child — inner-quote cascades, outer2 cascades
+    repo.delete_block(inner_auto_child_id)
+    fetched2 = repo.get_document(doc2["id"])
+    assert len(fetched2.blocks) == 0
 
 
 # ── API-level tests ───────────────────────────────────────────────────────────
@@ -244,4 +314,4 @@ class TestContainerBlocksAPI:
     fetched = client.get(f"/api/documents/{doc['id']}").json()
     toggle = fetched["blocks"][0]
     assert toggle["type"] == "toggle"
-    assert len(toggle["children"]) == 1
+    assert len(toggle["children"]) == 2  # 1 auto-created + 1 manually added

--- a/tests/test_container_blocks.py
+++ b/tests/test_container_blocks.py
@@ -14,7 +14,7 @@ class TestCreateContainerBlocks:
   """create_block returns correct defaults for each new type."""
 
   @pytest.mark.parametrize("block_type,expected_keys", [
-    ("toggle", {"title", "is_open"}),
+    ("toggle", {"text", "is_open"}),
     ("quote", {"text"}),
     ("code", {"code", "language"}),
     ("callout", {"text", "emoji", "color"}),
@@ -30,7 +30,7 @@ class TestCreateContainerBlocks:
   def test_toggle_defaults(self, repo):
     doc = repo.create_document()
     block = repo.create_block(doc["id"], "toggle")
-    assert block["title"] == ""
+    assert block["text"] == ""
     assert block["is_open"] is True  # default open so user can type immediately
 
   def test_container_types_include_one_child_on_create(self, repo):
@@ -58,13 +58,13 @@ class TestCreateContainerBlocks:
 class TestUpdateContainerBlocks:
   """update_block persists type-specific fields correctly."""
 
-  def test_update_toggle_title_and_open(self, repo):
+  def test_update_toggle_text_and_open(self, repo):
     doc = repo.create_document()
     block = repo.create_block(doc["id"], "toggle")
-    assert repo.update_block(block["id"], {"title": "섹션 제목", "is_open": True})
+    assert repo.update_block(block["id"], {"text": "섹션 제목", "is_open": True})
     fetched = repo.get_document(doc["id"])
     toggle = fetched.blocks[0]
-    assert toggle.title == "섹션 제목"
+    assert toggle.text == "섹션 제목"
     assert toggle.is_open is True
 
   def test_update_quote_text(self, repo):

--- a/tests/test_container_blocks.py
+++ b/tests/test_container_blocks.py
@@ -1,0 +1,247 @@
+"""Tests for container-type block interface extension (issue #27).
+
+Covers toggle, quote, code, callout block creation, update, type change,
+child nesting, and delete/subtree logic via both repository and API layers.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Repository-level tests ────────────────────────────────────────────────────
+
+class TestCreateContainerBlocks:
+  """create_block returns correct defaults for each new type."""
+
+  @pytest.mark.parametrize("block_type,expected_keys", [
+    ("toggle", {"title", "is_open"}),
+    ("quote", {"text"}),
+    ("code", {"code", "language"}),
+    ("callout", {"text", "emoji", "color"}),
+  ])
+  def test_create_returns_correct_fields(self, repo, block_type, expected_keys):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], block_type)
+    assert block is not None
+    assert block["type"] == block_type
+    for key in expected_keys:
+      assert key in block
+
+  def test_toggle_defaults(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "toggle")
+    assert block["title"] == ""
+    assert block["is_open"] is False
+
+  def test_code_defaults(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    assert block["code"] == ""
+    assert block["language"] == "plain"
+
+  def test_callout_defaults(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "callout")
+    assert block["emoji"] == "💡"
+    assert block["color"] == "yellow"
+
+
+class TestUpdateContainerBlocks:
+  """update_block persists type-specific fields correctly."""
+
+  def test_update_toggle_title_and_open(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "toggle")
+    assert repo.update_block(block["id"], {"title": "섹션 제목", "is_open": True})
+    fetched = repo.get_document(doc["id"])
+    toggle = fetched.blocks[0]
+    assert toggle.title == "섹션 제목"
+    assert toggle.is_open is True
+
+  def test_update_quote_text(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "quote")
+    assert repo.update_block(block["id"], {"text": "인용 문구"})
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].text == "인용 문구"
+
+  def test_update_code_content_and_language(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    assert repo.update_block(block["id"], {"code": "print('hi')", "language": "python"})
+    fetched = repo.get_document(doc["id"])
+    code_block = fetched.blocks[0]
+    assert code_block.code == "print('hi')"
+    assert code_block.language == "python"
+
+  def test_update_callout_fields(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "callout")
+    assert repo.update_block(block["id"], {"text": "주의", "emoji": "⚠️", "color": "red"})
+    fetched = repo.get_document(doc["id"])
+    callout = fetched.blocks[0]
+    assert callout.text == "주의"
+    assert callout.emoji == "⚠️"
+    assert callout.color == "red"
+
+
+class TestToggleChildNesting:
+  """Children of toggle/quote/callout are loaded as nested Block objects."""
+
+  def test_toggle_children_loaded(self, repo):
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "toggle")
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    fetched = repo.get_document(doc["id"])
+    toggle = fetched.blocks[0]
+    assert toggle.type == "toggle"
+    assert len(toggle.children) == 2
+
+  def test_quote_children_loaded(self, repo):
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "quote")
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    fetched = repo.get_document(doc["id"])
+    quote = fetched.blocks[0]
+    assert quote.type == "quote"
+    assert len(quote.children) == 1
+
+  def test_callout_children_loaded(self, repo):
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "callout")
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    fetched = repo.get_document(doc["id"])
+    callout = fetched.blocks[0]
+    assert callout.type == "callout"
+    assert len(callout.children) == 1
+
+  def test_code_block_has_no_children_field(self, repo):
+    from app.models.blocks import CodeBlock
+    doc = repo.create_document()
+    repo.create_block(doc["id"], "code")
+    fetched = repo.get_document(doc["id"])
+    assert isinstance(fetched.blocks[0], CodeBlock)
+    assert not hasattr(fetched.blocks[0], "children")
+
+
+class TestChangeBlockType:
+  """change_block_type resets content and deletes descendants for new types."""
+
+  @pytest.mark.parametrize("new_type", ["toggle", "quote", "code", "callout"])
+  def test_change_to_new_type_succeeds(self, repo, new_type):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "text")
+    assert repo.change_block_type(block["id"], new_type)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == new_type
+
+  def test_change_from_toggle_deletes_children(self, repo):
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "toggle")
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    repo.change_block_type(parent["id"], "text")
+    fetched = repo.get_document(doc["id"])
+    # After change, the former toggle is now a text block with no children
+    assert fetched.blocks[0].type == "text"
+    assert len(fetched.blocks) == 1
+
+  def test_change_to_code_resets_to_defaults(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "text")
+    repo.update_block(block["id"], {"text": "hello"})
+    repo.change_block_type(block["id"], "code")
+    fetched = repo.get_document(doc["id"])
+    code = fetched.blocks[0]
+    assert code.code == ""
+    assert code.language == "plain"
+
+
+class TestDeleteContainerBlocks:
+  """delete_block removes the block and all its descendants."""
+
+  def test_delete_toggle_removes_children(self, repo):
+    doc = repo.create_document()
+    parent = repo.create_block(doc["id"], "toggle")
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+
+    assert repo.delete_block(parent["id"])
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 0
+
+
+# ── API-level tests ───────────────────────────────────────────────────────────
+
+class TestContainerBlocksAPI:
+  """HTTP API smoke tests for new block types."""
+
+  def _create_doc_and_block(self, client, block_type):
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": block_type},
+    ).json()
+    return doc, block
+
+  def test_create_toggle_via_api(self, client):
+    doc = client.post("/api/documents").json()
+    resp = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "toggle"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "toggle"
+    assert "is_open" in data
+
+  def test_create_code_via_api(self, client):
+    doc = client.post("/api/documents").json()
+    resp = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "code"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "code"
+    assert data["language"] == "plain"
+
+  def test_create_callout_via_api(self, client):
+    doc = client.post("/api/documents").json()
+    resp = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "callout"})
+    assert resp.status_code == 201
+    assert resp.json()["type"] == "callout"
+
+  def test_patch_toggle_is_open(self, client):
+    doc, block = self._create_doc_and_block(client, "toggle")
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"is_open": True})
+    assert resp.status_code == 200
+
+  def test_patch_code_language(self, client):
+    doc, block = self._create_doc_and_block(client, "code")
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"language": "python", "code": "pass"})
+    assert resp.status_code == 200
+
+  def test_patch_callout_color(self, client):
+    doc, block = self._create_doc_and_block(client, "callout")
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"color": "blue"})
+    assert resp.status_code == 200
+
+  @pytest.mark.parametrize("new_type", ["toggle", "quote", "code", "callout"])
+  def test_type_change_to_new_types(self, client, new_type):
+    doc, block = self._create_doc_and_block(client, "text")
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": new_type})
+    assert resp.status_code == 200
+
+  def test_get_document_includes_toggle_children(self, client):
+    doc = client.post("/api/documents").json()
+    parent = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "toggle"},
+    ).json()
+    client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "text", "parent_block_id": parent["id"]},
+    )
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    toggle = fetched["blocks"][0]
+    assert toggle["type"] == "toggle"
+    assert len(toggle["children"]) == 1

--- a/tests/test_container_blocks.py
+++ b/tests/test_container_blocks.py
@@ -1,7 +1,8 @@
-"""Tests for container-type block interface extension (issue #27).
+"""Tests for child-bearing block types (issue #27).
 
 Covers toggle, quote, code, callout block creation, update, type change,
 child nesting, and delete/subtree logic via both repository and API layers.
+ContainerBlockBase is the internal base — not a user-visible block type.
 """
 from __future__ import annotations
 
@@ -10,7 +11,7 @@ import pytest
 
 # ── Repository-level tests ────────────────────────────────────────────────────
 
-class TestCreateContainerBlocks:
+class TestCreateBlocks:
   """create_block returns correct defaults for each new type."""
 
   @pytest.mark.parametrize("block_type,expected_keys", [
@@ -33,10 +34,10 @@ class TestCreateContainerBlocks:
     assert block["text"] == ""
     assert block["is_open"] is True  # default open so user can type immediately
 
-  def test_container_types_include_one_child_on_create(self, repo):
-    """All container-type blocks are created with exactly one auto text child."""
+  def test_child_bearing_types_include_one_child_on_create(self, repo):
+    """toggle/quote/callout are created with exactly one auto text child."""
     doc = repo.create_document()
-    for block_type in ("container", "toggle", "quote", "callout"):
+    for block_type in ("toggle", "quote", "callout"):
       block = repo.create_block(doc["id"], block_type)
       assert "children" in block, f"{block_type} missing children in response"
       assert len(block["children"]) == 1
@@ -55,7 +56,7 @@ class TestCreateContainerBlocks:
     assert block["color"] == "yellow"
 
 
-class TestUpdateContainerBlocks:
+class TestUpdateBlocks:
   """update_block persists type-specific fields correctly."""
 
   def test_update_toggle_text_and_open(self, repo):
@@ -170,7 +171,7 @@ class TestChangeBlockType:
     assert code.language == "plain"
 
 
-class TestDeleteContainerBlocks:
+class TestDeleteBlocks:
   """delete_block removes the block and all its descendants."""
 
   def test_delete_toggle_removes_children(self, repo):
@@ -184,8 +185,8 @@ class TestDeleteContainerBlocks:
     fetched = repo.get_document(doc["id"])
     assert len(fetched.blocks) == 0
 
-  def test_deleting_last_child_cascades_container_delete(self, repo):
-    """When the last child of a container is deleted, the container is also deleted."""
+  def test_deleting_last_child_cascades_parent_delete(self, repo):
+    """When the last child of a child-bearing block is deleted, the parent is also deleted."""
     doc = repo.create_document()
     parent = repo.create_block(doc["id"], "toggle")
     # Only the 1 auto-created child exists
@@ -194,7 +195,7 @@ class TestDeleteContainerBlocks:
     repo.delete_block(auto_child_id)
 
     fetched = repo.get_document(doc["id"])
-    assert len(fetched.blocks) == 0  # container cascaded away
+    assert len(fetched.blocks) == 0  # toggle cascaded away
 
   def test_cascade_stops_when_siblings_remain(self, repo):
     """Container is kept alive as long as at least one child remains."""
@@ -210,17 +211,15 @@ class TestDeleteContainerBlocks:
     assert fetched.blocks[0].type == "toggle"
     assert len(fetched.blocks[0].children) == 1
 
-  def test_cascade_delete_propagates_through_nested_containers(self, repo):
-    """Cascade deletion propagates upward through nested containers."""
+  def test_cascade_delete_propagates_through_nested_blocks(self, repo):
+    """Cascade deletion propagates upward through nested child-bearing blocks."""
     doc = repo.create_document()
     outer = repo.create_block(doc["id"], "toggle")
     outer_auto_child_id = outer["children"][0]["id"]
 
-    # Replace the outer's auto-child with an inner container
+    # Delete outer's auto-child → outer cascades too (no children left).
     repo.delete_block(outer_auto_child_id)
-    # Outer is now empty and was cascade-deleted. Verify and recreate scenario:
-    # Actually this would cascade-delete outer too. Let's test differently:
-    # Create outer, add an inner container as explicit child, then outer auto child still exists.
+    # Recreate the scenario with an inner child-bearing block:
     doc2 = repo.create_document()
     outer2 = repo.create_block(doc2["id"], "toggle")
     inner = repo.create_block(doc2["id"], "quote", parent_block_id=outer2["id"])
@@ -247,7 +246,7 @@ class TestDeleteContainerBlocks:
 
 # ── API-level tests ───────────────────────────────────────────────────────────
 
-class TestContainerBlocksAPI:
+class TestBlocksAPI:
   """HTTP API smoke tests for new block types."""
 
   def _create_doc_and_block(self, client, block_type):


### PR DESCRIPTION
## 관련 이슈

close #27

## 배경 / 목적

`ContainerBlock`이 사용자 노출 블록 타입으로 혼재되어 있어 아키텍처 의도와 불일치했습니다.  
원래 설계 의도대로 `ContainerBlock`을 내부 추상 기반 클래스(`ContainerBlockBase`)로 전환하고,  
이를 계기로 토글 블록 편집 UX, 코드 블록 편집 기능, 문법 강조 등 관련 기능을 함께 개선합니다.

## 변경 사항

### 아키텍처 리팩토링
- `ContainerBlock` → `ContainerBlockBase` 내부 기반 클래스로 전환 (`Block` 유니언에서 제거)
- `ToggleBlock`, `QuoteBlock`, `CalloutBlock`이 `ContainerBlockBase` 상속
- `_CHILD_BEARING_TYPES = frozenset({"toggle", "quote", "callout"})` 상수로 자식 블록 보유 타입 관리
- `ToggleBlock` 필드 통일: `title`/`formatted_title` → `text`/`formatted_text`/`level` (텍스트 블록과 동일)

### 토글 블록 편집 UX 개선
- `makeTextEditable()` 공유 헬퍼로 텍스트 블록과 동일한 인터페이스 통일
- 토글 제목에 헤딩(`#`/`##`/`###`) 및 서식 툴바 지원 추가
- 엔터 시 토글 열기 + 첫 번째 자식 블록 포커스
- `> ` 입력 후 스페이스 시 텍스트 블록 → 토글 블록 자동 변환
- CSS 수정: 빈 제목 최소 높이 보장, 토글 버튼 세로 중앙 정렬

### 코드 블록 편집 및 문법 강조
- 코드 블록 텍스트 영역 편집 기능 추가 (클릭 시 편집 모드, blur 시 저장)
- Highlight.js (v11.10.0, atom-one-dark 테마) CDN 적용
- 실시간 문법 강조: `input` 이벤트마다 `innerHTML` 교체 + `TreeWalker` 커서 위치 보존

### 테스트
- `tests/test_container_blocks.py` 추가: 37개 테스트 (자동 자식 생성, cascade 삭제, 타입 변환 등)

## 테스트 결과

```
tests/test_container_blocks.py ....................................  [37 passed]
```

## 리뷰 포인트

- `ContainerBlockBase`가 `Block` 유니언에 포함되지 않는 구조가 Pydantic v2 discriminated union과 올바르게 동작하는지
- `getCaretOffset` / `setCaretOffset` TreeWalker 기반 커서 보존 로직의 엣지 케이스 (IME 입력, 빈 노드 등)
- `makeTextEditable` opts 중 `enableSlash: false`, `enableTypeShortcuts: false`가 토글 제목에 올바르게 적용되는지