### PR TITLE
[FEAT#41] 페이지 블록 참조 생성 및 참조 페이지 이동 기능 추가

### DIFF
--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -85,6 +85,8 @@ class PageBlock(BlockBase):
   type: Literal["page"]
   document_id: str
   title: str = ""  # populated at query time from the referenced document
+  is_reference: bool = False  # True when linking to a pre-existing document (not auto-created)
+  is_broken_ref: bool = False  # True when the target document no longer exists
 
 
 Block = Annotated[

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -35,6 +35,10 @@ class SQLiteBlockRepository:
 
   # ── Documents ──────────────────────────────────────────────────────────────
 
+  def document_exists(self, document_id: str) -> bool:
+    """Return True if a document with the given id exists."""
+    return self._session.get(DocumentRow, document_id) is not None
+
   def list_documents(self) -> list[dict]:
     """Return all documents as a parent-child tree sorted by title.
 
@@ -123,7 +127,7 @@ class SQLiteBlockRepository:
           is_broken = bool(doc_id) and doc_id not in doc_titles
           nodes.append(PageBlock.model_validate({
             **item,
-            "title": doc_titles.get(doc_id, "알 수 없는 문서"),
+            "title": "" if is_broken else doc_titles.get(doc_id, ""),
             "is_broken_ref": is_broken,
           }))
         else:
@@ -333,8 +337,10 @@ class SQLiteBlockRepository:
   def delete_block(self, block_id: str) -> bool:
     """Delete a block and all its descendants. Compacts sibling positions after deletion.
 
-    When deleting a page block, the referenced document is promoted to root
-    (parent_id cleared) so it is not orphaned.
+    For owned page blocks (is_reference=False) the referenced document is promoted
+    to root (parent_id cleared) so it is not orphaned.
+    Reference page blocks (is_reference=True) are removed without touching the
+    target document's parent hierarchy.
     """
     block_row = self._session.get(BlockRow, block_id)
     if block_row is None:

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -119,9 +119,12 @@ class SQLiteBlockRepository:
         elif item["type"] == "divider":
           nodes.append(DividerBlock.model_validate(item))
         elif item["type"] == "page":
+          doc_id = item.get("document_id", "")
+          is_broken = bool(doc_id) and doc_id not in doc_titles
           nodes.append(PageBlock.model_validate({
             **item,
-            "title": doc_titles.get(item.get("document_id", ""), "알 수 없는 문서"),
+            "title": doc_titles.get(doc_id, "알 수 없는 문서"),
+            "is_broken_ref": is_broken,
           }))
         else:
           nodes.append(self._block_adapter.validate_python(item))
@@ -223,6 +226,7 @@ class SQLiteBlockRepository:
     document_id: str,
     block_type: str,
     parent_block_id: str | None = None,
+    target_document_id: str | None = None,
   ) -> dict[str, Any] | None:
     """Append a new block of the given type at the end of its sibling list.
 
@@ -241,12 +245,22 @@ class SQLiteBlockRepository:
       if parent_exists is None:
         return None
 
-    # ── Page block: auto-create a child document (single transaction) ────────
+    # ── Page block: link to existing or auto-create a child document ─────────
     if block_type == "page":
-      # Use _build_child_document_row (no commit) so both the new document and
-      # the page block are committed together below, keeping the DB consistent.
-      child_doc = self._build_child_document_row(document_id)
-      default_content: dict[str, Any] = {"document_id": child_doc["id"]}
+      if target_document_id is not None:
+        # Reference an existing document without changing its parent.
+        if self._session.get(DocumentRow, target_document_id) is None:
+          return None
+        default_content: dict[str, Any] = {
+          "document_id": target_document_id,
+          "is_reference": True,
+        }
+        child_doc = None
+      else:
+        # Use _build_child_document_row (no commit) so both the new document and
+        # the page block are committed together below, keeping the DB consistent.
+        child_doc = self._build_child_document_row(document_id)
+        default_content = {"document_id": child_doc["id"], "is_reference": False}
     else:
       match block_type:
         case "text":
@@ -304,8 +318,14 @@ class SQLiteBlockRepository:
 
     result: dict[str, Any] = {"id": block_id, "type": block_type, **default_content}
     if block_type == "page":
-      result["title"] = child_doc["title"]
-      result["child_document"] = child_doc
+      if child_doc is not None:
+        result["title"] = child_doc["title"]
+        result["child_document"] = child_doc
+      else:
+        ref_title = self._session.execute(
+          select(DocumentRow.title).where(DocumentRow.id == target_document_id)
+        ).scalar_one_or_none()
+        result["title"] = ref_title or ""
     if child_text_row is not None:
       result["children"] = [child_text_row]
     return result
@@ -320,11 +340,13 @@ class SQLiteBlockRepository:
     if block_row is None:
       return False
 
-    # Promote referenced document if this is a page block
+    # Promote referenced document to root only when this page block owns it.
+    # Reference blocks (is_reference=True) merely link to an existing document
+    # whose parent hierarchy must not be disturbed.
     if block_row.type == "page":
       content = json.loads(block_row.content_json)
       ref_doc_id = content.get("document_id")
-      if ref_doc_id:
+      if ref_doc_id and not content.get("is_reference", False):
         self._session.execute(
           update(DocumentRow)
           .where(DocumentRow.id == ref_doc_id)

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -87,9 +87,14 @@ def create_block(
   """
   if body.target_document_id is not None and body.type != "page":
     raise HTTPException(status_code=422, detail="target_document_id is only valid for page blocks")
+  if not repo.document_exists(document_id):
+    raise HTTPException(status_code=404, detail="Document not found")
+  if body.type == "page" and body.target_document_id is not None:
+    if not repo.document_exists(body.target_document_id):
+      raise HTTPException(status_code=404, detail="Target document not found")
   result = repo.create_block(document_id, body.type, body.parent_block_id, body.target_document_id)
   if result is None:
-    raise HTTPException(status_code=404, detail="Document not found")
+    raise HTTPException(status_code=422, detail="Parent block not found")
   return result
 
 

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -68,6 +68,8 @@ def update_document_title(
 class BlockCreate(BaseModel):
   type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "page"]
   parent_block_id: str | None = None
+  # Only used when type="page": link to an existing document instead of creating a new one
+  target_document_id: str | None = None
 
 
 @router.post("/{document_id}/blocks", status_code=201)
@@ -78,10 +80,14 @@ def create_block(
 ) -> dict:
   """Append a new block to a document.
 
-  For ``type=page`` a new child document is automatically created and returned
-  inside the ``child_document`` field of the response.
+  For ``type=page`` a new child document is automatically created unless
+  ``target_document_id`` is provided, in which case the block links to the
+  existing document.  A newly created child document is returned inside the
+  ``child_document`` field of the response.
   """
-  result = repo.create_block(document_id, body.type, body.parent_block_id)
+  if body.target_document_id is not None and body.type != "page":
+    raise HTTPException(status_code=422, detail="target_document_id is only valid for page blocks")
+  result = repo.create_block(document_id, body.type, body.parent_block_id, body.target_document_id)
   if result is None:
     raise HTTPException(status_code=404, detail="Document not found")
   return result

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -483,6 +483,136 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   color: var(--ink);
 }
 
+/* ── Page block: broken reference state ──────────────────────────────────── */
+
+.notion-page.is-broken-ref {
+  opacity: 0.55;
+  cursor: default;
+  pointer-events: none;
+}
+
+.notion-page.is-broken-ref .page-block-icon {
+  color: #b45309;
+}
+
+.notion-page.is-broken-ref .page-block-title {
+  color: #92400e;
+  text-decoration: line-through;
+}
+
+/* ── Page picker modal ───────────────────────────────────────────────────── */
+
+.page-picker-modal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 240px;
+  max-width: 320px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  box-shadow: 0 8px 20px -6px var(--shadow);
+  margin-top: 0.3rem;
+  overflow: hidden;
+  animation: fade-slide-up 0.18s ease both;
+  z-index: 200;
+}
+
+.page-picker-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ink);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.page-picker-option:hover {
+  background: var(--accent-soft);
+}
+
+.page-picker-icon {
+  font-style: normal;
+  color: var(--accent);
+  font-size: 0.95rem;
+}
+
+.page-picker-divider {
+  height: 1px;
+  background: var(--line);
+  margin: 0;
+}
+
+.page-picker-search {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-bottom: 1px solid var(--line);
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--ink);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.page-picker-search::placeholder {
+  color: var(--ink-soft);
+}
+
+.page-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.page-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 0.1s;
+  outline: none;
+}
+
+.page-picker-item:hover,
+.page-picker-item:focus {
+  background: var(--accent-soft);
+}
+
+.page-picker-item-icon {
+  color: var(--accent);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.page-picker-item-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.page-picker-empty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+  list-style: none;
+}
+
 .unsupported-block,
 .error-state,
 .empty-state {

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -41,11 +41,13 @@ export async function apiPatchBlock(blockId, fields) {
   if (!res.ok) throw new Error('Failed to update block');
 }
 
-export async function apiCreateBlock(documentId, type, parentBlockId = null) {
+export async function apiCreateBlock(documentId, type, parentBlockId = null, targetDocumentId = null) {
+  const body = { type, parent_block_id: parentBlockId };
+  if (targetDocumentId !== null) body.target_document_id = targetDocumentId;
   const res = await fetch(`/api/documents/${documentId}/blocks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ type, parent_block_id: parentBlockId }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error('Failed to create block');
   return res.json();

--- a/static/js/blocks/pageBlock.js
+++ b/static/js/blocks/pageBlock.js
@@ -14,20 +14,21 @@ export function create(block, { callbacks = {} } = {}) {
   const titleEl = node.querySelector(".page-block-title");
   const iconEl = node.querySelector(".page-block-icon");
 
-  titleEl.textContent = block.title || block.document_id;
-  titleEl.dataset.docId = block.document_id;
-
   if (block.is_broken_ref) {
     node.classList.add("is-broken-ref");
     iconEl.textContent = "⚠";
-    titleEl.textContent = block.title || "삭제된 페이지";
-    node.setAttribute("aria-label", `삭제된 페이지: ${titleEl.textContent}`);
+    titleEl.textContent = "삭제된 페이지";
+    titleEl.dataset.docId = block.document_id;
+    node.setAttribute("aria-label", "삭제된 페이지");
     node.setAttribute("aria-disabled", "true");
-    node.removeAttribute("tabindex");
+    // <button>은 tabindex 제거만으로는 탭 순서에서 빠지지 않으므로 disabled와 tabIndex=-1을 함께 사용
+    node.disabled = true;
+    node.tabIndex = -1;
     return node;
   }
 
-  node.setAttribute("tabindex", "0");
+  titleEl.textContent = block.title || block.document_id;
+  titleEl.dataset.docId = block.document_id;
   node.setAttribute("aria-label", `페이지로 이동: ${titleEl.textContent}`);
 
   function navigate() {

--- a/static/js/blocks/pageBlock.js
+++ b/static/js/blocks/pageBlock.js
@@ -12,12 +12,34 @@ export function create(block, { callbacks = {} } = {}) {
   const template = document.getElementById("page-block-template");
   const node = template.content.firstElementChild.cloneNode(true);
   const titleEl = node.querySelector(".page-block-title");
+  const iconEl = node.querySelector(".page-block-icon");
 
   titleEl.textContent = block.title || block.document_id;
   titleEl.dataset.docId = block.document_id;
 
-  node.addEventListener("click", () => {
+  if (block.is_broken_ref) {
+    node.classList.add("is-broken-ref");
+    iconEl.textContent = "⚠";
+    titleEl.textContent = block.title || "삭제된 페이지";
+    node.setAttribute("aria-label", `삭제된 페이지: ${titleEl.textContent}`);
+    node.setAttribute("aria-disabled", "true");
+    node.removeAttribute("tabindex");
+    return node;
+  }
+
+  node.setAttribute("tabindex", "0");
+  node.setAttribute("aria-label", `페이지로 이동: ${titleEl.textContent}`);
+
+  function navigate() {
     if (callbacks.navigateTo) callbacks.navigateTo(block.document_id);
+  }
+
+  node.addEventListener("click", navigate);
+  node.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      navigate();
+    }
   });
 
   return node;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -9,6 +9,7 @@ import {
   apiCreateBlock,
   apiMoveBlock,
 } from "./api.js";
+import { openPagePickerModal } from "./pagePickerModal.js";
 import { callbacks, renderBlock, renderDocument, focusBlock } from "./blockRenderers.js";
 import { addDocumentItem, closeAllMenus, setActiveItem, enterInlineEdit } from "./documentList.js";
 import { initSidebar } from "./sidebar.js";
@@ -154,8 +155,29 @@ async function initGallery() {
   async function loadDocument(documentId, { focusBlockId = null } = {}) {
     activeDocId = documentId;
 
+    /**
+     * Resolve page block creation parameters using the picker modal.
+     * Returns { targetDocumentId } where null means "create new page".
+     * Returns null when the user dismisses the modal without selecting.
+     * @param {HTMLElement} anchorEl
+     */
+    async function pickPageTarget(anchorEl) {
+      const choice = await openPagePickerModal(anchorEl, activeDocId);
+      if (!choice) return null;
+      return { targetDocumentId: choice.action === 'reference' ? choice.documentId : null };
+    }
+
     callbacks.addBlockAfter = async (type, afterBlockId, parentBlockId = null) => {
-      const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId);
+      let targetDocumentId = null;
+      if (type === 'page') {
+        const afterWrapper = document.querySelector(`[data-block-id="${afterBlockId}"]`);
+        const anchorEl = afterWrapper ?? root;
+        const pick = await pickPageTarget(anchorEl);
+        if (pick === null) return;
+        targetDocumentId = pick.targetDocumentId;
+      }
+
+      const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId, targetDocumentId);
       const afterWrapper = document.querySelector(`[data-block-id="${afterBlockId}"]`);
       if (afterWrapper) {
         const newWrapper = renderBlock(newBlock, parentBlockId);
@@ -174,7 +196,18 @@ async function initGallery() {
     };
 
     const addBlock = async (type, parentBlockId = null) => {
-      const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId);
+      let targetDocumentId = null;
+      if (type === 'page') {
+        const containerEl = parentBlockId
+          ? document.querySelector(`[data-block-id="${parentBlockId}"] [data-block-children]`)
+          : root;
+        const anchorEl = containerEl?.lastElementChild ?? root;
+        const pick = await pickPageTarget(anchorEl);
+        if (pick === null) return;
+        targetDocumentId = pick.targetDocumentId;
+      }
+
+      const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId, targetDocumentId);
       const containerEl = parentBlockId
         ? document.querySelector(`[data-block-id="${parentBlockId}"] [data-block-children]`)
         : root;

--- a/static/js/pagePickerModal.js
+++ b/static/js/pagePickerModal.js
@@ -19,6 +19,12 @@ function flattenDocs(docs, depth = 0) {
   return result;
 }
 
+// Module-level reference to the active modal's close function.
+// Ensures at most one modal is open at a time and that any previous Promise
+// always resolves (preventing leaks when openPagePickerModal is called again
+// before the previous modal is dismissed).
+let _activeClose = null;
+
 /**
  * Open the page picker modal anchored below anchorEl.
  * @param {HTMLElement} anchorEl
@@ -26,6 +32,12 @@ function flattenDocs(docs, depth = 0) {
  * @returns {Promise<{action:'new'}|{action:'reference', documentId:string}|null>}
  */
 export function openPagePickerModal(anchorEl, excludeDocumentId = null) {
+  // Resolve and remove any previously open modal so its Promise never hangs.
+  if (_activeClose) {
+    _activeClose(null);
+    _activeClose = null;
+  }
+
   return new Promise((resolve) => {
     document.querySelectorAll('.page-picker-modal').forEach((m) => m.remove());
 
@@ -37,10 +49,13 @@ export function openPagePickerModal(anchorEl, excludeDocumentId = null) {
     let removeOutsideListener = () => {};
 
     function close(result) {
+      _activeClose = null;
       modal.remove();
       removeOutsideListener();
       resolve(result ?? null);
     }
+
+    _activeClose = close;
 
     // ── 새 페이지 생성 button ─────────────────────────────────────────────────
     const newBtn = document.createElement('button');

--- a/static/js/pagePickerModal.js
+++ b/static/js/pagePickerModal.js
@@ -1,0 +1,155 @@
+// ── Page picker modal ─────────────────────────────────────────────────────────
+// Shown when the user selects the "페이지" block type.
+// Resolves with { action: 'new' } or { action: 'reference', documentId } or null (dismissed).
+
+import { fetchDocuments } from "./api.js";
+
+/**
+ * Flatten a nested document tree into a single array for display.
+ * @param {Array} docs - Tree from fetchDocuments()
+ * @param {number} depth
+ * @returns {Array<{id, title, depth}>}
+ */
+function flattenDocs(docs, depth = 0) {
+  const result = [];
+  for (const doc of docs) {
+    result.push({ id: doc.id, title: doc.title, depth });
+    if (doc.children?.length) result.push(...flattenDocs(doc.children, depth + 1));
+  }
+  return result;
+}
+
+/**
+ * Open the page picker modal anchored below anchorEl.
+ * @param {HTMLElement} anchorEl
+ * @param {string|null} excludeDocumentId - Current document to hide from the list
+ * @returns {Promise<{action:'new'}|{action:'reference', documentId:string}|null>}
+ */
+export function openPagePickerModal(anchorEl, excludeDocumentId = null) {
+  return new Promise((resolve) => {
+    document.querySelectorAll('.page-picker-modal').forEach((m) => m.remove());
+
+    const modal = document.createElement('div');
+    modal.className = 'page-picker-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-label', '페이지 블록 추가');
+
+    let removeOutsideListener = () => {};
+
+    function close(result) {
+      modal.remove();
+      removeOutsideListener();
+      resolve(result ?? null);
+    }
+
+    // ── 새 페이지 생성 button ─────────────────────────────────────────────────
+    const newBtn = document.createElement('button');
+    newBtn.type = 'button';
+    newBtn.className = 'page-picker-option';
+    newBtn.innerHTML = '<span class="page-picker-icon">＋</span>새 페이지 생성';
+    newBtn.addEventListener('mousedown', (e) => e.preventDefault());
+    newBtn.addEventListener('click', () => close({ action: 'new' }));
+    modal.appendChild(newBtn);
+
+    // ── 기존 페이지 참조 section ──────────────────────────────────────────────
+    const divider = document.createElement('div');
+    divider.className = 'page-picker-divider';
+    modal.appendChild(divider);
+
+    const searchInput = document.createElement('input');
+    searchInput.type = 'text';
+    searchInput.className = 'page-picker-search';
+    searchInput.placeholder = '페이지 검색...';
+    searchInput.setAttribute('aria-label', '페이지 검색');
+    modal.appendChild(searchInput);
+
+    const listEl = document.createElement('ul');
+    listEl.className = 'page-picker-list';
+    listEl.setAttribute('role', 'listbox');
+    listEl.setAttribute('aria-label', '페이지 목록');
+    modal.appendChild(listEl);
+
+    let allDocs = [];
+
+    function renderList(query) {
+      const q = query.trim().toLowerCase();
+      const filtered = q ? allDocs.filter((d) => d.title.toLowerCase().includes(q)) : allDocs;
+      listEl.innerHTML = '';
+
+      if (filtered.length === 0) {
+        const empty = document.createElement('li');
+        empty.className = 'page-picker-empty';
+        empty.textContent = '검색 결과 없음';
+        listEl.appendChild(empty);
+        return;
+      }
+
+      for (const doc of filtered) {
+        const item = document.createElement('li');
+        item.className = 'page-picker-item';
+        item.setAttribute('role', 'option');
+        item.setAttribute('tabindex', '0');
+        item.setAttribute('aria-label', doc.title || '제목 없음');
+
+        const indent = document.createElement('span');
+        indent.className = 'page-picker-indent';
+        indent.style.paddingLeft = `${doc.depth * 12}px`;
+
+        const icon = document.createElement('span');
+        icon.className = 'page-picker-item-icon';
+        icon.setAttribute('aria-hidden', 'true');
+        icon.textContent = '⊔';
+
+        const titleSpan = document.createElement('span');
+        titleSpan.className = 'page-picker-item-title';
+        titleSpan.textContent = doc.title || '제목 없음';
+
+        item.appendChild(indent);
+        item.appendChild(icon);
+        item.appendChild(titleSpan);
+
+        function select() {
+          close({ action: 'reference', documentId: doc.id });
+        }
+
+        item.addEventListener('mousedown', (e) => e.preventDefault());
+        item.addEventListener('click', select);
+        item.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(); }
+        });
+
+        listEl.appendChild(item);
+      }
+    }
+
+    // Fetch document list asynchronously while modal is visible
+    fetchDocuments()
+      .then((tree) => {
+        allDocs = flattenDocs(tree).filter((d) => d.id !== excludeDocumentId);
+        renderList(searchInput.value);
+      })
+      .catch(() => {
+        const err = document.createElement('li');
+        err.className = 'page-picker-empty';
+        err.textContent = '문서 목록을 불러오지 못했습니다.';
+        listEl.appendChild(err);
+      });
+
+    searchInput.addEventListener('input', () => renderList(searchInput.value));
+    searchInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') close(null);
+    });
+
+    anchorEl.after(modal);
+    searchInput.focus();
+
+    setTimeout(() => {
+      if (!modal.isConnected) return;
+      function onOutside(e) {
+        if (!modal.contains(e.target)) close(null);
+      }
+      document.addEventListener('click', onOutside, true);
+      removeOutsideListener = () => document.removeEventListener('click', onOutside, true);
+    }, 0);
+  });
+}

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -11,7 +11,7 @@
 
 
 <template id="page-block-template">
-  <button type="button" class="notion-block notion-page" tabindex="0">
+  <button type="button" class="notion-block notion-page">
     <span class="page-block-icon" aria-hidden="true">⤷</span>
     <span class="page-block-title"></span>
   </button>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -11,7 +11,7 @@
 
 
 <template id="page-block-template">
-  <button type="button" class="notion-block notion-page">
+  <button type="button" class="notion-block notion-page" tabindex="0">
     <span class="page-block-icon" aria-hidden="true">⤷</span>
     <span class="page-block-title"></span>
   </button>


### PR DESCRIPTION
## Summary

- 배경: 페이지 블록 생성 시 새 문서만 자동 생성되어 기존 문서를 참조 블록으로 연결할 수 없었음
- 목적: 페이지 블록 생성 단계에서 새 페이지/기존 페이지 참조를 선택할 수 있게 하고, 참조 블록 클릭 시 대상 페이지로 이동하며 깨진 참조도 안전하게 처리

## Changes

- **[모델]** `PageBlock`에 `is_reference`, `is_broken_ref` 필드 추가
- **[리포지터리]** `create_block`: `target_document_id` 파라미터로 기존 문서를 참조하는 페이지 블록 생성 지원
- **[리포지터리]** `delete_block`: `is_reference=True` 블록 삭제 시 대상 문서의 parent 계층 보존 (기존 own 페이지 동작은 유지)
- **[리포지터리]** `get_document`: page 블록 로드 시 대상 문서가 없으면 `is_broken_ref=True` 자동 감지
- **[라우터]** `BlockCreate` 스키마에 `target_document_id` 필드 추가, `page` 타입 외 사용 시 422 반환
- **[api.js]** `apiCreateBlock`에 `targetDocumentId` 파라미터 추가
- **[pagePickerModal.js]** 신규: 새 페이지 생성 / 기존 페이지 참조 선택 모달. 제목 기반 실시간 검색, 계층 깊이 시각화, 키보드(Escape) 닫기 지원
- **[pageBlock.js]** 깨진 참조 시 ⚠ 아이콘 + 취소선 UI, `aria-disabled` 처리. 정상 블록에 `tabindex="0"`, `aria-label`, Enter/Space 키 이동 지원
- **[main.js]** `addBlock`, `addBlockAfter` 양쪽에서 `page` 타입 선택 시 picker 모달 흐름 연결. 모달 취소 시 블록 미생성
- **[style.css]** `.page-picker-modal` 및 `.notion-page.is-broken-ref` 스타일 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 새 페이지 생성: 팔레트에서 페이지 선택 → picker 모달 → "새 페이지 생성" → 사이드바에 자식 문서 추가됨
- [x] 기존 페이지 참조: picker 모달 → "기존 페이지 참조" → 검색/선택 → 참조 블록 생성 → 클릭 시 해당 페이지로 이동
- [x] 참조 블록 삭제 시 대상 문서 parent 계층 유지 확인
- [x] 대상 문서 삭제 후 페이지 블록 재로드 시 깨진 참조 UI 표시 확인
- [x] Enter/Space 키로 페이지 이동 확인
- [x] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `delete_block`의 `is_reference` 분기 — 기존 own 페이지 promote 로직이 참조 블록 삭제 시 동작하지 않는지 (`is_reference` 플래그 신뢰성)
- `pagePickerModal.js`의 외부 클릭 닫기 타이밍 (0ms setTimeout guard) — `blockPalette.js`와 동일한 패턴을 따름

Closes #41