### PR TITLE
[CHORE#38] PR 및 main 브랜치 대상 pytest CI 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Run pytest
         run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run pytest
+        run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-anyio>=0.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"


### PR DESCRIPTION
Closes #38

## Summary

- 배경: PR과 main 브랜치 커밋에서 테스트가 자동 실행되지 않아, 병합 후 회귀를 조기에 감지하기 어려운 상태였습니다.
- 목적: GitHub Actions에 `pytest` CI 파이프라인을 추가하여 PR 및 `main` push 시 테스트를 자동 실행하고, 실패 시 병합을 차단할 수 있는 기반을 마련합니다.

## Changes

- `pyproject.toml`: `[tool.pytest.ini_options]` 섹션 추가 — `testpaths = ["tests"]`, `addopts = "-v --tb=short"` 설정으로 로컬/CI 실행 일관성 확보
- `.github/workflows/ci.yml` 추가
  - 트리거: `push: main`, `pull_request: opened / synchronize / reopened`
  - `astral-sh/setup-uv@v5` 사용, `pyproject.toml` 기반 uv 캐시 적용으로 설치 속도 최적화
  - `uv sync --group dev` → `uv run pytest` 순으로 실행
  - Python 3.12 단일 버전 (matrix 구조 유지하여 추후 확장 가능)
  - 테스트 실패 시 CI가 실패 상태를 반환하여 브랜치 보호 규칙과 연동 가능

## Test

- [x] 로컬 `uv run pytest` 실행 확인 — 80 passed
- [ ] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [ ] 주요 경로 확인 (`/`, `/api/projects`)
- [ ] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `astral-sh/setup-uv@v5`의 `cache-dependency-glob` 설정이 `pyproject.toml` 변경 시에만 캐시를 무효화하는 방식이 적절한지 확인 부탁드립니다.