### PR TITLE
[FEAT#30] DB 블록 — Row를 독립 페이지로 열기 및 사이드바 트리 구조화

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -21,14 +21,18 @@ _DB_FILE = _BASE_DIR / "data" / "blocks.sqlite3"
 def _migrate(engine: Engine) -> None:
   """Run additive schema migrations that create_all cannot handle."""
   with engine.connect() as conn:
-    try:
-      conn.execute(text("ALTER TABLE documents ADD COLUMN parent_id TEXT"))
-      conn.commit()
-    except OperationalError as e:
-      # SQLite raises OperationalError("duplicate column name") when the column
-      # already exists — that is the only expected error here.
-      if "duplicate column name" not in str(e).lower():
-        raise
+    for ddl in (
+      "ALTER TABLE documents ADD COLUMN parent_id TEXT",
+      "ALTER TABLE documents ADD COLUMN source_block_id TEXT",
+    ):
+      try:
+        conn.execute(text(ddl))
+        conn.commit()
+      except OperationalError as e:
+        # SQLite raises OperationalError("duplicate column name") when the column
+        # already exists — that is the only expected error here.
+        if "duplicate column name" not in str(e).lower():
+          raise
 
 
 @functools.cache

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -115,6 +115,7 @@ class DatabaseBlock(BlockBase):
 
   type: Literal["database"]
   title: str = ""
+  color: Literal["default", "gray", "brown", "orange", "yellow", "green", "blue", "purple", "pink", "red"] = "default"
   columns: list[ColumnSchema] = Field(default_factory=list)
   rows: list[DbRowBlock] = Field(default_factory=list)  # populated at query time
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -89,10 +89,66 @@ class PageBlock(BlockBase):
   is_broken_ref: bool = False  # True when the target document no longer exists
 
 
+# ── Database block types ───────────────────────────────────────────────────────
+
+class ColumnSchema(BaseModel):
+  """Schema definition for a single database column."""
+
+  id: str
+  name: str
+  type: Literal["text", "number", "select", "checkbox"] = "text"
+  options: list[str] = Field(default_factory=list)  # for select type
+
+
+class DbRowBlock(PageBlock):
+  """Database row block — extends PageBlock so each row is also a page.
+
+  Properties map column IDs to cell values.
+  """
+
+  type: Literal["db_row"]
+  properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class DatabaseBlock(BlockBase):
+  """Database block — renders as a table whose rows are pages."""
+
+  type: Literal["database"]
+  title: str = ""
+  schema: list[ColumnSchema] = Field(default_factory=list)
+  rows: list[DbRowBlock] = Field(default_factory=list)  # populated at query time
+
+
+# ── Discriminated union of all block types ─────────────────────────────────────
+
 Block = Annotated[
-  TextBlock | ImageBlock | ToggleBlock | QuoteBlock | CodeBlock | CalloutBlock | DividerBlock | PageBlock,
+  TextBlock
+  | ImageBlock
+  | ToggleBlock
+  | QuoteBlock
+  | CodeBlock
+  | CalloutBlock
+  | DividerBlock
+  | PageBlock
+  | DbRowBlock
+  | DatabaseBlock,
   Field(discriminator="type"),
 ]
+
+
+# ── Database row page context ──────────────────────────────────────────────────
+
+class DbContext(BaseModel):
+  """Attached to a BlockDocument when that document is a database row page.
+
+  Provides the schema from the parent DatabaseBlock so the page can render
+  editable property fields below the title.
+  """
+
+  block_id: str       # the db_row block id
+  db_block_id: str    # the parent DatabaseBlock id
+  schema: list[ColumnSchema]
+  properties: dict[str, Any]
 
 
 class BlockDocument(BaseModel):
@@ -102,3 +158,4 @@ class BlockDocument(BaseModel):
   title: str
   subtitle: str = ""
   blocks: list[Block]
+  db_context: DbContext | None = None

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -115,7 +115,7 @@ class DatabaseBlock(BlockBase):
 
   type: Literal["database"]
   title: str = ""
-  schema: list[ColumnSchema] = Field(default_factory=list)
+  columns: list[ColumnSchema] = Field(default_factory=list)
   rows: list[DbRowBlock] = Field(default_factory=list)  # populated at query time
 
 
@@ -141,13 +141,13 @@ Block = Annotated[
 class DbContext(BaseModel):
   """Attached to a BlockDocument when that document is a database row page.
 
-  Provides the schema from the parent DatabaseBlock so the page can render
-  editable property fields below the title.
+  Provides the column schema from the parent DatabaseBlock so the page can
+  render editable property fields below the title.
   """
 
   block_id: str       # the db_row block id
   db_block_id: str    # the parent DatabaseBlock id
-  schema: list[ColumnSchema]
+  columns: list[ColumnSchema]
   properties: dict[str, Any]
 
 

--- a/app/models/orm.py
+++ b/app/models/orm.py
@@ -15,6 +15,8 @@ class DocumentRow(Base):
   title: Mapped[str] = mapped_column(String, nullable=False)
   subtitle: Mapped[str] = mapped_column(String, nullable=False, default="")
   parent_id: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
+  # db_row 블록이 생성한 페이지임을 표시 — 해당 db_row 블록의 id
+  source_block_id: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
 
   blocks: Mapped[list[BlockRow]] = relationship(
     back_populates="document",

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -388,13 +388,16 @@ class SQLiteBlockRepository:
       return None
 
     if parent_block_id is not None:
-      parent_exists = self._session.execute(
-        select(BlockRow.id).where(
+      parent_block = self._session.execute(
+        select(BlockRow.id, BlockRow.type).where(
           BlockRow.id == parent_block_id,
           BlockRow.document_id == document_id,
         )
-      ).scalar_one_or_none()
-      if parent_exists is None:
+      ).one_or_none()
+      if parent_block is None:
+        return None
+      # db_row는 반드시 database 블록 아래에만 생성 가능
+      if block_type == "db_row" and parent_block.type != "database":
         return None
 
     child_doc: dict[str, Any] | None = None

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -366,7 +366,7 @@ class SQLiteBlockRepository:
 
     # ── Database block ────────────────────────────────────────────────────────
     elif block_type == "database":
-      default_content = {"title": "", "columns": []}
+      default_content = {"title": "", "color": "default", "columns": []}
 
     # ── db_row block: always creates a child document ─────────────────────────
     elif block_type == "db_row":

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -12,6 +12,10 @@ from app.models.blocks import (
   Block,
   BlockDocument,
   CalloutBlock,
+  ColumnSchema,
+  DatabaseBlock,
+  DbContext,
+  DbRowBlock,
   DividerBlock,
   PageBlock,
   QuoteBlock,
@@ -44,9 +48,13 @@ class SQLiteBlockRepository:
 
     Each root-level document has a ``children`` list; children are sorted
     alphabetically and may themselves contain further children.
+    Documents that are db_row pages (source_block_id set) are excluded from the
+    sidebar tree — they are accessed by opening the row from within the database block.
     """
     rows = self._session.execute(
-      select(DocumentRow).order_by(DocumentRow.title)
+      select(DocumentRow)
+      .where(DocumentRow.source_block_id.is_(None))
+      .order_by(DocumentRow.title)
     ).scalars().all()
 
     all_docs: list[dict] = [
@@ -89,7 +97,7 @@ class SQLiteBlockRepository:
     page_doc_ids = list({
       item["document_id"]
       for item in parsed_blocks
-      if item["type"] == "page" and "document_id" in item
+      if item["type"] in ("page", "db_row") and "document_id" in item
     })
     doc_titles: dict[str, str] = {}
     if page_doc_ids:
@@ -130,15 +138,100 @@ class SQLiteBlockRepository:
             "title": "" if is_broken else doc_titles.get(doc_id, ""),
             "is_broken_ref": is_broken,
           }))
+        elif item["type"] == "database":
+          nodes.append(self._build_database_block(item))
+        elif item["type"] == "db_row":
+          # db_row는 database 블록 내부에서만 등장 (build_database_block 처리)
+          # 최상위에 고아로 있는 경우 무시
+          pass
         else:
           nodes.append(self._block_adapter.validate_python(item))
       return nodes
+
+    # ── db_context: 이 페이지가 db_row 페이지인지 확인 ────────────────────────
+    db_context: DbContext | None = None
+    if doc_row.source_block_id:
+      db_context = self._build_db_context(doc_row.source_block_id)
 
     return BlockDocument(
       id=doc_row.id,
       title=doc_row.title,
       subtitle=doc_row.subtitle,
       blocks=build_nodes(None),
+      db_context=db_context,
+    )
+
+  def _build_database_block(self, item: dict[str, Any]) -> DatabaseBlock:
+    """DatabaseBlock을 조립: 자식 db_row 블록들을 rows로 채워 반환."""
+    db_block_id = item["id"]
+    schema_raw = item.get("schema", [])
+    schema = [ColumnSchema.model_validate(c) for c in schema_raw]
+
+    row_blocks = self._session.execute(
+      select(BlockRow)
+      .where(
+        BlockRow.parent_block_id == db_block_id,
+        BlockRow.type == "db_row",
+      )
+      .order_by(BlockRow.position.asc())
+    ).scalars().all()
+
+    # 행 문서 제목 일괄 조회
+    row_doc_ids = [json.loads(r.content_json).get("document_id", "") for r in row_blocks]
+    valid_ids = [did for did in row_doc_ids if did]
+    title_map: dict[str, str] = {}
+    if valid_ids:
+      title_rows = self._session.execute(
+        select(DocumentRow.id, DocumentRow.title).where(DocumentRow.id.in_(valid_ids))
+      ).all()
+      title_map = {r.id: r.title for r in title_rows}
+
+    rows: list[DbRowBlock] = []
+    for rb in row_blocks:
+      content = json.loads(rb.content_json)
+      doc_id = content.get("document_id", "")
+      is_broken = bool(doc_id) and doc_id not in title_map
+      rows.append(DbRowBlock.model_validate({
+        "id": rb.id,
+        "type": "db_row",
+        "document_id": doc_id,
+        "title": "" if is_broken else title_map.get(doc_id, ""),
+        "is_reference": False,
+        "is_broken_ref": is_broken,
+        "properties": content.get("properties", {}),
+      }))
+
+    return DatabaseBlock.model_validate({
+      **item,
+      "schema": schema,
+      "rows": rows,
+    })
+
+  def _build_db_context(self, db_row_block_id: str) -> DbContext | None:
+    """db_row 블록 id로 DbContext를 조립. 블록이 없으면 None 반환."""
+    row_block = self._session.get(BlockRow, db_row_block_id)
+    if row_block is None or row_block.type != "db_row":
+      return None
+
+    content = json.loads(row_block.content_json)
+    properties = content.get("properties", {})
+
+    # 부모 DatabaseBlock 조회
+    db_block_id = row_block.parent_block_id
+    if db_block_id is None:
+      return None
+    db_block = self._session.get(BlockRow, db_block_id)
+    if db_block is None or db_block.type != "database":
+      return None
+
+    db_content = json.loads(db_block.content_json)
+    schema = [ColumnSchema.model_validate(c) for c in db_content.get("schema", [])]
+
+    return DbContext(
+      block_id=db_row_block_id,
+      db_block_id=db_block_id,
+      schema=schema,
+      properties=properties,
     )
 
   def create_document(self) -> dict:
@@ -159,7 +252,7 @@ class SQLiteBlockRepository:
     self._session.commit()
     return data
 
-  def _build_child_document_row(self, parent_id: str) -> dict:
+  def _build_child_document_row(self, parent_id: str, source_block_id: str | None = None) -> dict:
     """Add a child DocumentRow to the session without committing.
 
     Callers are responsible for the commit so that the operation can be
@@ -167,7 +260,13 @@ class SQLiteBlockRepository:
     """
     doc_id = str(uuid.uuid4())
     title = "새 문서"
-    self._session.add(DocumentRow(id=doc_id, title=title, subtitle="", parent_id=parent_id))
+    self._session.add(DocumentRow(
+      id=doc_id,
+      title=title,
+      subtitle="",
+      parent_id=parent_id,
+      source_block_id=source_block_id,
+    ))
     return {"id": doc_id, "title": title, "subtitle": "", "parent_id": parent_id, "children": []}
 
   def _is_descendant(self, ancestor_id: str, candidate_id: str) -> bool:
@@ -249,10 +348,11 @@ class SQLiteBlockRepository:
       if parent_exists is None:
         return None
 
+    child_doc: dict[str, Any] | None = None
+
     # ── Page block: link to existing or auto-create a child document ─────────
     if block_type == "page":
       if target_document_id is not None:
-        # Reference an existing document without changing its parent.
         if self._session.get(DocumentRow, target_document_id) is None:
           return None
         default_content: dict[str, Any] = {
@@ -261,10 +361,59 @@ class SQLiteBlockRepository:
         }
         child_doc = None
       else:
-        # Use _build_child_document_row (no commit) so both the new document and
-        # the page block are committed together below, keeping the DB consistent.
         child_doc = self._build_child_document_row(document_id)
         default_content = {"document_id": child_doc["id"], "is_reference": False}
+
+    # ── Database block ────────────────────────────────────────────────────────
+    elif block_type == "database":
+      default_content = {"title": "", "schema": []}
+
+    # ── db_row block: always creates a child document ─────────────────────────
+    elif block_type == "db_row":
+      if parent_block_id is None:
+        return None  # db_row는 반드시 database 블록의 자식이어야 함
+      # db_row 블록 id를 미리 생성해 두어야 source_block_id에 연결할 수 있음
+      block_id = str(uuid.uuid4())
+      child_doc = self._build_child_document_row(document_id, source_block_id=block_id)
+      default_content = {
+        "document_id": child_doc["id"],
+        "is_reference": False,
+        "properties": {},
+      }
+      # 나머지 로직(position 계산 / BlockRow 추가)을 아래에서 계속 처리하기 위해
+      # block_id를 미리 확정한다
+      parent_filter = (
+        BlockRow.parent_block_id.is_(None)
+        if parent_block_id is None
+        else BlockRow.parent_block_id == parent_block_id
+      )
+      max_pos = self._session.execute(
+        select(func.coalesce(func.max(BlockRow.position), 0))
+        .where(BlockRow.document_id == document_id, parent_filter)
+      ).scalar_one()
+      self._session.add(BlockRow(
+        id=block_id,
+        document_id=document_id,
+        parent_block_id=parent_block_id,
+        type=block_type,
+        position=max_pos + 1,
+        content_json=json.dumps(default_content, ensure_ascii=False),
+      ))
+      self._session.commit()
+
+      doc_title = child_doc["title"]
+      result: dict[str, Any] = {
+        "id": block_id,
+        "type": "db_row",
+        "document_id": child_doc["id"],
+        "title": doc_title,
+        "is_reference": False,
+        "is_broken_ref": False,
+        "properties": {},
+        "child_document": child_doc,
+      }
+      return result
+
     else:
       match block_type:
         case "text":
@@ -320,7 +469,7 @@ class SQLiteBlockRepository:
 
     self._session.commit()
 
-    result: dict[str, Any] = {"id": block_id, "type": block_type, **default_content}
+    result = {"id": block_id, "type": block_type, **default_content}
     if block_type == "page":
       if child_doc is not None:
         result["title"] = child_doc["title"]
@@ -337,8 +486,8 @@ class SQLiteBlockRepository:
   def delete_block(self, block_id: str) -> bool:
     """Delete a block and all its descendants. Compacts sibling positions after deletion.
 
-    For owned page blocks (is_reference=False) the referenced document is promoted
-    to root (parent_id cleared) so it is not orphaned.
+    For owned page/db_row blocks the referenced document is promoted to root
+    so it is not orphaned.
     Reference page blocks (is_reference=True) are removed without touching the
     target document's parent hierarchy.
     """
@@ -346,18 +495,34 @@ class SQLiteBlockRepository:
     if block_row is None:
       return False
 
-    # Promote referenced document to root only when this page block owns it.
-    # Reference blocks (is_reference=True) merely link to an existing document
-    # whose parent hierarchy must not be disturbed.
-    if block_row.type == "page":
+    # Promote referenced document to root only when this block owns it.
+    if block_row.type in ("page", "db_row"):
       content = json.loads(block_row.content_json)
       ref_doc_id = content.get("document_id")
       if ref_doc_id and not content.get("is_reference", False):
         self._session.execute(
           update(DocumentRow)
           .where(DocumentRow.id == ref_doc_id)
-          .values(parent_id=None)
+          .values(parent_id=None, source_block_id=None)
         )
+
+    # database 블록 삭제: 모든 db_row 자식의 문서를 root로 승격
+    if block_row.type == "database":
+      row_blocks = self._session.execute(
+        select(BlockRow).where(
+          BlockRow.parent_block_id == block_id,
+          BlockRow.type == "db_row",
+        )
+      ).scalars().all()
+      for rb in row_blocks:
+        content = json.loads(rb.content_json)
+        ref_doc_id = content.get("document_id")
+        if ref_doc_id:
+          self._session.execute(
+            update(DocumentRow)
+            .where(DocumentRow.id == ref_doc_id)
+            .values(parent_id=None, source_block_id=None)
+          )
 
     document_id = block_row.document_id
     parent_block_id = block_row.parent_block_id
@@ -501,6 +666,77 @@ class SQLiteBlockRepository:
 
     for i, sid in enumerate(sibling_ids, start=1):
       self._session.execute(update(BlockRow).where(BlockRow.id == sid).values(position=i))
+    self._session.commit()
+    return True
+
+  # ── Database-specific operations ───────────────────────────────────────────
+
+  def update_db_row_properties(self, block_id: str, properties: dict[str, Any]) -> bool:
+    """Replace all properties on a db_row block. Returns False if not found."""
+    block_row = self._session.get(BlockRow, block_id)
+    if block_row is None or block_row.type != "db_row":
+      return False
+    content = json.loads(block_row.content_json)
+    content["properties"] = properties
+    block_row.content_json = json.dumps(content, ensure_ascii=False)
+    self._session.commit()
+    return True
+
+  def add_db_column(self, db_block_id: str, column: dict[str, Any]) -> bool:
+    """Append a new column to the database block schema. Returns False if not found."""
+    block_row = self._session.get(BlockRow, db_block_id)
+    if block_row is None or block_row.type != "database":
+      return False
+    content = json.loads(block_row.content_json)
+    schema: list[dict] = content.get("schema", [])
+    schema.append(column)
+    content["schema"] = schema
+    block_row.content_json = json.dumps(content, ensure_ascii=False)
+    self._session.commit()
+    return True
+
+  def update_db_column(self, db_block_id: str, col_id: str, patch: dict[str, Any]) -> bool:
+    """Update a column's name/type/options in the schema. Returns False if not found."""
+    block_row = self._session.get(BlockRow, db_block_id)
+    if block_row is None or block_row.type != "database":
+      return False
+    content = json.loads(block_row.content_json)
+    schema: list[dict] = content.get("schema", [])
+    col = next((c for c in schema if c["id"] == col_id), None)
+    if col is None:
+      return False
+    col.update({k: v for k, v in patch.items() if v is not None})
+    block_row.content_json = json.dumps(content, ensure_ascii=False)
+    self._session.commit()
+    return True
+
+  def remove_db_column(self, db_block_id: str, col_id: str) -> bool:
+    """Remove a column from the database schema (and its values from all rows)."""
+    block_row = self._session.get(BlockRow, db_block_id)
+    if block_row is None or block_row.type != "database":
+      return False
+    content = json.loads(block_row.content_json)
+    schema: list[dict] = content.get("schema", [])
+    new_schema = [c for c in schema if c["id"] != col_id]
+    if len(new_schema) == len(schema):
+      return False  # column not found
+    content["schema"] = new_schema
+    block_row.content_json = json.dumps(content, ensure_ascii=False)
+
+    # Remove property values for this column from all db_row children
+    row_blocks = self._session.execute(
+      select(BlockRow).where(
+        BlockRow.parent_block_id == db_block_id,
+        BlockRow.type == "db_row",
+      )
+    ).scalars().all()
+    for rb in row_blocks:
+      row_content = json.loads(rb.content_json)
+      props: dict = row_content.get("properties", {})
+      props.pop(col_id, None)
+      row_content["properties"] = props
+      rb.content_json = json.dumps(row_content, ensure_ascii=False)
+
     self._session.commit()
     return True
 

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -44,32 +44,81 @@ class SQLiteBlockRepository:
     return self._session.get(DocumentRow, document_id) is not None
 
   def list_documents(self) -> list[dict]:
-    """Return all documents as a parent-child tree sorted by title.
+    """Return all documents as a parent-child tree, with database blocks as virtual folder nodes.
 
-    Each root-level document has a ``children`` list; children are sorted
-    alphabetically and may themselves contain further children.
-    Documents that are db_row pages (source_block_id set) are excluded from the
-    sidebar tree — they are accessed by opening the row from within the database block.
+    트리 구조:
+      Document
+        ├── Child Page          (page block 자식 문서)
+        └── [db:block_id]       (is_database=True 가상 노드 — database 블록)
+              └── db_row 문서   (is_db_row=True)
+
+    db_row 문서의 parent_id는 "db:{database_block_id}" 형태로 가상 노드를 가리킨다.
     """
-    rows = self._session.execute(
-      select(DocumentRow)
-      .where(DocumentRow.source_block_id.is_(None))
-      .order_by(DocumentRow.title)
+    doc_rows = self._session.execute(
+      select(DocumentRow).order_by(DocumentRow.title)
     ).scalars().all()
 
-    all_docs: list[dict] = [
-      {"id": r.id, "title": r.title, "subtitle": r.subtitle, "parent_id": r.parent_id, "children": []}
-      for r in rows
-    ]
-    by_id = {d["id"]: d for d in all_docs}
-    roots: list[dict] = []
+    # ── database 블록 조회 ────────────────────────────────────────────────────
+    db_blocks = self._session.execute(
+      select(BlockRow).where(BlockRow.type == "database")
+    ).scalars().all()
 
-    for doc in all_docs:
-      pid = doc["parent_id"]
+    # db_row 블록 조회 (parent = database 블록)
+    db_block_ids = [b.id for b in db_blocks]
+    db_row_block_to_db: dict[str, str] = {}  # db_row_block_id → database_block_id
+    if db_block_ids:
+      row_blocks = self._session.execute(
+        select(BlockRow.id, BlockRow.parent_block_id).where(
+          BlockRow.type == "db_row",
+          BlockRow.parent_block_id.in_(db_block_ids),
+        )
+      ).all()
+      db_row_block_to_db = {rb.id: rb.parent_block_id for rb in row_blocks}
+
+    # source_block_id → database_block_id
+    doc_to_db: dict[str, str] = {}
+    for r in doc_rows:
+      if r.source_block_id and r.source_block_id in db_row_block_to_db:
+        doc_to_db[r.id] = db_row_block_to_db[r.source_block_id]
+
+    # ── 가상 database 노드 생성 ───────────────────────────────────────────────
+    db_virtual: dict[str, dict] = {}
+    for b in db_blocks:
+      content = json.loads(b.content_json)
+      node_id = f"db:{b.id}"
+      db_virtual[node_id] = {
+        "id": node_id,
+        "block_id": b.id,
+        "title": content.get("title") or "데이터베이스",
+        "is_database": True,
+        "parent_id": b.document_id,
+        "parent_doc_id": b.document_id,
+        "children": [],
+      }
+
+    # ── 문서 노드 생성 ─────────────────────────────────────────────────────────
+    all_items: list[dict] = list(db_virtual.values())
+    for r in doc_rows:
+      db_block_id = doc_to_db.get(r.id)
+      parent_ref = f"db:{db_block_id}" if db_block_id else r.parent_id
+      all_items.append({
+        "id": r.id,
+        "title": r.title,
+        "subtitle": r.subtitle,
+        "parent_id": parent_ref,
+        "is_db_row": db_block_id is not None,
+        "children": [],
+      })
+
+    # ── 트리 조립 ─────────────────────────────────────────────────────────────
+    by_id = {item["id"]: item for item in all_items}
+    roots: list[dict] = []
+    for item in all_items:
+      pid = item["parent_id"]
       if pid and pid in by_id:
-        by_id[pid]["children"].append(doc)
-      else:
-        roots.append(doc)
+        by_id[pid]["children"].append(item)
+      elif not item.get("is_db_row") and not item.get("is_database"):
+        roots.append(item)
 
     return roots
 
@@ -402,6 +451,8 @@ class SQLiteBlockRepository:
       self._session.commit()
 
       doc_title = child_doc["title"]
+      child_doc["is_db_row"] = True
+      child_doc["parent_sidebar_id"] = f"db:{parent_block_id}"
       result: dict[str, Any] = {
         "id": block_id,
         "type": "db_row",

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -164,7 +164,7 @@ class SQLiteBlockRepository:
   def _build_database_block(self, item: dict[str, Any]) -> DatabaseBlock:
     """DatabaseBlock을 조립: 자식 db_row 블록들을 rows로 채워 반환."""
     db_block_id = item["id"]
-    schema_raw = item.get("schema", [])
+    schema_raw = item.get("columns", [])
     schema = [ColumnSchema.model_validate(c) for c in schema_raw]
 
     row_blocks = self._session.execute(
@@ -203,7 +203,7 @@ class SQLiteBlockRepository:
 
     return DatabaseBlock.model_validate({
       **item,
-      "schema": schema,
+      "columns": schema,
       "rows": rows,
     })
 
@@ -225,7 +225,7 @@ class SQLiteBlockRepository:
       return None
 
     db_content = json.loads(db_block.content_json)
-    schema = [ColumnSchema.model_validate(c) for c in db_content.get("schema", [])]
+    schema = [ColumnSchema.model_validate(c) for c in db_content.get("columns", [])]
 
     return DbContext(
       block_id=db_row_block_id,
@@ -366,7 +366,7 @@ class SQLiteBlockRepository:
 
     # ── Database block ────────────────────────────────────────────────────────
     elif block_type == "database":
-      default_content = {"title": "", "schema": []}
+      default_content = {"title": "", "columns": []}
 
     # ── db_row block: always creates a child document ─────────────────────────
     elif block_type == "db_row":
@@ -683,26 +683,26 @@ class SQLiteBlockRepository:
     return True
 
   def add_db_column(self, db_block_id: str, column: dict[str, Any]) -> bool:
-    """Append a new column to the database block schema. Returns False if not found."""
+    """Append a new column to the database block. Returns False if not found."""
     block_row = self._session.get(BlockRow, db_block_id)
     if block_row is None or block_row.type != "database":
       return False
     content = json.loads(block_row.content_json)
-    schema: list[dict] = content.get("schema", [])
-    schema.append(column)
-    content["schema"] = schema
+    cols: list[dict] = content.get("columns", [])
+    cols.append(column)
+    content["columns"] = cols
     block_row.content_json = json.dumps(content, ensure_ascii=False)
     self._session.commit()
     return True
 
   def update_db_column(self, db_block_id: str, col_id: str, patch: dict[str, Any]) -> bool:
-    """Update a column's name/type/options in the schema. Returns False if not found."""
+    """Update a column's name/type/options. Returns False if not found."""
     block_row = self._session.get(BlockRow, db_block_id)
     if block_row is None or block_row.type != "database":
       return False
     content = json.loads(block_row.content_json)
-    schema: list[dict] = content.get("schema", [])
-    col = next((c for c in schema if c["id"] == col_id), None)
+    cols: list[dict] = content.get("columns", [])
+    col = next((c for c in cols if c["id"] == col_id), None)
     if col is None:
       return False
     col.update({k: v for k, v in patch.items() if v is not None})
@@ -711,16 +711,16 @@ class SQLiteBlockRepository:
     return True
 
   def remove_db_column(self, db_block_id: str, col_id: str) -> bool:
-    """Remove a column from the database schema (and its values from all rows)."""
+    """Remove a column and wipe its values from all rows."""
     block_row = self._session.get(BlockRow, db_block_id)
     if block_row is None or block_row.type != "database":
       return False
     content = json.loads(block_row.content_json)
-    schema: list[dict] = content.get("schema", [])
-    new_schema = [c for c in schema if c["id"] != col_id]
-    if len(new_schema) == len(schema):
+    cols: list[dict] = content.get("columns", [])
+    new_cols = [c for c in cols if c["id"] != col_id]
+    if len(new_cols) == len(cols):
       return False  # column not found
-    content["schema"] = new_schema
+    content["columns"] = new_cols
     block_row.content_json = json.dumps(content, ensure_ascii=False)
 
     # Remove property values for this column from all db_row children

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -230,7 +230,7 @@ class SQLiteBlockRepository:
     return DbContext(
       block_id=db_row_block_id,
       db_block_id=db_block_id,
-      schema=schema,
+      columns=schema,
       properties=properties,
     )
 

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -26,7 +26,9 @@ class BlockPatch(BaseModel):
   language: str | None = None
   # callout
   emoji: str | None = None
-  color: Literal["yellow", "blue", "green", "red", "gray"] | None = None
+  color: Literal["yellow", "blue", "green", "red", "gray", "default", "brown", "orange", "purple", "pink"] | None = None
+  # database
+  title: str | None = None
 
 
 class BlockPositionPatch(BaseModel):

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -24,11 +24,14 @@ class BlockPatch(BaseModel):
   # code
   code: str | None = None
   language: str | None = None
-  # callout
+  # callout (color은 callout 지원 색상만 허용)
   emoji: str | None = None
-  color: Literal["yellow", "blue", "green", "red", "gray", "default", "brown", "orange", "purple", "pink"] | None = None
-  # database
+  color: Literal["yellow", "blue", "green", "red", "gray"] | None = None
+
+
+class DatabaseBlockPatch(BaseModel):
   title: str | None = None
+  color: Literal["default", "gray", "brown", "orange", "yellow", "green", "blue", "purple", "pink", "red"] | None = None
 
 
 class BlockPositionPatch(BaseModel):

--- a/app/routers/database.py
+++ b/app/routers/database.py
@@ -4,7 +4,7 @@ import uuid
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/api/database", tags=["database"])
 class ColumnCreate(BaseModel):
   name: str
   type: Literal["text", "number", "select", "checkbox"] = "text"
-  options: list[str] = []
+  options: list[str] = Field(default_factory=list)
 
 
 class ColumnUpdate(BaseModel):
@@ -33,7 +33,7 @@ def add_column(
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict:
   """Add a new column to a database block's schema."""
-  col_id = str(uuid.uuid4())[:8]
+  col_id = str(uuid.uuid4())
   column: dict[str, Any] = {
     "id": col_id,
     "name": body.name,

--- a/app/routers/database.py
+++ b/app/routers/database.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel
+
+from app.dependencies import get_repository
+from app.repositories.sqlite_blocks import SQLiteBlockRepository
+
+router = APIRouter(prefix="/api/database", tags=["database"])
+
+
+# ── Schema management ──────────────────────────────────────────────────────────
+
+class ColumnCreate(BaseModel):
+  name: str
+  type: Literal["text", "number", "select", "checkbox"] = "text"
+  options: list[str] = []
+
+
+class ColumnUpdate(BaseModel):
+  name: str | None = None
+  type: Literal["text", "number", "select", "checkbox"] | None = None
+  options: list[str] | None = None
+
+
+@router.post("/blocks/{block_id}/schema/columns", status_code=201)
+def add_column(
+  block_id: str,
+  body: ColumnCreate,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict:
+  """Add a new column to a database block's schema."""
+  col_id = str(uuid.uuid4())[:8]
+  column: dict[str, Any] = {
+    "id": col_id,
+    "name": body.name,
+    "type": body.type,
+    "options": body.options,
+  }
+  if not repo.add_db_column(block_id, column):
+    raise HTTPException(status_code=404, detail="Database block not found")
+  return column
+
+
+@router.patch("/blocks/{block_id}/schema/columns/{col_id}")
+def update_column(
+  block_id: str,
+  col_id: str,
+  body: ColumnUpdate,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict[str, str]:
+  """Rename or change a column's type/options."""
+  patch = body.model_dump(exclude_unset=True, exclude_none=True)
+  if not patch:
+    raise HTTPException(status_code=422, detail="No fields to update")
+  if not repo.update_db_column(block_id, col_id, patch):
+    raise HTTPException(status_code=404, detail="Database block or column not found")
+  return {"block_id": block_id, "col_id": col_id}
+
+
+@router.delete("/blocks/{block_id}/schema/columns/{col_id}", status_code=204)
+def remove_column(
+  block_id: str,
+  col_id: str,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> Response:
+  """Remove a column from the database schema (and wipes its values from all rows)."""
+  if not repo.remove_db_column(block_id, col_id):
+    raise HTTPException(status_code=404, detail="Database block or column not found")
+  return Response(status_code=204)
+
+
+# ── Row properties ─────────────────────────────────────────────────────────────
+
+class PropertiesUpdate(BaseModel):
+  properties: dict[str, Any]
+
+
+@router.patch("/blocks/{block_id}/properties")
+def update_properties(
+  block_id: str,
+  body: PropertiesUpdate,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict[str, str]:
+  """Replace all property values on a db_row block."""
+  if not repo.update_db_row_properties(block_id, body.properties):
+    raise HTTPException(status_code=404, detail="db_row block not found")
+  return {"block_id": block_id}

--- a/app/routers/database.py
+++ b/app/routers/database.py
@@ -8,8 +8,26 @@ from pydantic import BaseModel, Field
 
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
+from app.routers.blocks import DatabaseBlockPatch
 
 router = APIRouter(prefix="/api/database", tags=["database"])
+
+
+# ── Database block meta patch ─────────────────────────────────────────────────
+
+@router.patch("/blocks/{block_id}")
+def patch_database_block(
+  block_id: str,
+  body: DatabaseBlockPatch,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict[str, str]:
+  """Update title or color of a database block."""
+  patch_data = body.model_dump(exclude_unset=True, exclude_none=True)
+  if not patch_data:
+    raise HTTPException(status_code=422, detail="No fields to update")
+  if not repo.update_block(block_id, patch_data):
+    raise HTTPException(status_code=404, detail="Database block not found")
+  return {"id": block_id}
 
 
 # ── Schema management ──────────────────────────────────────────────────────────

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -66,7 +66,7 @@ def update_document_title(
 
 
 class BlockCreate(BaseModel):
-  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "page"]
+  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "page", "database", "db_row"]
   parent_block_id: str | None = None
   # Only used when type="page": link to an existing document instead of creating a new one
   target_document_id: str | None = None

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.routers import blocks, documents, upload
+from app.routers import blocks, database, documents, upload
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -18,6 +18,7 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 app.include_router(documents.router)
 app.include_router(blocks.router)
+app.include_router(database.router)
 app.include_router(upload.router)
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1513,6 +1513,297 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   }
 }
 
+/* ── Database Block ──────────────────────────────────────────────────────── */
+
+.notion-database {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--panel);
+}
+
+.db-title-row {
+  padding: 0.6rem 0.75rem 0.4rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.db-title-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.db-title-input::placeholder {
+  color: var(--ink-soft);
+  font-weight: 400;
+}
+
+.db-table-wrap {
+  overflow-x: auto;
+}
+
+.db-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.db-th {
+  padding: 0.45rem 0.65rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+  background: var(--paper);
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  position: relative;
+}
+
+.db-th-open {
+  width: 32px;
+  padding: 0.45rem 0.4rem;
+}
+
+.db-th-title {
+  min-width: 160px;
+}
+
+.db-th-add {
+  width: 36px;
+  padding: 0.45rem 0.4rem;
+}
+
+.db-col-name {
+  cursor: pointer;
+  user-select: none;
+}
+
+.db-col-name:hover {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.db-col-remove-btn {
+  display: none;
+  border: none;
+  background: none;
+  color: var(--ink-soft);
+  cursor: pointer;
+  padding: 0 0.2rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  margin-left: 4px;
+}
+
+.db-th:hover .db-col-remove-btn {
+  display: inline;
+}
+
+.db-col-remove-btn:hover {
+  color: #e53e3e;
+}
+
+.db-add-col-btn {
+  border: none;
+  background: none;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0;
+  line-height: 1;
+}
+
+.db-add-col-btn:hover {
+  color: var(--accent);
+}
+
+.db-col-rename-input {
+  width: 100%;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0.15rem 0.3rem;
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  outline: none;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.db-row {
+  border-bottom: 1px solid var(--line);
+}
+
+.db-row:last-child {
+  border-bottom: none;
+}
+
+.db-row:hover {
+  background: var(--paper);
+}
+
+.db-row.is-broken-ref {
+  opacity: 0.5;
+}
+
+.db-td {
+  padding: 0.4rem 0.65rem;
+  vertical-align: middle;
+}
+
+.db-td-open {
+  width: 32px;
+  padding: 0.4rem 0.4rem;
+  text-align: center;
+}
+
+.db-td-title {
+  min-width: 160px;
+}
+
+.db-row-open-btn {
+  border: none;
+  background: none;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.db-row:hover .db-row-open-btn {
+  opacity: 1;
+}
+
+.db-row-open-btn:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.db-row-title {
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.db-row-title[style*="cursor"] {
+  color: var(--accent);
+}
+
+.db-row-title[style*="cursor"]:hover {
+  text-decoration: underline;
+}
+
+.db-cell-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--ink);
+  padding: 0;
+}
+
+.db-cell-input:focus {
+  background: var(--accent-soft);
+  border-radius: 3px;
+  padding: 0 4px;
+}
+
+.db-cell-checkbox {
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+
+.db-add-row-btn {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-top: 1px solid var(--line);
+  background: transparent;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.825rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.db-add-row-btn:hover {
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* ── DB row 페이지 속성 패널 ─────────────────────────────────────────────── */
+
+.page-properties {
+  max-width: 720px;
+  margin: 0 auto 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.db-prop-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 2rem;
+}
+
+.db-prop-label {
+  flex: 0 0 140px;
+  font-size: 0.825rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.db-prop-value {
+  flex: 1;
+}
+
+.db-prop-input {
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid transparent;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--ink);
+  padding: 0.15rem 0.2rem;
+  border-radius: 3px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.db-prop-input:focus {
+  border-bottom-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.db-prop-checkbox {
+  cursor: pointer;
+  accent-color: var(--accent);
+  width: 16px;
+  height: 16px;
+}
+
 @media (max-width: 920px) {
   .sidebar {
     position: static;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1518,17 +1518,28 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .notion-database {
   border: 1px solid var(--line);
   border-radius: 8px;
+  overflow: visible; /* 팔레트 드롭다운이 잘리지 않도록 */
+  background: #ffffff; /* 기본 흰색 — JS에서 인라인 스타일로 덮어씀 */
+}
+
+.notion-database > .db-table-wrap,
+.notion-database > .db-add-row-btn {
+  border-radius: 0 0 8px 8px;
   overflow: hidden;
-  background: var(--panel);
 }
 
 .db-title-row {
-  padding: 0.6rem 0.75rem 0.4rem;
+  padding: 0.5rem 0.75rem 0.4rem;
   border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  position: relative;
+  border-radius: 8px 8px 0 0;
 }
 
 .db-title-input {
-  width: 100%;
+  flex: 1;
   border: none;
   outline: none;
   background: transparent;
@@ -1536,11 +1547,70 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-size: 0.9rem;
   font-weight: 700;
   color: var(--ink);
+  min-width: 0;
 }
 
 .db-title-input::placeholder {
   color: var(--ink-soft);
   font-weight: 400;
+}
+
+/* ── 색상 버튼 & 팔레트 ──────────────────────────────────────────────────── */
+
+.db-color-btn {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  line-height: 1;
+}
+
+.db-title-row:hover .db-color-btn,
+.db-color-btn:focus {
+  opacity: 1;
+}
+
+.db-color-btn:hover {
+  background: var(--paper-deep);
+}
+
+.db-color-palette {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 300;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px -4px var(--shadow);
+  width: 196px;
+}
+
+.db-color-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.1s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+}
+
+.db-color-swatch:hover {
+  transform: scale(1.15);
+}
+
+.db-color-swatch.is-active {
+  border-color: var(--accent);
 }
 
 .db-table-wrap {
@@ -1559,7 +1629,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-weight: 600;
   font-size: 0.8rem;
   color: var(--ink-soft);
-  background: var(--paper);
+  background: rgba(0, 0, 0, 0.03); /* 블록 배경색 위에 살짝 어둡게 */
   border-bottom: 1px solid var(--line);
   white-space: nowrap;
   position: relative;
@@ -1645,7 +1715,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 }
 
 .db-row:hover {
-  background: var(--paper);
+  background: rgba(0, 0, 0, 0.03);
 }
 
 .db-row.is-broken-ref {
@@ -1739,7 +1809,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 }
 
 .db-add-row-btn:hover {
-  background: var(--paper);
+  background: rgba(0, 0, 0, 0.04);
   color: var(--ink);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1844,13 +1844,11 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .page-properties {
   max-width: 720px;
   margin: 0 auto 1.5rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--paper);
+  padding: 0 1rem;
+  border: none;
+  background: transparent;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
 }
 
 .db-prop-row {
@@ -1858,6 +1856,11 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   align-items: center;
   gap: 0.75rem;
   min-height: 2rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.db-prop-row:first-child {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .db-prop-label {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -218,6 +218,28 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-weight: 600;
 }
 
+.document-item-icon {
+  margin-right: 5px;
+  font-size: 0.75rem;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
+.document-item.is-database-node {
+  color: var(--ink-soft);
+  font-style: italic;
+  cursor: default;
+}
+
+.document-item.is-db-row {
+  color: var(--ink-soft);
+  font-size: 0.85rem;
+}
+
+.document-item.is-db-row.is-active {
+  color: var(--accent);
+}
+
 .document-title-input {
   flex: 1;
   min-width: 0;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1595,6 +1595,10 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   width: 196px;
 }
 
+.db-color-palette[hidden] {
+  display: none;
+}
+
 .db-color-swatch {
   width: 28px;
   height: 28px;

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -86,3 +86,40 @@ export async function apiMoveBlock(blockId, beforeBlockId) {
   });
   if (!res.ok) throw new Error('Failed to move block');
 }
+
+// ── Database API ──────────────────────────────────────────────────────────────
+
+export async function apiAddDbColumn(dbBlockId, name, type = 'text', options = []) {
+  const res = await fetch(`/api/database/blocks/${dbBlockId}/schema/columns`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, type, options }),
+  });
+  if (!res.ok) throw new Error('Failed to add column');
+  return res.json();
+}
+
+export async function apiUpdateDbColumn(dbBlockId, colId, patch) {
+  const res = await fetch(`/api/database/blocks/${dbBlockId}/schema/columns/${colId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error('Failed to update column');
+}
+
+export async function apiRemoveDbColumn(dbBlockId, colId) {
+  const res = await fetch(`/api/database/blocks/${dbBlockId}/schema/columns/${colId}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Failed to remove column');
+}
+
+export async function apiUpdateDbRowProperties(dbRowBlockId, properties) {
+  const res = await fetch(`/api/database/blocks/${dbRowBlockId}/properties`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ properties }),
+  });
+  if (!res.ok) throw new Error('Failed to update row properties');
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -123,3 +123,12 @@ export async function apiUpdateDbRowProperties(dbRowBlockId, properties) {
   });
   if (!res.ok) throw new Error('Failed to update row properties');
 }
+
+export async function apiPatchDatabaseBlock(dbBlockId, fields) {
+  const res = await fetch(`/api/database/blocks/${dbBlockId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(fields),
+  });
+  if (!res.ok) throw new Error('Failed to patch database block');
+}

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -11,6 +11,7 @@ export const BLOCK_PALETTE_ITEMS = [
   { type: 'callout', label: '콜아웃', icon: '💡' },
   { type: 'divider', label: '구분선', icon: '—' },
   { type: 'page', label: '페이지', icon: '⊔' },
+  { type: 'database', label: '데이터베이스', icon: '⊞' },
 ];
 
 /**

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -12,9 +12,10 @@ import * as quoteBlock from "./blocks/quoteBlock.js";
 import * as calloutBlock from "./blocks/calloutBlock.js";
 import * as dividerBlock from "./blocks/dividerBlock.js";
 import * as pageBlock from "./blocks/pageBlock.js";
+import * as databaseBlock from "./blocks/databaseBlock.js";
 
 // 블록 모듈 등록
-[textBlock, imageBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, pageBlock]
+[textBlock, imageBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, pageBlock, databaseBlock]
   .forEach((mod) => blockRegistry.register(mod));
 
 // Initialise singleton toolbar once

--- a/static/js/blockWrapper.js
+++ b/static/js/blockWrapper.js
@@ -39,9 +39,10 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
   moreMenu.className = 'block-more-menu';
   moreMenu.hidden = true;
 
-  // Type change section (only for non-page blocks)
+  // Type change section (only for non-page / non-database blocks)
   const isPageBlock = block.type === 'page';
-  if (!isPageBlock) {
+  const isDbBlock = block.type === 'database' || block.type === 'db_row';
+  if (!isPageBlock && !isDbBlock) {
     const sectionLabel = document.createElement('div');
     sectionLabel.className = 'block-menu-section-label';
     sectionLabel.textContent = '타입 변경';
@@ -126,8 +127,9 @@ export function wrapBlock(blockEl, block, parentBlockId = null, { addBlockAfter,
   deleteBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     moreMenu.hidden = true;
-    // Page block deletion also requires a sidebar refresh (referenced doc promoted to root)
-    const afterDelete = (block.type === 'page' && reloadSidebar)
+    // page / database / db_row 삭제 시 사이드바 갱신 필요
+    const needsSidebarRefresh = (block.type === 'page' || block.type === 'database' || block.type === 'db_row') && reloadSidebar;
+    const afterDelete = needsSidebarRefresh
       ? async () => { await reloadSidebar(); reloadDocument?.(); }
       : reloadDocument;
     showBlockDeleteConfirm(wrapper, block.id, afterDelete);

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -121,10 +121,12 @@ export function create(block, { callbacks = {} } = {}) {
 
   function openPalette() {
     colorPalette.hidden = false;
-    // 이 클릭 이벤트가 버블링되어 즉시 닫히지 않도록 다음 틱에 등록
+    // 다음 틱에 등록: 팔레트를 연 클릭 자체가 즉시 닫기를 트리거하지 않도록
     setTimeout(() => {
       if (!colorPalette.isConnected) return;
       function onOutside(e) {
+        // colorBtn 클릭은 여기서 처리하지 않음 — 버튼 핸들러가 toggle을 담당
+        if (colorBtn.contains(e.target)) return;
         if (!colorPalette.contains(e.target)) closePalette();
       }
       document.addEventListener("click", onOutside, true);

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -20,12 +20,39 @@ export const type = "database";
  * @param {object} opts.callbacks
  * @returns {HTMLElement}
  */
+// 사용 가능한 배경 색상 목록
+const DB_COLORS = [
+  { id: "default", label: "기본 (흰색)",  bg: "#ffffff" },
+  { id: "gray",    label: "회색",          bg: "#f1f1ef" },
+  { id: "brown",   label: "갈색",          bg: "#f4eeee" },
+  { id: "orange",  label: "주황",          bg: "#fbecdd" },
+  { id: "yellow",  label: "노랑",          bg: "#fbf3db" },
+  { id: "green",   label: "초록",          bg: "#edf3ec" },
+  { id: "blue",    label: "파랑",          bg: "#e7f0f8" },
+  { id: "purple",  label: "보라",          bg: "#f4f0f7" },
+  { id: "pink",    label: "분홍",          bg: "#f9eff3" },
+  { id: "red",     label: "빨강",          bg: "#fbe4e4" },
+];
+
+/**
+ * color id를 받아 .notion-database 요소에 배경색 인라인 스타일을 적용한다.
+ * @param {HTMLElement} el
+ * @param {string} colorId
+ */
+function applyColor(el, colorId) {
+  const found = DB_COLORS.find((c) => c.id === colorId) ?? DB_COLORS[0];
+  el.style.backgroundColor = found.bg;
+}
+
 export function create(block, { callbacks = {} } = {}) {
   const wrap = document.createElement("div");
   wrap.className = "notion-block notion-database";
   wrap.dataset.dbBlockId = block.id;
 
-  // ── 제목 ────────────────────────────────────────────────────────────────────
+  // 저장된 색상 적용 (없으면 기본 흰색)
+  applyColor(wrap, block.color ?? "default");
+
+  // ── 제목 + 색상 버튼 ────────────────────────────────────────────────────────
   const titleRow = document.createElement("div");
   titleRow.className = "db-title-row";
 
@@ -45,7 +72,60 @@ export function create(block, { callbacks = {} } = {}) {
     if (e.key === "Enter") titleInput.blur();
   });
 
+  // 색상 선택 버튼
+  const colorBtn = document.createElement("button");
+  colorBtn.type = "button";
+  colorBtn.className = "db-color-btn";
+  colorBtn.title = "배경 색상 변경";
+  colorBtn.textContent = "🎨";
+  colorBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggleColorPalette();
+  });
+
+  // 색상 팔레트 드롭다운
+  const colorPalette = document.createElement("div");
+  colorPalette.className = "db-color-palette";
+  colorPalette.hidden = true;
+
+  DB_COLORS.forEach((c) => {
+    const swatch = document.createElement("button");
+    swatch.type = "button";
+    swatch.className = "db-color-swatch";
+    swatch.title = c.label;
+    swatch.style.backgroundColor = c.bg;
+    if ((block.color ?? "default") === c.id) swatch.classList.add("is-active");
+
+    swatch.addEventListener("mousedown", (e) => e.preventDefault());
+    swatch.addEventListener("click", async () => {
+      block.color = c.id;
+      applyColor(wrap, c.id);
+      colorPalette.querySelectorAll(".db-color-swatch").forEach((s) => s.classList.remove("is-active"));
+      swatch.classList.add("is-active");
+      colorPalette.hidden = true;
+      try {
+        await apiPatchBlock(block.id, { color: c.id });
+      } catch (err) {
+        console.error("색상 저장 실패:", err);
+      }
+    });
+    colorPalette.appendChild(swatch);
+  });
+
+  function toggleColorPalette() {
+    colorPalette.hidden = !colorPalette.hidden;
+  }
+
+  // 팔레트 외부 클릭 시 닫기
+  document.addEventListener("click", (e) => {
+    if (!colorPalette.contains(e.target) && e.target !== colorBtn) {
+      colorPalette.hidden = true;
+    }
+  });
+
   titleRow.appendChild(titleInput);
+  titleRow.appendChild(colorBtn);
+  titleRow.appendChild(colorPalette);
   wrap.appendChild(titleRow);
 
   // ── 테이블 ──────────────────────────────────────────────────────────────────

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -1,0 +1,289 @@
+// ── Database Block ─────────────────────────────────────────────────────────────
+//
+// 테이블 형태로 렌더링되는 데이터베이스 블록.
+// 각 행(db_row)은 클릭 시 독립 페이지로 열린다.
+
+import {
+  apiAddDbColumn,
+  apiUpdateDbColumn,
+  apiRemoveDbColumn,
+  apiCreateBlock,
+  apiUpdateDbRowProperties,
+  apiPatchBlock,
+} from "../api.js";
+
+export const type = "database";
+
+/**
+ * @param {object} block  - DatabaseBlock 데이터
+ * @param {object} opts
+ * @param {object} opts.callbacks
+ * @returns {HTMLElement}
+ */
+export function create(block, { callbacks = {} } = {}) {
+  const wrap = document.createElement("div");
+  wrap.className = "notion-block notion-database";
+  wrap.dataset.dbBlockId = block.id;
+
+  // ── 제목 ────────────────────────────────────────────────────────────────────
+  const titleRow = document.createElement("div");
+  titleRow.className = "db-title-row";
+
+  const titleInput = document.createElement("input");
+  titleInput.type = "text";
+  titleInput.className = "db-title-input";
+  titleInput.value = block.title || "";
+  titleInput.placeholder = "데이터베이스 이름...";
+  titleInput.addEventListener("blur", async () => {
+    try {
+      await apiPatchBlock(block.id, { title: titleInput.value.trim() });
+    } catch (err) {
+      console.error("DB 제목 저장 실패:", err);
+    }
+  });
+  titleInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") titleInput.blur();
+  });
+
+  titleRow.appendChild(titleInput);
+  wrap.appendChild(titleRow);
+
+  // ── 테이블 ──────────────────────────────────────────────────────────────────
+  const tableWrap = document.createElement("div");
+  tableWrap.className = "db-table-wrap";
+
+  const table = document.createElement("table");
+  table.className = "db-table";
+
+  const thead = document.createElement("thead");
+  const tbody = document.createElement("tbody");
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+  wrap.appendChild(tableWrap);
+
+  // ── 새 행 추가 버튼 ──────────────────────────────────────────────────────────
+  const addRowBtn = document.createElement("button");
+  addRowBtn.type = "button";
+  addRowBtn.className = "db-add-row-btn";
+  addRowBtn.textContent = "+ 새 행";
+  addRowBtn.addEventListener("click", async () => {
+    if (!callbacks.addDbRow) return;
+    await callbacks.addDbRow(block.id);
+  });
+  wrap.appendChild(addRowBtn);
+
+  // ── 렌더 함수 ─────────────────────────────────────────────────────────────────
+  function render(schema, rows) {
+    renderHeader(schema);
+    renderRows(schema, rows);
+  }
+
+  function renderHeader(schema) {
+    thead.innerHTML = "";
+    const tr = document.createElement("tr");
+
+    // 열기 버튼 컬럼 (고정)
+    const thOpen = document.createElement("th");
+    thOpen.className = "db-th db-th-open";
+    tr.appendChild(thOpen);
+
+    // 이름(제목) 컬럼 (고정)
+    const thTitle = document.createElement("th");
+    thTitle.className = "db-th db-th-title";
+    thTitle.textContent = "이름";
+    tr.appendChild(thTitle);
+
+    // 스키마 컬럼들
+    schema.forEach((col) => {
+      const th = document.createElement("th");
+      th.className = "db-th";
+      th.dataset.colId = col.id;
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "db-col-name";
+      nameSpan.textContent = col.name;
+      nameSpan.title = "클릭하여 편집";
+      nameSpan.addEventListener("click", () => startColumnRename(th, nameSpan, col));
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "db-col-remove-btn";
+      removeBtn.textContent = "×";
+      removeBtn.title = "컬럼 삭제";
+      removeBtn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        if (!confirm(`"${col.name}" 컬럼을 삭제할까요? 모든 행의 해당 값도 삭제됩니다.`)) return;
+        try {
+          await apiRemoveDbColumn(block.id, col.id);
+          if (callbacks.reloadDocument) callbacks.reloadDocument();
+        } catch (err) {
+          console.error("컬럼 삭제 실패:", err);
+        }
+      });
+
+      th.appendChild(nameSpan);
+      th.appendChild(removeBtn);
+      tr.appendChild(th);
+    });
+
+    // + 컬럼 추가 버튼
+    const thAdd = document.createElement("th");
+    thAdd.className = "db-th db-th-add";
+    const addColBtn = document.createElement("button");
+    addColBtn.type = "button";
+    addColBtn.className = "db-add-col-btn";
+    addColBtn.textContent = "+";
+    addColBtn.title = "컬럼 추가";
+    addColBtn.addEventListener("click", () => promptAddColumn());
+    thAdd.appendChild(addColBtn);
+    tr.appendChild(thAdd);
+
+    thead.appendChild(tr);
+  }
+
+  function renderRows(schema, rows) {
+    tbody.innerHTML = "";
+    rows.forEach((row) => {
+      tbody.appendChild(createRowEl(schema, row));
+    });
+  }
+
+  function createRowEl(schema, row) {
+    const tr = document.createElement("tr");
+    tr.className = "db-row";
+    tr.dataset.rowBlockId = row.id;
+    tr.dataset.docId = row.document_id;
+
+    if (row.is_broken_ref) {
+      tr.classList.add("is-broken-ref");
+    }
+
+    // 페이지로 열기 버튼
+    const tdOpen = document.createElement("td");
+    tdOpen.className = "db-td db-td-open";
+    const openBtn = document.createElement("button");
+    openBtn.type = "button";
+    openBtn.className = "db-row-open-btn";
+    openBtn.title = "페이지로 열기";
+    openBtn.textContent = "⤷";
+    if (!row.is_broken_ref) {
+      openBtn.addEventListener("click", () => {
+        if (callbacks.navigateTo) callbacks.navigateTo(row.document_id);
+      });
+    }
+    tdOpen.appendChild(openBtn);
+    tr.appendChild(tdOpen);
+
+    // 이름(제목) 셀
+    const tdTitle = document.createElement("td");
+    tdTitle.className = "db-td db-td-title";
+    const titleEl = document.createElement("span");
+    titleEl.className = "db-row-title";
+    titleEl.textContent = row.is_broken_ref ? "삭제된 페이지" : (row.title || "제목 없음");
+    if (!row.is_broken_ref) {
+      titleEl.style.cursor = "pointer";
+      titleEl.addEventListener("click", () => {
+        if (callbacks.navigateTo) callbacks.navigateTo(row.document_id);
+      });
+    }
+    tdTitle.appendChild(titleEl);
+    tr.appendChild(tdTitle);
+
+    // 속성 셀들
+    schema.forEach((col) => {
+      const td = document.createElement("td");
+      td.className = "db-td";
+      td.dataset.colId = col.id;
+
+      if (!row.is_broken_ref) {
+        const input = createCellInput(col, row.properties?.[col.id] ?? "", async (newVal) => {
+          const props = { ...(row.properties || {}), [col.id]: newVal };
+          try {
+            await apiUpdateDbRowProperties(row.id, props);
+            row.properties = props;
+          } catch (err) {
+            console.error("속성 저장 실패:", err);
+          }
+        });
+        td.appendChild(input);
+      }
+
+      tr.appendChild(td);
+    });
+
+    return tr;
+  }
+
+  function createCellInput(col, value, onCommit) {
+    if (col.type === "checkbox") {
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.className = "db-cell-checkbox";
+      input.checked = value === true || value === "true";
+      input.addEventListener("change", () => onCommit(input.checked));
+      return input;
+    }
+
+    const input = document.createElement("input");
+    input.type = col.type === "number" ? "number" : "text";
+    input.className = "db-cell-input";
+    input.value = value ?? "";
+
+    let original = input.value;
+    input.addEventListener("focus", () => { original = input.value; });
+    input.addEventListener("blur", () => {
+      if (input.value !== original) onCommit(input.value);
+    });
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); input.blur(); }
+      if (e.key === "Escape") { input.value = original; input.blur(); }
+    });
+    return input;
+  }
+
+  function startColumnRename(thEl, nameSpan, col) {
+    if (thEl.querySelector(".db-col-rename-input")) return;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "db-col-rename-input";
+    input.value = col.name;
+    nameSpan.replaceWith(input);
+    input.focus();
+    input.select();
+
+    async function commit() {
+      const newName = input.value.trim() || col.name;
+      try {
+        await apiUpdateDbColumn(block.id, col.id, { name: newName });
+        col.name = newName;
+        if (callbacks.reloadDocument) callbacks.reloadDocument();
+      } catch (err) {
+        console.error("컬럼 이름 변경 실패:", err);
+        input.replaceWith(nameSpan);
+      }
+    }
+
+    input.addEventListener("blur", commit);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); input.blur(); }
+      if (e.key === "Escape") { input.replaceWith(nameSpan); }
+    });
+  }
+
+  async function promptAddColumn() {
+    const name = prompt("새 컬럼 이름:");
+    if (!name || !name.trim()) return;
+    try {
+      await apiAddDbColumn(block.id, name.trim());
+      if (callbacks.reloadDocument) callbacks.reloadDocument();
+    } catch (err) {
+      console.error("컬럼 추가 실패:", err);
+    }
+  }
+
+  // 최초 렌더
+  render(block.columns ?? [], block.rows ?? []);
+
+  return wrap;
+}

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -78,8 +78,7 @@ export function create(block, { callbacks = {} } = {}) {
   colorBtn.className = "db-color-btn";
   colorBtn.title = "배경 색상 변경";
   colorBtn.textContent = "🎨";
-  colorBtn.addEventListener("click", (e) => {
-    e.stopPropagation();
+  colorBtn.addEventListener("click", () => {
     toggleColorPalette();
   });
 
@@ -102,7 +101,7 @@ export function create(block, { callbacks = {} } = {}) {
       applyColor(wrap, c.id);
       colorPalette.querySelectorAll(".db-color-swatch").forEach((s) => s.classList.remove("is-active"));
       swatch.classList.add("is-active");
-      colorPalette.hidden = true;
+      closePalette();
       try {
         await apiPatchBlock(block.id, { color: c.id });
       } catch (err) {
@@ -112,16 +111,31 @@ export function create(block, { callbacks = {} } = {}) {
     colorPalette.appendChild(swatch);
   });
 
-  function toggleColorPalette() {
-    colorPalette.hidden = !colorPalette.hidden;
+  let removeOutsideListener = () => {};
+
+  function closePalette() {
+    colorPalette.hidden = true;
+    removeOutsideListener();
+    removeOutsideListener = () => {};
   }
 
-  // 팔레트 외부 클릭 시 닫기
-  document.addEventListener("click", (e) => {
-    if (!colorPalette.contains(e.target) && e.target !== colorBtn) {
-      colorPalette.hidden = true;
-    }
-  });
+  function openPalette() {
+    colorPalette.hidden = false;
+    // 이 클릭 이벤트가 버블링되어 즉시 닫히지 않도록 다음 틱에 등록
+    setTimeout(() => {
+      if (!colorPalette.isConnected) return;
+      function onOutside(e) {
+        if (!colorPalette.contains(e.target)) closePalette();
+      }
+      document.addEventListener("click", onOutside, true);
+      removeOutsideListener = () => document.removeEventListener("click", onOutside, true);
+    }, 0);
+  }
+
+  function toggleColorPalette() {
+    if (colorPalette.hidden) openPalette();
+    else closePalette();
+  }
 
   titleRow.appendChild(titleInput);
   titleRow.appendChild(colorBtn);

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -128,7 +128,8 @@ export function create(block, { callbacks = {} } = {}) {
     colorPalette.hidden = false;
     // 다음 틱에 등록: 팔레트를 연 클릭 자체가 즉시 닫기를 트리거하지 않도록
     setTimeout(() => {
-      if (!colorPalette.isConnected) return;
+      // timeout 실행 전에 이미 닫혔거나 DOM에서 제거된 경우 리스너 등록 생략
+      if (colorPalette.hidden || !colorPalette.isConnected) return;
       function onOutside(e) {
         // colorBtn 클릭은 여기서 처리하지 않음 — 버튼 핸들러가 toggle을 담당
         if (colorBtn.contains(e.target)) return;

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -61,9 +61,15 @@ export function create(block, { callbacks = {} } = {}) {
   titleInput.className = "db-title-input";
   titleInput.value = block.title || "";
   titleInput.placeholder = "데이터베이스 이름...";
+  let dbTitleOriginal = titleInput.value;
+  titleInput.addEventListener("focus", () => { dbTitleOriginal = titleInput.value; });
   titleInput.addEventListener("blur", async () => {
+    const newTitle = titleInput.value.trim();
+    if (newTitle === dbTitleOriginal) return;
     try {
-      await apiPatchBlock(block.id, { title: titleInput.value.trim() });
+      await apiPatchBlock(block.id, { title: newTitle });
+      dbTitleOriginal = newTitle;
+      if (callbacks.onDbTitleChanged) callbacks.onDbTitleChanged(block.id, newTitle);
     } catch (err) {
       console.error("DB 제목 저장 실패:", err);
     }

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -7,9 +7,8 @@ import {
   apiAddDbColumn,
   apiUpdateDbColumn,
   apiRemoveDbColumn,
-  apiCreateBlock,
   apiUpdateDbRowProperties,
-  apiPatchBlock,
+  apiPatchDatabaseBlock,
 } from "../api.js";
 
 export const type = "database";
@@ -67,7 +66,7 @@ export function create(block, { callbacks = {} } = {}) {
     const newTitle = titleInput.value.trim();
     if (newTitle === dbTitleOriginal) return;
     try {
-      await apiPatchBlock(block.id, { title: newTitle });
+      await apiPatchDatabaseBlock(block.id, { title: newTitle });
       dbTitleOriginal = newTitle;
       if (callbacks.onDbTitleChanged) callbacks.onDbTitleChanged(block.id, newTitle);
     } catch (err) {
@@ -109,7 +108,7 @@ export function create(block, { callbacks = {} } = {}) {
       swatch.classList.add("is-active");
       closePalette();
       try {
-        await apiPatchBlock(block.id, { color: c.id });
+        await apiPatchDatabaseBlock(block.id, { color: c.id });
       } catch (err) {
         console.error("색상 저장 실패:", err);
       }

--- a/static/js/blocks/databaseBlock.js
+++ b/static/js/blocks/databaseBlock.js
@@ -231,7 +231,7 @@ export function create(block, { callbacks = {} } = {}) {
     addColBtn.className = "db-add-col-btn";
     addColBtn.textContent = "+";
     addColBtn.title = "컬럼 추가";
-    addColBtn.addEventListener("click", () => promptAddColumn());
+    addColBtn.addEventListener("click", () => startAddColumn(thAdd));
     thAdd.appendChild(addColBtn);
     tr.appendChild(thAdd);
 
@@ -367,15 +367,51 @@ export function create(block, { callbacks = {} } = {}) {
     });
   }
 
-  async function promptAddColumn() {
-    const name = prompt("새 컬럼 이름:");
-    if (!name || !name.trim()) return;
-    try {
-      await apiAddDbColumn(block.id, name.trim());
-      if (callbacks.reloadDocument) callbacks.reloadDocument();
-    } catch (err) {
-      console.error("컬럼 추가 실패:", err);
+  function startAddColumn(thAdd) {
+    // 이미 추가 중이면 중복 방지
+    if (thead.querySelector(".db-col-new-input")) return;
+
+    const thNew = document.createElement("th");
+    thNew.className = "db-th";
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "db-col-rename-input db-col-new-input";
+    input.placeholder = "컬럼 이름";
+    thNew.appendChild(input);
+    thAdd.before(thNew);
+    input.focus();
+
+    let committed = false;
+
+    async function commit() {
+      if (committed) return;
+      committed = true;
+      const name = input.value.trim();
+      if (!name) {
+        thNew.remove();
+        return;
+      }
+      try {
+        await apiAddDbColumn(block.id, name);
+        if (callbacks.reloadDocument) callbacks.reloadDocument();
+      } catch (err) {
+        console.error("컬럼 추가 실패:", err);
+        thNew.remove();
+      }
     }
+
+    function cancel() {
+      if (committed) return;
+      committed = true;
+      thNew.remove();
+    }
+
+    input.addEventListener("blur", commit);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); input.blur(); }
+      if (e.key === "Escape") { cancel(); }
+    });
   }
 
   // 최초 렌더

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -20,6 +20,11 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
   const existingBtn = listItem.querySelector(':scope > .document-row > .document-item');
   const menuBtn = listItem.querySelector(':scope > .document-row > .document-menu-btn');
 
+  // 기존 버튼의 클래스 목록과 아이콘 텍스트를 캡처해 복원 시 재사용
+  const savedClasses = Array.from(existingBtn.classList);
+  const iconEl = existingBtn.querySelector('.document-item-icon');
+  const savedIconText = iconEl ? iconEl.textContent : null;
+
   const input = document.createElement('input');
   input.type = 'text';
   input.setAttribute('size', '1');
@@ -40,8 +45,22 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
 
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'document-item is-active';
-    btn.textContent = title;
+    btn.className = savedClasses.join(' ');
+    btn.classList.add('is-active');
+
+    if (savedIconText !== null) {
+      const icon = document.createElement('span');
+      icon.className = 'document-item-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = savedIconText;
+      btn.appendChild(icon);
+    }
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'document-item-title';
+    titleSpan.textContent = title;
+    btn.appendChild(titleSpan);
+
     btn.addEventListener('click', () => {
       closeAllMenus(list);
       setActiveItem(list, listItem);
@@ -59,7 +78,11 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
       .then(() => { if (onTitleSaved) onTitleSaved(docId, newTitle); })
       .catch((err) => {
         console.error(err);
-        if (btn) btn.textContent = initialTitle;
+        if (btn) {
+          const ts = btn.querySelector('.document-item-title');
+          if (ts) ts.textContent = initialTitle;
+          else btn.textContent = initialTitle;
+        }
       });
   }
 

--- a/static/js/documentList.js
+++ b/static/js/documentList.js
@@ -89,6 +89,8 @@ export function enterInlineEdit(listItem, docId, initialTitle, list, onSelect, o
  */
 export function addDocumentItem(list, docInfo, handlers, depth = 0) {
   const { onSelect, onDelete, onRename } = handlers;
+  const isDbRow = !!docInfo.is_db_row;
+  const isDatabase = !!docInfo.is_database;
 
   const item = document.createElement('li');
   item.dataset.id = docInfo.id;
@@ -109,70 +111,96 @@ export function addDocumentItem(list, docInfo, handlers, depth = 0) {
   if (hasChildren) {
     toggleBtn.classList.add('has-children');
   } else {
-    // No children: keep button in DOM for layout stability but remove from
-    // tab order and hide from assistive technology.
     toggleBtn.tabIndex = -1;
     toggleBtn.setAttribute('aria-hidden', 'true');
   }
 
-  // ── Document select button ────────────────────────────────────────────────
+  // ── Select/navigate button ────────────────────────────────────────────────
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'document-item';
-  btn.textContent = docInfo.title;
+  if (isDbRow) btn.classList.add('is-db-row');
+  if (isDatabase) btn.classList.add('is-database-node');
+
+  // 아이콘 + 제목 span 구조 (일반 문서도 동일하게 구성해 updateSidebarTitle 통일)
+  const icon = document.createElement('span');
+  icon.className = 'document-item-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  if (isDatabase) icon.textContent = '⊞';
+  else if (isDbRow) icon.textContent = '≡';
+  else icon.textContent = '';
+  btn.appendChild(icon);
+
+  const titleSpan = document.createElement('span');
+  titleSpan.className = 'document-item-title';
+  titleSpan.textContent = docInfo.title;
+  btn.appendChild(titleSpan);
+
   btn.addEventListener('click', () => {
     closeAllMenus(list);
-    setActiveItem(list, item);
-    onSelect(docInfo.id);
+    if (isDatabase) {
+      // 데이터베이스 노드 클릭 → 포함된 문서로 이동
+      onSelect(docInfo.parent_doc_id);
+    } else {
+      setActiveItem(list, item);
+      onSelect(docInfo.id);
+    }
   });
 
-  // ── More (⋯) menu button ──────────────────────────────────────────────────
-  const menuBtn = document.createElement('button');
-  menuBtn.type = 'button';
-  menuBtn.className = 'document-menu-btn';
-  menuBtn.setAttribute('aria-label', '더보기');
-  menuBtn.textContent = '⋯';
-
-  const menu = document.createElement('div');
-  menu.className = 'document-menu';
-  menu.hidden = true;
-
-  const renameBtn = document.createElement('button');
-  renameBtn.type = 'button';
-  renameBtn.className = 'document-menu-rename';
-  renameBtn.textContent = '이름 바꾸기';
-  renameBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    menu.hidden = true;
-    const currentTitle = btn.textContent;
-    enterInlineEdit(item, docInfo.id, currentTitle, list, (docId) => onSelect(docId), (docId, newTitle) => {
-      if (onRename) onRename(docId, newTitle);
-    });
-  });
-
-  const deleteBtn = document.createElement('button');
-  deleteBtn.type = 'button';
-  deleteBtn.className = 'document-menu-delete';
-  deleteBtn.textContent = '삭제';
-  deleteBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    menu.hidden = true;
-    onDelete(docInfo.id, item);
-  });
-
-  menuBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const wasHidden = menu.hidden;
-    closeAllMenus(list);
-    menu.hidden = !wasHidden;
-  });
-
-  menu.appendChild(renameBtn);
-  menu.appendChild(deleteBtn);
+  // ── More (⋯) menu (database 가상 노드는 메뉴 없음) ───────────────────────
   row.appendChild(toggleBtn);
   row.appendChild(btn);
-  row.appendChild(menuBtn);
-  row.appendChild(menu);
+
+  if (!isDatabase) {
+    const menuBtn = document.createElement('button');
+    menuBtn.type = 'button';
+    menuBtn.className = 'document-menu-btn';
+    menuBtn.setAttribute('aria-label', '더보기');
+    menuBtn.textContent = '⋯';
+
+    const menu = document.createElement('div');
+    menu.className = 'document-menu';
+    menu.hidden = true;
+
+    const renameBtn = document.createElement('button');
+    renameBtn.type = 'button';
+    renameBtn.className = 'document-menu-rename';
+    renameBtn.textContent = '이름 바꾸기';
+    renameBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      menu.hidden = true;
+      const currentTitle = titleSpan.textContent;
+      enterInlineEdit(item, docInfo.id, currentTitle, list, (docId) => onSelect(docId), (docId, newTitle) => {
+        if (onRename) onRename(docId, newTitle);
+      });
+    });
+    menu.appendChild(renameBtn);
+
+    // db_row는 사이드바에서 직접 삭제 불가 (database 블록에 broken ref 발생)
+    if (!isDbRow) {
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'document-menu-delete';
+      deleteBtn.textContent = '삭제';
+      deleteBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        menu.hidden = true;
+        onDelete(docInfo.id, item);
+      });
+      menu.appendChild(deleteBtn);
+    }
+
+    menuBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const wasHidden = menu.hidden;
+      closeAllMenus(list);
+      menu.hidden = !wasHidden;
+    });
+
+    row.appendChild(menuBtn);
+    row.appendChild(menu);
+  }
+
   item.appendChild(row);
 
   // ── Children list ─────────────────────────────────────────────────────────

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -79,8 +79,7 @@ async function initGallery() {
     if (!item) return;
     const btn = item.querySelector(':scope > .document-row > .document-item');
     if (!btn) return;
-    // db_row 아이템은 아이콘 span + 제목 span 구조이므로 제목 span만 교체
-    const titleSpan = btn.querySelector('span:last-child');
+    const titleSpan = btn.querySelector('.document-item-title');
     if (titleSpan) titleSpan.textContent = newTitle;
     else btn.textContent = newTitle;
   }
@@ -314,6 +313,7 @@ async function initGallery() {
         cb.addEventListener('change', async () => {
           ctx.properties[col.id] = cb.checked;
           await _saveDbProperties(ctx);
+          _syncDbCellInParent(ctx.block_id, col.id, cb.checked);
         });
         valueWrap.appendChild(cb);
       } else {
@@ -353,10 +353,14 @@ async function initGallery() {
   }
 
   function _syncDbCellInParent(rowBlockId, colId, newValue) {
-    const cellInput = document.querySelector(
-      `.db-row[data-row-block-id="${rowBlockId}"] [data-col-id="${colId}"] .db-cell-input`
+    const cell = document.querySelector(
+      `.db-row[data-row-block-id="${rowBlockId}"] [data-col-id="${colId}"]`
     );
-    if (cellInput) cellInput.value = newValue;
+    if (!cell) return;
+    const textInput = cell.querySelector('.db-cell-input');
+    if (textInput) { textInput.value = newValue; return; }
+    const checkbox = cell.querySelector('.db-cell-checkbox');
+    if (checkbox) checkbox.checked = newValue === true || newValue === 'true';
   }
 
   function showEmptyState() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,6 +8,7 @@ import {
   apiUpdateTitle,
   apiCreateBlock,
   apiMoveBlock,
+  apiUpdateDbRowProperties,
 } from "./api.js";
 import { openPagePickerModal } from "./pagePickerModal.js";
 import { callbacks, renderBlock, renderDocument, focusBlock } from "./blockRenderers.js";
@@ -149,6 +150,10 @@ async function initGallery() {
     document.querySelectorAll(`.page-block-title[data-doc-id="${documentId}"]`).forEach((el) => {
       el.textContent = newTitle;
     });
+    // Update db row title cells that reference this document
+    document.querySelectorAll(`.db-row[data-doc-id="${documentId}"] .db-row-title`).forEach((el) => {
+      el.textContent = newTitle;
+    });
   };
 
   // ── Document loader ───────────────────────────────────────────────────────
@@ -195,6 +200,15 @@ async function initGallery() {
       }
     };
 
+    // db_row 추가: database 블록 id를 parent_block_id로 전달
+    callbacks.addDbRow = async (dbBlockId) => {
+      const newBlock = await apiCreateBlock(activeDocId, 'db_row', dbBlockId);
+      if (newBlock.child_document && callbacks.onPageBlockAdded) {
+        callbacks.onPageBlockAdded(newBlock.child_document);
+      }
+      if (callbacks.reloadDocument) callbacks.reloadDocument();
+    };
+
     const addBlock = async (type, parentBlockId = null) => {
       let targetDocumentId = null;
       if (type === 'page') {
@@ -236,6 +250,7 @@ async function initGallery() {
       }
 
       renderDocument(payload);
+      renderDbProperties(payload.db_context);
       if (focusBlockId) {
         const targetWrapper = root.querySelector(`[data-block-id="${focusBlockId}"]`);
         const targetBlock = targetWrapper?.querySelector('.notion-block');
@@ -252,6 +267,87 @@ async function initGallery() {
       p.textContent = `문서를 불러오지 못했습니다: ${err.message}`;
       root.replaceChildren(p);
     }
+  }
+
+  // ── DB row 속성 패널 ──────────────────────────────────────────────────────
+  /**
+   * db_context가 있을 때 타이틀 아래에 속성 패널을 렌더링한다.
+   * @param {object|null} ctx - DbContext | null
+   */
+  function renderDbProperties(ctx) {
+    const panel = document.getElementById('page-properties');
+    panel.innerHTML = '';
+
+    if (!ctx || !ctx.columns || ctx.columns.length === 0) {
+      panel.hidden = true;
+      return;
+    }
+
+    panel.hidden = false;
+
+    ctx.columns.forEach((col) => {
+      const row = document.createElement('div');
+      row.className = 'db-prop-row';
+
+      const label = document.createElement('span');
+      label.className = 'db-prop-label';
+      label.textContent = col.name;
+      row.appendChild(label);
+
+      const valueWrap = document.createElement('div');
+      valueWrap.className = 'db-prop-value';
+
+      if (col.type === 'checkbox') {
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'db-prop-checkbox';
+        cb.checked = ctx.properties[col.id] === true || ctx.properties[col.id] === 'true';
+        cb.addEventListener('change', async () => {
+          ctx.properties[col.id] = cb.checked;
+          await _saveDbProperties(ctx);
+        });
+        valueWrap.appendChild(cb);
+      } else {
+        const input = document.createElement('input');
+        input.type = col.type === 'number' ? 'number' : 'text';
+        input.className = 'db-prop-input';
+        input.value = ctx.properties[col.id] ?? '';
+        input.placeholder = col.type === 'number' ? '0' : '값 입력...';
+
+        let original = input.value;
+        input.addEventListener('focus', () => { original = input.value; });
+        input.addEventListener('blur', async () => {
+          if (input.value === original) return;
+          ctx.properties[col.id] = input.value;
+          await _saveDbProperties(ctx);
+          // database 블록이 열려 있는 경우 셀도 갱신
+          _syncDbCellInParent(ctx.block_id, col.id, input.value);
+        });
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+          if (e.key === 'Escape') { input.value = original; input.blur(); }
+        });
+        valueWrap.appendChild(input);
+      }
+
+      row.appendChild(valueWrap);
+      panel.appendChild(row);
+    });
+  }
+
+  async function _saveDbProperties(ctx) {
+    try {
+      await apiUpdateDbRowProperties(ctx.block_id, ctx.properties);
+    } catch (err) {
+      console.error('속성 저장 실패:', err);
+    }
+  }
+
+  function _syncDbCellInParent(rowBlockId, colId, newValue) {
+    const cellInput = document.querySelector(
+      `.db-row[data-row-block-id="${rowBlockId}"] [data-col-id="${colId}"] .db-cell-input`
+    );
+    if (cellInput) cellInput.value = newValue;
   }
 
   function showEmptyState() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -78,7 +78,11 @@ async function initGallery() {
     const item = list.querySelector(`li[data-id="${docId}"]`);
     if (!item) return;
     const btn = item.querySelector(':scope > .document-row > .document-item');
-    if (btn) btn.textContent = newTitle;
+    if (!btn) return;
+    // db_row 아이템은 아이콘 span + 제목 span 구조이므로 제목 span만 교체
+    const titleSpan = btn.querySelector('span:last-child');
+    if (titleSpan) titleSpan.textContent = newTitle;
+    else btn.textContent = newTitle;
   }
 
   // ── Sidebar helpers ───────────────────────────────────────────────────────
@@ -101,7 +105,8 @@ async function initGallery() {
    * without a full reload. The parent's toggle is expanded automatically.
    */
   function addChildToSidebar(childDoc) {
-    const parentItem = list.querySelector(`li[data-id="${childDoc.parent_id}"]`);
+    const sidebarParentId = childDoc.parent_sidebar_id ?? childDoc.parent_id;
+    const parentItem = list.querySelector(`li[data-id="${sidebarParentId}"]`);
     if (!parentItem) return;
 
     const parentDepth = parseInt(parentItem.dataset.depth ?? '0', 10);
@@ -154,6 +159,10 @@ async function initGallery() {
     document.querySelectorAll(`.db-row[data-doc-id="${documentId}"] .db-row-title`).forEach((el) => {
       el.textContent = newTitle;
     });
+  };
+
+  callbacks.onDbTitleChanged = (dbBlockId, newTitle) => {
+    updateSidebarTitle(`db:${dbBlockId}`, newTitle);
   };
 
   // ── Document loader ───────────────────────────────────────────────────────

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
     <h1 id="page-title"></h1>
     <p id="page-subtitle"></p>
   </header>
+  <div id="page-properties" class="page-properties" hidden></div>
   <div id="block-root" class="block-root"></div>
 </section>
 {% endblock %}


### PR DESCRIPTION
Closes #30

## Summary

- **배경**: 데이터베이스 블록의 각 Row를 독립적인 페이지로 열어 상세 편집이 가능하도록 기능 확장 필요
- **목적**: `DbRowBlock`이 `PageBlock`을 상속해 Row를 문서로 관리하고, DB 스키마 속성을 페이지 타이틀 아래에 표시

## Changes

- **백엔드**
  - `DocumentRow` ORM에 `source_block_id` 컬럼 추가 (db_row 블록과 연결)
  - `DbRowBlock(PageBlock)` 및 `DatabaseBlock` Pydantic 모델 추가 (`columns`, `rows`, `color` 등)
  - `DbContext` 모델: db_row 페이지 열람 시 컬럼 스키마 + 현재 속성 값 반환
  - `list_documents`: database 블록을 가상 노드(`"db:{block_id}"`)로 생성해 db_row 문서를 하위로 배치
  - `create_block`: `db_row` 생성 시 연결 문서 자동 생성, `parent_sidebar_id` 반환
  - `/api/database/blocks/{block_id}/...` 엔드포인트: 컬럼 추가·수정·삭제, Row 속성 저장

- **프론트엔드**
  - `databaseBlock.js`: 테이블 렌더링, 배경 색상 팔레트(10색), 인라인 컬럼 추가·이름 수정, Row 클릭 시 페이지 이동
  - `main.js`: db_row 페이지 로드 시 `db_context` 속성 패널 렌더링, `onDbTitleChanged` 콜백으로 사이드바 가상 노드 제목 실시간 반영
  - `documentList.js`: `is_database` 노드 (⊞ 아이콘, 메뉴 없음), `is_db_row` 노드 (≡ 아이콘, 삭제 불가) 처리
  - `blockPalette.js`: 데이터베이스 블록 타입 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] Database 블록 생성 → 컬럼 추가/수정/삭제
- [x] Row 추가 → 사이드바 DB 노드 하위에 자동 삽입 확인
- [x] Row 클릭 → 독립 페이지로 이동, 타이틀 아래 속성 패널 표시 확인
- [x] 속성 편집 → DB 테이블 셀과 실시간 동기화 확인
- [x] 배경 색상 팔레트 열기/닫기 및 색상 저장 확인
- [x] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- `list_documents`의 가상 노드 트리 빌드 로직 (`"db:{block_id}"` 문자열 ID 처리)
- CSS `[hidden] { display: none }` 명시 추가 — flex 컨테이너가 hidden 어트리뷰트를 무시하는 브라우저 동작 대응
- 색상 팔레트 capture-phase 리스너 등록 방식 (`setTimeout` + `colorBtn.contains` 가드)