### PR TITLE
[FIX#33] 페이지 전환 시 스크롤 최상단 초기화

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -258,6 +258,8 @@ async function initGallery() {
       }
 
       renderDocument(payload);
+      // 페이지 전환 시 본문 최상단에서 시작 (#33)
+      window.scrollTo(0, 0);
       renderDbProperties(payload.db_context);
       if (focusBlockId) {
         const targetWrapper = root.querySelector(`[data-block-id="${focusBlockId}"]`);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -135,7 +135,7 @@ async function initGallery() {
   };
 
   callbacks.reloadDocument = () => {
-    if (activeDocId) loadDocument(activeDocId);
+    if (activeDocId) loadDocument(activeDocId, { pushHistory: false });
   };
 
   callbacks.reloadSidebar = reloadSidebar;
@@ -165,7 +165,7 @@ async function initGallery() {
   };
 
   // ── Document loader ───────────────────────────────────────────────────────
-  async function loadDocument(documentId, { focusBlockId = null } = {}) {
+  async function loadDocument(documentId, { focusBlockId = null, pushHistory = true } = {}) {
     activeDocId = documentId;
 
     /**
@@ -253,13 +253,19 @@ async function initGallery() {
       const lastBlock = rootBlocks[rootBlocks.length - 1];
       if (!lastBlock || lastBlock.type !== 'text') {
         const newBlock = await apiCreateBlock(activeDocId, 'text');
-        await loadDocument(documentId, { focusBlockId: focusBlockId ?? newBlock.id });
+        await loadDocument(documentId, { focusBlockId: focusBlockId ?? newBlock.id, pushHistory });
         return;
       }
 
       renderDocument(payload);
       // 페이지 전환 시 본문 최상단에서 시작 (#33)
       window.scrollTo(0, 0);
+      if (pushHistory) {
+        const state = { docId: documentId };
+        history.state?.docId === undefined
+          ? history.replaceState(state, '')
+          : history.pushState(state, '');
+      }
       renderDbProperties(payload.db_context);
       if (focusBlockId) {
         const targetWrapper = root.querySelector(`[data-block-id="${focusBlockId}"]`);
@@ -409,6 +415,18 @@ async function initGallery() {
     document.getElementById('sidebar-tab'),
     document.getElementById('sidebar-panel'),
   );
+
+  // ── 브라우저 뒤로/앞으로: 히스토리 상태에서 문서 복원 (#33) ───────────────
+  window.addEventListener('popstate', (e) => {
+    const docId = e.state?.docId;
+    if (!docId) return;
+    const targetItem = list.querySelector(`li[data-id="${docId}"]`);
+    if (targetItem) {
+      closeAllMenus(list);
+      setActiveItem(list, targetItem);
+    }
+    loadDocument(docId, { pushHistory: false });
+  });
 
   document.addEventListener('click', () => {
     closeAllMenus(list);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -135,7 +135,7 @@ async function initGallery() {
   };
 
   callbacks.reloadDocument = () => {
-    if (activeDocId) loadDocument(activeDocId, { pushHistory: false });
+    if (activeDocId) loadDocument(activeDocId, { pushHistory: false, resetScroll: false });
   };
 
   callbacks.reloadSidebar = reloadSidebar;
@@ -165,7 +165,7 @@ async function initGallery() {
   };
 
   // ── Document loader ───────────────────────────────────────────────────────
-  async function loadDocument(documentId, { focusBlockId = null, pushHistory = true } = {}) {
+  async function loadDocument(documentId, { focusBlockId = null, pushHistory = true, resetScroll = true } = {}) {
     activeDocId = documentId;
 
     /**
@@ -253,13 +253,13 @@ async function initGallery() {
       const lastBlock = rootBlocks[rootBlocks.length - 1];
       if (!lastBlock || lastBlock.type !== 'text') {
         const newBlock = await apiCreateBlock(activeDocId, 'text');
-        await loadDocument(documentId, { focusBlockId: focusBlockId ?? newBlock.id, pushHistory });
+        await loadDocument(documentId, { focusBlockId: focusBlockId ?? newBlock.id, pushHistory, resetScroll });
         return;
       }
 
       renderDocument(payload);
-      // 페이지 전환 시 본문 최상단에서 시작 (#33)
-      window.scrollTo(0, 0);
+      // 페이지 전환 시 본문 최상단에서 시작 (#33) — 네비게이션 경로에서만 리셋
+      if (resetScroll) window.scrollTo(0, 0);
       if (pushHistory) {
         const state = { docId: documentId };
         history.state?.docId === undefined
@@ -425,7 +425,7 @@ async function initGallery() {
       closeAllMenus(list);
       setActiveItem(list, targetItem);
     }
-    loadDocument(docId, { pushHistory: false });
+    loadDocument(docId, { pushHistory: false, resetScroll: true });
   });
 
   document.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

- 배경: 페이지를 전환할 때 이전 페이지의 스크롤 위치가 유지되어, 새 페이지가 최상단이 아닌 곳에서 시작되는 문제 (#33)
- 목적: 사이드바·페이지 블록·뒤로/앞으로 등 모든 전환 경로에서 본문이 항상 최상단에서 시작되도록 보장

## Changes

- `loadDocument()` 내 `renderDocument()` 완료 직후 `window.scrollTo(0, 0)` 호출 — 모든 전환 경로가 이 함수를 거치므로 한 곳에서 처리
- `loadDocument()`에 `pushHistory` 옵션 추가, 렌더링 후 `history.pushState` / `history.replaceState`로 문서 상태 기록
- `window.addEventListener('popstate', ...)` 추가 — 뒤로/앞으로 시 상태의 `docId`로 문서 복원 및 사이드바 하이라이트 동기화
- `reloadDocument`, 내부 재귀 호출은 `pushHistory: false`로 히스토리 스택 중복 적재 방지

## Test

- [ ] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [ ] 긴 문서 하단까지 스크롤 후 사이드바에서 다른 문서 선택 → 최상단에서 시작되는지 확인
- [ ] 페이지 블록 클릭 → 최상단에서 시작되는지 확인
- [ ] 브라우저 뒤로/앞으로 버튼으로 문서 복원 및 스크롤 초기화 확인
- [ ] 브라우저 콘솔 에러 없음

## Checklist

- [ ] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [ ] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- 중점적으로 봐야 할 부분: `pushHistory` 조건 분기 — 최초 진입은 `replaceState`, 이후 전환은 `pushState`로 처리하는 로직 (`history.state?.docId === undefined` 체크)

Closes #33