### PR TITLE
[REFAC#45] 블록 추가 기본 동작을 텍스트 블록 즉시 생성으로 변경

### DIFF
--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -1,7 +1,7 @@
 // ── Block wrapper (drag handle + more menu) ───────────────────────────────────
 
 import { apiChangeBlockType, apiMoveBlock } from "./api.js";
-import { BLOCK_PALETTE_ITEMS, openBlockPalette, showBlockDeleteConfirm } from "./blockPalette.js";
+import { BLOCK_PALETTE_ITEMS, showBlockDeleteConfirm } from "./blockPalette.js";
 
 // ── Drag state ────────────────────────────────────────────────────────────────
 let currentDragBlockId = null;
@@ -111,12 +111,10 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
   });
 
   // ── Insert below ─────────────────────────────────────────────────────────
-  insertBtn.addEventListener('click', (e) => {
+  insertBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
     document.querySelectorAll('.block-more-menu').forEach((m) => (m.hidden = true));
-    openBlockPalette(wrapper, parentBlockId, async (type) => {
-      if (addBlockAfter) await addBlockAfter(type, block.id, parentBlockId);
-    });
+    if (addBlockAfter) await addBlockAfter('text', block.id, parentBlockId);
   });
 
   // ── Delete with confirmation ──────────────────────────────────────────────

--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -114,7 +114,12 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
   insertBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
     document.querySelectorAll('.block-more-menu').forEach((m) => (m.hidden = true));
-    if (addBlockAfter) await addBlockAfter('text', block.id, parentBlockId);
+    if (!addBlockAfter) return;
+    try {
+      await addBlockAfter('text', block.id, parentBlockId);
+    } catch (err) {
+      console.error('블록 추가 실패:', err);
+    }
   });
 
   // ── Delete with confirmation ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 배경: 블록 추가 시 타입 선택 팔레트가 먼저 노출되어 빠른 입력 흐름이 끊겼습니다.
- 목적: `+` 버튼의 기본 동작을 텍스트 블록 즉시 생성으로 전환하여 작성 중심 흐름으로 단순화합니다.

Closes #45

## Changes

- `blockWrapper.js`: `+` 버튼 클릭 시 `openBlockPalette()` 대신 `addBlockAfter('text', ...)` 직접 호출
- `blockWrapper.js`: 불필요해진 `openBlockPalette` import 제거

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [x] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `+` 버튼 외 Enter·`/`·타입 변경 경로에서 회귀가 없는지 확인
  - Enter 키: 기존과 동일하게 `addBlockAfter("text", ...)` 직접 호출 → 변경 없음
  - `/` 커맨드: `openBlockPalette()` 유지 → 변경 없음
  - 타입 변경(moreMenu): `apiChangeBlockType()` 경로 → 변경 없음