### PR TITLE
[CHORE#51] PR 자동 리뷰어로 GitHub Copilot 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# 모든 파일 변경 시 GitHub Copilot이 자동으로 코드 리뷰어로 지정됩니다.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @github-copilot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, review_requested]
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, review_requested]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- 배경: PR이 열릴 때 리뷰어를 수동으로 지정해야 하는 번거로움이 있음
- 목적: CODEOWNERS 설정으로 GitHub Copilot을 자동 리뷰어로 등록하여 매 PR마다 코드 리뷰가 보장되도록 함

## Changes

- `.github/CODEOWNERS` 신규 생성 — 전체 경로(`*`)에 `@github-copilot` 지정
- `.github/workflows/ci.yml` — `pull_request.types`에 `review_requested` 추가 (CODEOWNERS 자동 지정 시점에도 CI 실행)

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [x] 브라우저 콘솔 에러 없음

> 본 PR은 설정 파일만 변경하므로 애플리케이션 동작에 영향 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [x] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: CODEOWNERS의 `* @github-copilot` 패턴이 의도한 전체 경로에 적용되는지 확인

Closes #51