### PR TITLE
[FEAT#36] URL 임베드 블록 추가

### DIFF
--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -94,7 +94,7 @@ class UrlEmbedBlock(BlockBase):
   description: str = ""
   logo: str = ""        # resolved absolute URL: og:image / apple-touch-icon / favicon
   provider: str = ""    # hostname without "www." prefix
-  fetched_at: str = ""  # ISO-8601 UTC timestamp of last successful fetch
+  fetched_at: str = ""  # ISO-8601 UTC timestamp of last fetch attempt
   status: Literal["pending", "success", "error"] = "pending"
 
 

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -79,6 +79,25 @@ class DividerBlock(BlockBase):
   type: Literal["divider"]
 
 
+class UrlEmbedBlock(BlockBase):
+  """URL embed block that displays page metadata as a bookmark-style card.
+
+  Metadata fields (title, description, logo, provider) are populated
+  server-side by the /api/url-embed/fetch endpoint.
+
+  Ref: Open Graph Protocol — https://ogp.me/
+  """
+
+  type: Literal["url_embed"]
+  url: str = ""
+  title: str = ""
+  description: str = ""
+  logo: str = ""        # resolved absolute URL: og:image / apple-touch-icon / favicon
+  provider: str = ""    # hostname without "www." prefix
+  fetched_at: str = ""  # ISO-8601 UTC timestamp of last successful fetch
+  status: Literal["pending", "success", "error"] = "pending"
+
+
 class PageBlock(BlockBase):
   """Block that links to another BlockDocument, enabling recursive page nesting."""
 
@@ -130,6 +149,7 @@ Block = Annotated[
   | CodeBlock
   | CalloutBlock
   | DividerBlock
+  | UrlEmbedBlock
   | PageBlock
   | DbRowBlock
   | DatabaseBlock,

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -484,6 +484,16 @@ class SQLiteBlockRepository:
           default_content = {"text": "", "emoji": "💡", "color": "yellow"}
         case "divider":
           default_content = {}
+        case "url_embed":
+          default_content = {
+            "url": "",
+            "title": "",
+            "description": "",
+            "logo": "",
+            "provider": "",
+            "fetched_at": "",
+            "status": "pending",
+          }
         case _:
           return None
 
@@ -646,6 +656,16 @@ class SQLiteBlockRepository:
         default_content = {"text": "", "emoji": "💡", "color": "yellow"}
       case "divider":
         default_content = {}
+      case "url_embed":
+        default_content = {
+          "url": "",
+          "title": "",
+          "description": "",
+          "logo": "",
+          "provider": "",
+          "fetched_at": "",
+          "status": "pending",
+        }
       case _:
         return False
 

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -39,7 +39,7 @@ class BlockPositionPatch(BaseModel):
 
 
 class BlockTypeChange(BaseModel):
-  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider"]
+  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "url_embed"]
 
 
 @router.patch("/{block_id}")

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -66,7 +66,7 @@ def update_document_title(
 
 
 class BlockCreate(BaseModel):
-  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "page", "database", "db_row"]
+  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "url_embed", "page", "database", "db_row"]
   parent_block_id: str | None = None
   # Only used when type="page": link to an existing document instead of creating a new one
   target_document_id: str | None = None

--- a/app/routers/url_embed.py
+++ b/app/routers/url_embed.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, HttpUrl, field_validator
+from pydantic import BaseModel, field_validator
 
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository

--- a/app/routers/url_embed.py
+++ b/app/routers/url_embed.py
@@ -1,0 +1,93 @@
+"""URL 임베드 메타데이터 조회 라우터.
+
+엔드포인트:
+  POST /api/url-embed/fetch
+    — URL을 받아 Open Graph / Twitter Card / HTML 메타데이터를 수집하고,
+      선택적으로 해당 블록의 content_json을 즉시 업데이트한다.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, HttpUrl, field_validator
+
+from app.dependencies import get_repository
+from app.repositories.sqlite_blocks import SQLiteBlockRepository
+from app.services.url_embed import UrlEmbedMetadata, fetch_url_metadata
+
+router = APIRouter(prefix="/api/url-embed", tags=["url-embed"])
+
+# URL 최대 길이 — 실용적 상한값 (RFC 7230 권고 수준)
+_MAX_URL_LENGTH = 2048
+
+
+class UrlFetchRequest(BaseModel):
+  """POST /api/url-embed/fetch 요청 바디."""
+
+  url: str
+  # 블록 ID를 함께 전달하면 fetch 결과가 해당 블록 content_json에 즉시 반영됨
+  block_id: str | None = None
+
+  @field_validator("url")
+  @classmethod
+  def validate_url(cls, v: str) -> str:
+    v = v.strip()
+    if not v:
+      raise ValueError("URL은 비어 있을 수 없습니다.")
+    if len(v) > _MAX_URL_LENGTH:
+      raise ValueError(f"URL은 {_MAX_URL_LENGTH}자를 초과할 수 없습니다.")
+    if not v.startswith(("http://", "https://")):
+      raise ValueError("http:// 또는 https://로 시작하는 URL만 허용됩니다.")
+    return v
+
+
+class UrlFetchResponse(BaseModel):
+  """POST /api/url-embed/fetch 응답 바디."""
+
+  url: str
+  title: str
+  description: str
+  logo: str
+  provider: str
+  fetched_at: str
+  status: str   # "success" | "error"
+  error: str    # status="error"일 때 사람이 읽을 수 있는 메시지
+
+
+@router.post("/fetch", response_model=UrlFetchResponse)
+def fetch_embed(
+  body: UrlFetchRequest,
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> UrlFetchResponse:
+  """URL의 Open Graph / Twitter Card 메타데이터를 조회한다.
+
+  block_id가 함께 전달되면 조회 결과를 해당 url_embed 블록에 자동으로 저장한다.
+  메타데이터 수집에 실패하더라도 HTTP 200으로 응답하고 status 필드를 "error"로 설정한다.
+  (클라이언트가 fallback UI를 표시하기 위해 에러 상태를 명시적으로 전달받아야 함)
+  """
+  meta: UrlEmbedMetadata = fetch_url_metadata(body.url)
+
+  # 블록 ID가 주어진 경우 content_json 업데이트
+  if body.block_id is not None:
+    patch = {
+      "url": meta.url,
+      "title": meta.title,
+      "description": meta.description,
+      "logo": meta.logo,
+      "provider": meta.provider,
+      "fetched_at": meta.fetched_at,
+      "status": meta.status,
+    }
+    updated = repo.update_block(body.block_id, patch)
+    if not updated:
+      raise HTTPException(status_code=404, detail="Block not found")
+
+  return UrlFetchResponse(
+    url=meta.url,
+    title=meta.title,
+    description=meta.description,
+    logo=meta.logo,
+    provider=meta.provider,
+    fetched_at=meta.fetched_at,
+    status=meta.status,
+    error=meta.error,
+  )

--- a/app/services/url_embed.py
+++ b/app/services/url_embed.py
@@ -1,0 +1,335 @@
+"""URL embed metadata fetching service.
+
+책임:
+  1. SSRF 방지 — 사설 네트워크·루프백 주소 차단
+  2. Open Graph / Twitter Card / 기본 HTML 태그 우선순위 적용
+  3. 로고 URL 결정 — og:image > apple-touch-icon > favicon 순
+  4. 타임아웃·HTTP 에러 시 graceful fallback (status="error") 반환
+
+참고 자료:
+  - Open Graph Protocol: https://ogp.me/
+  - Twitter Cards: https://developer.twitter.com/en/docs/twitter-for-websites/cards
+  - OWASP SSRF Prevention Cheat Sheet:
+    https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from typing import Literal
+
+# 요청 타임아웃 (초) — 느린 서버로 인한 UX 지연 방지
+_FETCH_TIMEOUT: int = 10
+
+# 파싱할 최대 응답 바이트 (2 MB) — 메모리 고갈 방지
+_MAX_BODY_BYTES: int = 2 * 1024 * 1024
+
+# 사설·예약 IP 대역 — SSRF 공격 방어를 위해 모두 차단
+# Ref: RFC 1918, RFC 4193, RFC 3927, RFC 6598
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+  ipaddress.ip_network("10.0.0.0/8"),        # 사설 클래스 A
+  ipaddress.ip_network("172.16.0.0/12"),      # 사설 클래스 B
+  ipaddress.ip_network("192.168.0.0/16"),     # 사설 클래스 C
+  ipaddress.ip_network("127.0.0.0/8"),        # IPv4 루프백
+  ipaddress.ip_network("169.254.0.0/16"),     # 링크-로컬 (APIPA)
+  ipaddress.ip_network("100.64.0.0/10"),      # 공유 주소 공간 (RFC 6598)
+  ipaddress.ip_network("0.0.0.0/8"),          # "이 네트워크" (RFC 1122)
+  ipaddress.ip_network("::1/128"),            # IPv6 루프백
+  ipaddress.ip_network("fc00::/7"),           # IPv6 고유 로컬
+  ipaddress.ip_network("fe80::/10"),          # IPv6 링크-로컬
+]
+
+# 요청 User-Agent — 대부분의 사이트에서 봇 차단을 피하기 위한 최소 식별자
+_USER_AGENT = "Mozilla/5.0 (compatible; ProjectsDisplay/1.0; +metadata-fetch)"
+
+
+@dataclass
+class UrlEmbedMetadata:
+  """fetch_url_metadata() 반환값 DTO."""
+
+  url: str
+  title: str = ""
+  description: str = ""
+  logo: str = ""        # 절대 URL (og:image / apple-touch-icon / favicon)
+  provider: str = ""    # "www." 제거한 호스트명
+  fetched_at: str = ""  # ISO-8601 UTC 타임스탬프
+  status: Literal["success", "error"] = "success"
+  error: str = ""       # status="error"일 때 사람이 읽을 수 있는 설명
+
+
+# ── SSRF 방어 ─────────────────────────────────────────────────────────────────
+
+def _is_ssrf_safe(url: str) -> bool:
+  """URL이 공개 서버를 가리킬 때만 True를 반환한다.
+
+  검사 항목:
+    1. 프로토콜 — http 또는 https만 허용
+    2. 호스트명 — 반드시 존재해야 함
+    3. IP 해석 결과 — _BLOCKED_NETWORKS에 포함되면 차단
+
+  Ref: OWASP SSRF Prevention Cheat Sheet
+  """
+  parsed = urllib.parse.urlparse(url)
+  if parsed.scheme not in ("http", "https"):
+    return False
+  hostname = parsed.hostname
+  if not hostname:
+    return False
+
+  try:
+    # getaddrinfo는 단일 호스트명에 대해 여러 주소를 반환할 수 있으므로
+    # 하나라도 사설 대역이면 차단 (SSRF DNS rebinding 방지)
+    addr_infos = socket.getaddrinfo(hostname, None)
+  except (socket.gaierror, OSError):
+    # 도메인 해석 실패 → 안전하지 않음으로 처리
+    return False
+
+  for addr_info in addr_infos:
+    raw_addr = addr_info[4][0]
+    try:
+      ip = ipaddress.ip_address(raw_addr)
+    except ValueError:
+      return False
+    for net in _BLOCKED_NETWORKS:
+      if ip in net:
+        return False
+
+  return True
+
+
+# ── HTML 메타데이터 파서 ───────────────────────────────────────────────────────
+
+class _MetaParser(HTMLParser):
+  """Open Graph, Twitter Card, 기본 HTML 태그에서 메타데이터를 추출한다.
+
+  <head> 종료 태그를 만나면 파싱을 중단해 불필요한 본문 처리 비용을 줄인다.
+  """
+
+  def __init__(self) -> None:
+    super().__init__()
+    self._og: dict[str, str] = {}
+    self._twitter: dict[str, str] = {}
+    self._meta_description: str = ""
+    self._page_title: str = ""
+    self._favicon: str = ""
+    self._apple_icon: str = ""
+    self._og_image: str = ""
+    self._in_title: bool = False
+    self._in_head: bool = True   # </head> 이후 파싱 생략
+    self._title_buf: list[str] = []
+
+  # HTMLParser 콜백 ─────────────────────────────────────────────────────────
+
+  def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    if not self._in_head:
+      return
+    attr = {k: (v or "") for k, v in attrs}
+
+    if tag == "meta":
+      self._handle_meta(attr)
+    elif tag == "link":
+      self._handle_link(attr)
+    elif tag == "title":
+      self._in_title = True
+      self._title_buf = []
+
+  def handle_data(self, data: str) -> None:
+    if self._in_title:
+      self._title_buf.append(data)
+
+  def handle_endtag(self, tag: str) -> None:
+    if tag == "title" and self._in_title:
+      self._page_title = "".join(self._title_buf).strip()
+      self._in_title = False
+    elif tag == "head":
+      self._in_head = False
+
+  # 태그별 처리 ─────────────────────────────────────────────────────────────
+
+  def _handle_meta(self, attr: dict[str, str]) -> None:
+    prop = attr.get("property", "").lower()
+    name = attr.get("name", "").lower()
+    content = attr.get("content", "").strip()
+    if not content:
+      return
+
+    # Open Graph — https://ogp.me/
+    if prop.startswith("og:"):
+      key = prop[3:]  # "og:" 제거
+      if key in ("title", "description", "image"):
+        self._og[key] = content
+
+    # Twitter Card — https://developer.twitter.com/en/docs/twitter-for-websites/cards
+    elif name.startswith("twitter:"):
+      key = name[8:]  # "twitter:" 제거
+      if key in ("title", "description", "image"):
+        self._twitter[key] = content
+
+    # 기본 meta description
+    elif name == "description":
+      self._meta_description = content
+
+  def _handle_link(self, attr: dict[str, str]) -> None:
+    rel = attr.get("rel", "").lower()
+    href = attr.get("href", "").strip()
+    if not href:
+      return
+    if "apple-touch-icon" in rel:
+      self._apple_icon = href
+    elif "icon" in rel:
+      # "shortcut icon", "icon" 모두 포함
+      self._favicon = href
+
+  # 우선순위 적용된 결과값 ──────────────────────────────────────────────────
+
+  @property
+  def best_title(self) -> str:
+    """og:title > twitter:title > <title> 순으로 반환."""
+    return self._og.get("title") or self._twitter.get("title") or self._page_title
+
+  @property
+  def best_description(self) -> str:
+    """og:description > twitter:description > meta[name=description] 순으로 반환."""
+    return (
+      self._og.get("description")
+      or self._twitter.get("description")
+      or self._meta_description
+    )
+
+  @property
+  def best_logo(self) -> str:
+    """og:image > apple-touch-icon > favicon 순으로 반환."""
+    return self._og.get("image") or self._apple_icon or self._favicon
+
+
+# ── 유틸리티 ──────────────────────────────────────────────────────────────────
+
+def _resolve_url(base: str, url: str) -> str:
+  """상대 URL을 절대 URL로 변환한다. 이미 절대 URL이면 그대로 반환."""
+  if not url:
+    return ""
+  return urllib.parse.urljoin(base, url)
+
+
+def _extract_provider(url: str) -> str:
+  """URL에서 사람이 읽기 쉬운 제공자명(호스트명)을 추출한다.
+
+  'www.' 접두어는 제거한다. (예: "www.example.com" → "example.com")
+  """
+  parsed = urllib.parse.urlparse(url)
+  hostname = parsed.hostname or ""
+  if hostname.startswith("www."):
+    hostname = hostname[4:]
+  return hostname
+
+
+# ── 공개 API ─────────────────────────────────────────────────────────────────
+
+def fetch_url_metadata(url: str) -> UrlEmbedMetadata:
+  """지정 URL의 Open Graph / Twitter Card / HTML 메타데이터를 수집해 반환한다.
+
+  우선순위 (높음 → 낮음):
+    - title:       og:title > twitter:title > <title>
+    - description: og:description > twitter:description > meta[name=description]
+    - logo:        og:image > apple-touch-icon > favicon
+
+  실패 시에도 예외를 던지지 않고 status="error"인 UrlEmbedMetadata를 반환한다.
+
+  보안:
+    - http / https 이외의 프로토콜 차단
+    - 사설·루프백 IP 대역 차단 (SSRF 방지)
+    - 응답 바디 최대 2 MB까지만 읽음 (메모리 보호)
+
+  Args:
+    url: 메타데이터를 조회할 HTTP(S) URL.
+
+  Returns:
+    UrlEmbedMetadata 인스턴스.
+  """
+  fetched_at = datetime.now(timezone.utc).isoformat()
+  provider = _extract_provider(url)
+
+  # ── 1. SSRF 사전 차단 ────────────────────────────────────────────────────
+  if not _is_ssrf_safe(url):
+    return UrlEmbedMetadata(
+      url=url,
+      provider=provider,
+      fetched_at=fetched_at,
+      status="error",
+      error="허용되지 않는 URL입니다 (프로토콜 또는 대상 주소 제한).",
+    )
+
+  # ── 2. HTTP 요청 ──────────────────────────────────────────────────────────
+  req = urllib.request.Request(
+    url,
+    headers={
+      "User-Agent": _USER_AGENT,
+      "Accept": "text/html,application/xhtml+xml,*/*;q=0.9",
+      "Accept-Language": "ko,en;q=0.9",
+    },
+  )
+
+  try:
+    with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT) as resp:
+      content_type: str = resp.headers.get("Content-Type", "")
+      # HTML이 아닌 응답(PDF, 이미지 등)은 파싱 대상이 아님
+      if "html" not in content_type.lower():
+        return UrlEmbedMetadata(
+          url=url,
+          provider=provider,
+          fetched_at=fetched_at,
+          status="error",
+          error=f"HTML 응답이 아닙니다 (Content-Type: {content_type}).",
+        )
+      body = resp.read(_MAX_BODY_BYTES).decode("utf-8", errors="replace")
+
+  except urllib.error.HTTPError as exc:
+    return UrlEmbedMetadata(
+      url=url,
+      provider=provider,
+      fetched_at=fetched_at,
+      status="error",
+      error=f"HTTP {exc.code}: {exc.reason}",
+    )
+  except urllib.error.URLError as exc:
+    return UrlEmbedMetadata(
+      url=url,
+      provider=provider,
+      fetched_at=fetched_at,
+      status="error",
+      error=f"URL 요청 실패: {exc.reason}",
+    )
+  except TimeoutError:
+    return UrlEmbedMetadata(
+      url=url,
+      provider=provider,
+      fetched_at=fetched_at,
+      status="error",
+      error="요청 시간이 초과되었습니다.",
+    )
+
+  # ── 3. HTML 파싱 ─────────────────────────────────────────────────────────
+  parser = _MetaParser()
+  try:
+    parser.feed(body)
+  except Exception:
+    # 비정형 HTML에서 HTMLParser가 예외를 던질 수 있음 — 부분 추출 결과 사용
+    pass
+
+  logo = _resolve_url(url, parser.best_logo)
+
+  return UrlEmbedMetadata(
+    url=url,
+    title=parser.best_title[:200],        # 비정상적으로 긴 title 방어
+    description=parser.best_description[:500],
+    logo=logo,
+    provider=provider,
+    fetched_at=fetched_at,
+    status="success",
+  )

--- a/app/services/url_embed.py
+++ b/app/services/url_embed.py
@@ -119,7 +119,6 @@ class _MetaParser(HTMLParser):
     self._page_title: str = ""
     self._favicon: str = ""
     self._apple_icon: str = ""
-    self._og_image: str = ""
     self._in_title: bool = False
     self._in_head: bool = True   # </head> 이후 파싱 생략
     self._title_buf: list[str] = []
@@ -229,6 +228,33 @@ def _extract_provider(url: str) -> str:
   return hostname
 
 
+# ── SSRF-안전 리다이렉트 핸들러 ───────────────────────────────────────────────
+
+class _SSRFRedirectHandler(urllib.request.HTTPRedirectHandler):
+  """리다이렉트 목적지 URL을 추적할 때마다 SSRF 검사를 재실행한다.
+
+  urllib의 기본 HTTPRedirectHandler는 Location 헤더를 아무 검사 없이 따라간다.
+  서버가 초기 SSRF 검사를 통과한 뒤 내부 주소로 리다이렉트를 유도하는
+  "open redirect via 30x" 공격을 방지하기 위해 각 목적지를 재검증한다.
+
+  Ref: OWASP SSRF Prevention Cheat Sheet — Redirect Handling
+       https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+  """
+
+  def redirect_request(
+    self,
+    req: urllib.request.Request,
+    fp: object,
+    code: int,
+    msg: str,
+    headers: object,
+    newurl: str,
+  ) -> urllib.request.Request | None:
+    if not _is_ssrf_safe(newurl):
+      raise urllib.error.URLError(f"리다이렉트 목적지가 허용되지 않는 주소입니다: {newurl}")
+    return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 # ── 공개 API ─────────────────────────────────────────────────────────────────
 
 def fetch_url_metadata(url: str) -> UrlEmbedMetadata:
@@ -275,8 +301,9 @@ def fetch_url_metadata(url: str) -> UrlEmbedMetadata:
     },
   )
 
+  opener = urllib.request.build_opener(_SSRFRedirectHandler())
   try:
-    with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT) as resp:
+    with opener.open(req, timeout=_FETCH_TIMEOUT) as resp:
       content_type: str = resp.headers.get("Content-Type", "")
       # HTML이 아닌 응답(PDF, 이미지 등)은 파싱 대상이 아님
       if "html" not in content_type.lower():
@@ -287,7 +314,15 @@ def fetch_url_metadata(url: str) -> UrlEmbedMetadata:
           status="error",
           error=f"HTML 응답이 아닙니다 (Content-Type: {content_type}).",
         )
-      body = resp.read(_MAX_BODY_BYTES).decode("utf-8", errors="replace")
+      raw_body = resp.read(_MAX_BODY_BYTES)
+      # Content-Type 헤더의 charset 파라미터를 우선 사용한다.
+      # 예) "text/html; charset=euc-kr" → "euc-kr"
+      # Ref: https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse.headers
+      try:
+        charset = resp.headers.get_content_charset("utf-8") or "utf-8"
+      except LookupError:
+        charset = "utf-8"
+      body = raw_body.decode(charset, errors="replace")
 
   except urllib.error.HTTPError as exc:
     return UrlEmbedMetadata(

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.routers import blocks, database, documents, upload
+from app.routers import blocks, database, documents, upload, url_embed
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -20,6 +20,7 @@ app.include_router(documents.router)
 app.include_router(blocks.router)
 app.include_router(database.router)
 app.include_router(upload.router)
+app.include_router(url_embed.router)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1915,7 +1915,7 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .url-embed-input-wrap[hidden],
 .url-embed-placeholder[hidden],
 .url-embed-error[hidden],
-.url-embed-card[hidden] {
+.url-embed-card-wrap[hidden] {
   display: none;
 }
 
@@ -2021,6 +2021,11 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 
 /* ── 북마크 카드 ──────────────────────────────────────────────────────────── */
 
+/* <a>와 편집 버튼을 감싸는 래퍼 — 편집 버튼 위치 기준점이자 호버 감지 대상 */
+.url-embed-card-wrap {
+  position: relative;
+}
+
 .url-embed-card {
   display: flex;
   align-items: center;
@@ -2032,11 +2037,10 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   text-decoration: none;
   color: inherit;
   transition: border-color 0.15s, box-shadow 0.15s;
-  position: relative;
   overflow: hidden;
 }
 
-.url-embed-card:hover {
+.url-embed-card-wrap:hover .url-embed-card {
   border-color: var(--accent);
   box-shadow: 0 2px 8px var(--shadow);
 }
@@ -2100,7 +2104,10 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-family: inherit;
 }
 
-.url-embed-card:hover .url-embed-edit-btn {
+/* 마우스 호버 또는 키보드 포커스(접근성) 시 편집 버튼 노출
+   Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within */
+.url-embed-card-wrap:hover .url-embed-edit-btn,
+.url-embed-card-wrap:focus-within .url-embed-edit-btn {
   display: block;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1903,6 +1903,164 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   height: 16px;
 }
 
+/* ── URL Embed Block ─────────────────────────────────────────────────────── */
+
+.notion-url-embed {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* ── 입력 폼 ─────────────────────────────────────────────────────────────── */
+
+.url-embed-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border: 1.5px dashed var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+}
+
+.url-embed-input-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.url-embed-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 0.9rem;
+  color: var(--ink);
+  font-family: inherit;
+}
+
+.url-embed-input::placeholder {
+  color: var(--ink-soft);
+}
+
+.url-embed-input:disabled {
+  opacity: 0.5;
+}
+
+/* ── 에러 메시지 ──────────────────────────────────────────────────────────── */
+
+.url-embed-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  color: #c0392b;
+}
+
+.url-embed-retry-btn {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 0.8rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-family: inherit;
+}
+
+.url-embed-retry-btn:hover {
+  background: var(--accent-soft);
+}
+
+/* ── 북마크 카드 ──────────────────────────────────────────────────────────── */
+
+.url-embed-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1.5px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  position: relative;
+  overflow: hidden;
+}
+
+.url-embed-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.url-embed-info {
+  flex: 1;
+  min-width: 0;  /* 텍스트 줄임표 작동을 위해 필요 */
+}
+
+.url-embed-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.url-embed-description {
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+  margin-top: 0.2rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.url-embed-provider {
+  font-size: 0.75rem;
+  color: var(--ink-soft);
+  margin-top: 0.3rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.url-embed-logo {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: 6px;
+  flex-shrink: 0;
+  background: var(--paper);
+}
+
+/* 편집 버튼: 카드 우측 상단, 호버 시 나타남 */
+.url-embed-edit-btn {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  display: none;
+  border: none;
+  background: var(--paper-deep);
+  color: var(--ink-soft);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  line-height: 1.4;
+  font-family: inherit;
+}
+
+.url-embed-card:hover .url-embed-edit-btn {
+  display: block;
+}
+
+.url-embed-edit-btn:hover {
+  background: var(--line);
+  color: var(--ink);
+}
+
 @media (max-width: 920px) {
   .sidebar {
     position: static;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1910,6 +1910,45 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   overflow: hidden;
 }
 
+/* ── 편집 유도 placeholder (기존 블록 / 타입 변환 후) ───────────────────── */
+
+.url-embed-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1.5px dashed var(--line);
+  border-radius: 8px;
+  color: var(--ink-soft);
+  font-size: 0.875rem;
+}
+
+.url-embed-placeholder-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.url-embed-placeholder-text {
+  flex: 1;
+}
+
+.url-embed-placeholder-edit-btn {
+  border: none;
+  background: var(--paper-deep);
+  color: var(--ink-soft);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+
+.url-embed-placeholder-edit-btn:hover {
+  background: var(--line);
+  color: var(--ink);
+}
+
 /* ── 입력 폼 ─────────────────────────────────────────────────────────────── */
 
 .url-embed-input-wrap {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1910,6 +1910,15 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   overflow: hidden;
 }
 
+/* display:flex overrides the UA [hidden]{display:none} rule,
+   so we re-declare it with higher specificity. */
+.url-embed-input-wrap[hidden],
+.url-embed-placeholder[hidden],
+.url-embed-error[hidden],
+.url-embed-card[hidden] {
+  display: none;
+}
+
 /* ── 편집 유도 placeholder (기존 블록 / 타입 변환 후) ───────────────────── */
 
 .url-embed-placeholder {

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -78,6 +78,18 @@ export async function apiUploadImage(file) {
   return res.json();
 }
 
+export async function apiFetchUrlEmbed(url, blockId = null) {
+  const body = { url };
+  if (blockId !== null) body.block_id = blockId;
+  const res = await fetch('/api/url-embed/fetch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error('Failed to fetch url embed');
+  return res.json();
+}
+
 export async function apiMoveBlock(blockId, beforeBlockId) {
   const res = await fetch(`/api/blocks/${blockId}/position`, {
     method: 'PATCH',

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -86,7 +86,10 @@ export async function apiFetchUrlEmbed(url, blockId = null) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error('Failed to fetch url embed');
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail ?? 'URL 메타데이터를 가져올 수 없습니다.');
+  }
   return res.json();
 }
 

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -10,6 +10,7 @@ export const BLOCK_PALETTE_ITEMS = [
   { type: 'code', label: '코드', icon: '⟨⟩' },
   { type: 'callout', label: '콜아웃', icon: '💡' },
   { type: 'divider', label: '구분선', icon: '—' },
+  { type: 'url_embed', label: 'URL 임베드', icon: '🔗' },
   { type: 'page', label: '페이지', icon: '⊔' },
   { type: 'database', label: '데이터베이스', icon: '⊞' },
 ];

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -39,11 +39,12 @@ export const callbacks = {
 
 // ── Public render functions ───────────────────────────────────────────────────
 
-export function renderBlock(block, parentBlockId = null) {
+export function renderBlock(block, parentBlockId = null, { isNew = false } = {}) {
   const blockEl = blockRegistry.create(block, {
     callbacks,
     renderBlock,
     focusBlock,
+    isNew,
   });
   return wrapBlock(blockEl, block, parentBlockId, {
     addBlockAfter: callbacks.addBlockAfter,

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -13,9 +13,10 @@ import * as calloutBlock from "./blocks/calloutBlock.js";
 import * as dividerBlock from "./blocks/dividerBlock.js";
 import * as pageBlock from "./blocks/pageBlock.js";
 import * as databaseBlock from "./blocks/databaseBlock.js";
+import * as urlEmbedBlock from "./blocks/urlEmbedBlock.js";
 
 // 블록 모듈 등록
-[textBlock, imageBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, pageBlock, databaseBlock]
+[textBlock, imageBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, urlEmbedBlock, pageBlock, databaseBlock]
   .forEach((mod) => blockRegistry.register(mod));
 
 // Initialise singleton toolbar once

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -44,13 +44,13 @@ export function create(block, { isNew = false } = {}) {
 
   // ── 상태 전환 헬퍼 ────────────────────────────────────────────────────────
 
-  /** URL 입력 폼을 표시한다. 에러 메시지는 선택적으로 유지한다. */
-  function showInputMode(keepError = false) {
-    input.value = block.url || "";
-    inputWrap.hidden  = false;
-    card.hidden       = true;
+  /** URL 입력 폼을 표시한다. */
+  function showInputMode() {
+    input.value        = block.url || "";
+    inputWrap.hidden   = false;
+    card.hidden        = true;
     placeholder.hidden = true;
-    if (!keepError) errorWrap.hidden = true;
+    errorWrap.hidden   = true;
     input.focus();
   }
 
@@ -83,11 +83,13 @@ export function create(block, { isNew = false } = {}) {
     errorWrap.hidden  = true;
   }
 
-  /** 에러 메시지를 표시하고 입력 폼도 함께 연다. */
+  /** 에러 메시지만 표시한다. 입력창은 재시도/URL변경 버튼을 통해 연다. */
   function showError(msg) {
-    errorMsg.textContent = msg || "메타데이터를 가져올 수 없습니다.";
-    errorWrap.hidden = false;
-    showInputMode(/* keepError */ true);
+    errorMsg.textContent  = msg || "메타데이터를 가져올 수 없습니다.";
+    errorWrap.hidden      = false;
+    inputWrap.hidden      = true;
+    card.hidden           = true;
+    placeholder.hidden    = true;
   }
 
   function setLoading(isLoading) {
@@ -154,10 +156,10 @@ export function create(block, { isNew = false } = {}) {
   // placeholder 편집 버튼 → 입력 폼으로 전환
   placeholderEdit.addEventListener("click", () => showInputMode());
 
-  // 에러 상태 재시도
+  // 에러 상태 재시도 — 저장된 URL로 바로 재요청. URL 없으면 입력창 오픈
   retryBtn.addEventListener("click", () => {
-    const url = input.value.trim() || block.url;
-    if (url) fetchMeta(url);
+    if (block.url) fetchMeta(block.url);
+    else showInputMode();
   });
 
   // 로고 로드 실패 시 숨김

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -1,0 +1,138 @@
+// ── URL Embed Block ───────────────────────────────────────────────────────────
+//
+// 상태 흐름:
+//   pending → (URL 입력 + Enter) → 서버 fetch → success | error
+//   error   → (재시도 버튼 클릭) → 서버 fetch → success | error
+//   success → 북마크 카드 표시, 클릭 시 새 탭으로 이동
+//             편집 버튼(✎) 클릭 → URL 재입력 모드로 전환
+
+import { apiFetchUrlEmbed } from "../api.js";
+
+export const type = "url_embed";
+
+/**
+ * @param {object} block  - 서버에서 받은 블록 데이터
+ * @returns {HTMLElement}
+ */
+export function create(block) {
+  const template = document.getElementById("url-embed-block-template");
+  const node = template.content.firstElementChild.cloneNode(true);
+
+  const inputWrap  = node.querySelector(".url-embed-input-wrap");
+  const input      = node.querySelector(".url-embed-input");
+  const card       = node.querySelector(".url-embed-card");
+  const titleEl    = node.querySelector(".url-embed-title");
+  const descEl     = node.querySelector(".url-embed-description");
+  const providerEl = node.querySelector(".url-embed-provider");
+  const logoEl     = node.querySelector(".url-embed-logo");
+  const editBtn    = node.querySelector(".url-embed-edit-btn");
+  const errorWrap  = node.querySelector(".url-embed-error");
+  const errorMsg   = node.querySelector(".url-embed-error-msg");
+  const retryBtn   = node.querySelector(".url-embed-retry-btn");
+
+  // 상태 렌더링 ─────────────────────────────────────────────────────────────
+
+  function showInputMode() {
+    input.value = block.url || "";
+    inputWrap.hidden = false;
+    card.hidden      = true;
+    errorWrap.hidden = true;
+    input.focus();
+  }
+
+  function showCard() {
+    titleEl.textContent    = block.title       || block.url || "제목 없음";
+    descEl.textContent     = block.description || "";
+    providerEl.textContent = block.provider    || "";
+    card.href              = block.url;
+
+    if (block.logo) {
+      logoEl.src = block.logo;
+      logoEl.hidden = false;
+    } else {
+      logoEl.hidden = true;
+    }
+
+    descEl.hidden  = !block.description;
+    card.hidden    = false;
+    inputWrap.hidden = true;
+    errorWrap.hidden = true;
+  }
+
+  function showError(msg) {
+    errorMsg.textContent = msg || "메타데이터를 가져올 수 없습니다.";
+    input.value = block.url || "";
+    inputWrap.hidden = false;
+    card.hidden      = true;
+    errorWrap.hidden = false;
+  }
+
+  function setLoading(isLoading) {
+    input.disabled = isLoading;
+    input.placeholder = isLoading ? "가져오는 중..." : "URL을 붙여넣으세요...";
+  }
+
+  // 초기 렌더링 ─────────────────────────────────────────────────────────────
+
+  if (block.status === "success" && block.url) {
+    showCard();
+  } else if (block.status === "error") {
+    showError(null);
+  } else {
+    showInputMode();
+  }
+
+  // URL fetch 처리 ──────────────────────────────────────────────────────────
+
+  async function fetchMeta(url) {
+    if (!url) return;
+    setLoading(true);
+    try {
+      const meta = await apiFetchUrlEmbed(url, block.id);
+      // block 객체를 업데이트해서 카드/에러 렌더링에 반영
+      Object.assign(block, meta);
+      if (meta.status === "success") {
+        showCard();
+      } else {
+        showError(meta.error);
+      }
+    } catch (err) {
+      showError("서버 오류가 발생했습니다.");
+      console.error("URL embed fetch 실패:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // 이벤트 ──────────────────────────────────────────────────────────────────
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const url = input.value.trim();
+      if (url) fetchMeta(url);
+    }
+    if (e.key === "Escape") {
+      // 이미 성공 상태가 있으면 카드로 되돌아감
+      if (block.status === "success" && block.url) showCard();
+    }
+  });
+
+  // 카드 표시 중 편집 버튼 → URL 재입력 모드
+  editBtn.addEventListener("click", (e) => {
+    e.preventDefault();  // <a> 클릭 전파 차단
+    e.stopPropagation();
+    showInputMode();
+  });
+
+  // 에러 상태에서 재시도
+  retryBtn.addEventListener("click", () => {
+    const url = input.value.trim() || block.url;
+    if (url) fetchMeta(url);
+  });
+
+  // 로고 로드 실패 시 숨김
+  logoEl.addEventListener("error", () => { logoEl.hidden = true; });
+
+  return node;
+}

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -1,45 +1,68 @@
 // ── URL Embed Block ───────────────────────────────────────────────────────────
 //
 // 상태 흐름:
-//   pending → (URL 입력 + Enter) → 서버 fetch → success | error
-//   error   → (재시도 버튼 클릭) → 서버 fetch → success | error
-//   success → 북마크 카드 표시, 클릭 시 새 탭으로 이동
-//             편집 버튼(✎) 클릭 → URL 재입력 모드로 전환
+//
+//   [생성 직후 isNew=true]         [기존 블록 / 타입 변환]
+//         ↓                                ↓
+//    inputMode (자동 오픈)          placeholder (편집 유도)
+//         ↓ Enter                          ↓ "✎ URL 입력" 버튼
+//    fetch 요청                      inputMode
+//     ├─ success → card               ↓ Enter
+//     └─ error   → inputMode + error  fetch 요청
+//                     ↓ 재시도         ├─ success → card
+//                   fetch 요청         └─ error   → inputMode + error
+//
+//   [card 상태]
+//     호버 → ✎ 버튼 → inputMode
 
 import { apiFetchUrlEmbed } from "../api.js";
 
 export const type = "url_embed";
 
 /**
- * @param {object} block  - 서버에서 받은 블록 데이터
+ * @param {object} block              - 서버에서 받은 블록 데이터
+ * @param {{ isNew?: boolean }} opts  - isNew=true 이면 URL 입력창을 즉시 연다
  * @returns {HTMLElement}
  */
-export function create(block) {
+export function create(block, { isNew = false } = {}) {
   const template = document.getElementById("url-embed-block-template");
   const node = template.content.firstElementChild.cloneNode(true);
 
-  const inputWrap  = node.querySelector(".url-embed-input-wrap");
-  const input      = node.querySelector(".url-embed-input");
-  const card       = node.querySelector(".url-embed-card");
-  const titleEl    = node.querySelector(".url-embed-title");
-  const descEl     = node.querySelector(".url-embed-description");
-  const providerEl = node.querySelector(".url-embed-provider");
-  const logoEl     = node.querySelector(".url-embed-logo");
-  const editBtn    = node.querySelector(".url-embed-edit-btn");
-  const errorWrap  = node.querySelector(".url-embed-error");
-  const errorMsg   = node.querySelector(".url-embed-error-msg");
-  const retryBtn   = node.querySelector(".url-embed-retry-btn");
+  const inputWrap       = node.querySelector(".url-embed-input-wrap");
+  const input           = node.querySelector(".url-embed-input");
+  const card            = node.querySelector(".url-embed-card");
+  const titleEl         = node.querySelector(".url-embed-title");
+  const descEl          = node.querySelector(".url-embed-description");
+  const providerEl      = node.querySelector(".url-embed-provider");
+  const logoEl          = node.querySelector(".url-embed-logo");
+  const editBtn         = node.querySelector(".url-embed-edit-btn");
+  const errorWrap       = node.querySelector(".url-embed-error");
+  const errorMsg        = node.querySelector(".url-embed-error-msg");
+  const retryBtn        = node.querySelector(".url-embed-retry-btn");
+  const placeholder     = node.querySelector(".url-embed-placeholder");
+  const placeholderEdit = node.querySelector(".url-embed-placeholder-edit-btn");
 
-  // 상태 렌더링 ─────────────────────────────────────────────────────────────
+  // ── 상태 전환 헬퍼 ────────────────────────────────────────────────────────
 
-  function showInputMode() {
+  /** URL 입력 폼을 표시한다. 에러 메시지는 선택적으로 유지한다. */
+  function showInputMode(keepError = false) {
     input.value = block.url || "";
-    inputWrap.hidden = false;
-    card.hidden      = true;
-    errorWrap.hidden = true;
+    inputWrap.hidden  = false;
+    card.hidden       = true;
+    placeholder.hidden = true;
+    if (!keepError) errorWrap.hidden = true;
     input.focus();
   }
 
+  /** 편집 유도 placeholder를 표시한다 (기존 블록이 URL 없는 경우). */
+  function showPlaceholder() {
+    placeholder.hidden  = false;
+    inputWrap.hidden    = true;
+    card.hidden         = true;
+    errorWrap.hidden    = true;
+  }
+
+  /** 북마크 카드를 표시한다. */
   function showCard() {
     titleEl.textContent    = block.title       || block.url || "제목 없음";
     descEl.textContent     = block.description || "";
@@ -47,49 +70,50 @@ export function create(block) {
     card.href              = block.url;
 
     if (block.logo) {
-      logoEl.src = block.logo;
+      logoEl.src    = block.logo;
       logoEl.hidden = false;
     } else {
       logoEl.hidden = true;
     }
 
-    descEl.hidden  = !block.description;
-    card.hidden    = false;
-    inputWrap.hidden = true;
-    errorWrap.hidden = true;
+    descEl.hidden     = !block.description;
+    card.hidden       = false;
+    inputWrap.hidden  = true;
+    placeholder.hidden = true;
+    errorWrap.hidden  = true;
   }
 
+  /** 에러 메시지를 표시하고 입력 폼도 함께 연다. */
   function showError(msg) {
     errorMsg.textContent = msg || "메타데이터를 가져올 수 없습니다.";
-    input.value = block.url || "";
-    inputWrap.hidden = false;
-    card.hidden      = true;
     errorWrap.hidden = false;
+    showInputMode(/* keepError */ true);
   }
 
   function setLoading(isLoading) {
-    input.disabled = isLoading;
+    input.disabled    = isLoading;
     input.placeholder = isLoading ? "가져오는 중..." : "URL을 붙여넣으세요...";
   }
 
-  // 초기 렌더링 ─────────────────────────────────────────────────────────────
+  // ── 초기 렌더링 ───────────────────────────────────────────────────────────
 
   if (block.status === "success" && block.url) {
     showCard();
-  } else if (block.status === "error") {
-    showError(null);
-  } else {
+  } else if (isNew) {
+    // 생성 직후: 입력창 자동 오픈
     showInputMode();
+  } else {
+    // 타입 변환 후 리로드 or DB에서 불러온 미입력 블록: 편집 유도 placeholder
+    showPlaceholder();
   }
 
-  // URL fetch 처리 ──────────────────────────────────────────────────────────
+  // ── URL fetch ─────────────────────────────────────────────────────────────
 
   async function fetchMeta(url) {
     if (!url) return;
     setLoading(true);
     try {
       const meta = await apiFetchUrlEmbed(url, block.id);
-      // block 객체를 업데이트해서 카드/에러 렌더링에 반영
       Object.assign(block, meta);
       if (meta.status === "success") {
         showCard();
@@ -104,8 +128,9 @@ export function create(block) {
     }
   }
 
-  // 이벤트 ──────────────────────────────────────────────────────────────────
+  // ── 이벤트 ───────────────────────────────────────────────────────────────
 
+  // 입력 폼 — Enter: fetch / Escape: 이전 상태로 복귀
   input.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
@@ -113,19 +138,23 @@ export function create(block) {
       if (url) fetchMeta(url);
     }
     if (e.key === "Escape") {
-      // 이미 성공 상태가 있으면 카드로 되돌아감
+      // 이미 성공 상태가 있으면 카드로, 없으면 placeholder로
       if (block.status === "success" && block.url) showCard();
+      else showPlaceholder();
     }
   });
 
-  // 카드 표시 중 편집 버튼 → URL 재입력 모드
+  // 카드 편집 버튼 → 입력 폼으로 전환
   editBtn.addEventListener("click", (e) => {
-    e.preventDefault();  // <a> 클릭 전파 차단
+    e.preventDefault();
     e.stopPropagation();
     showInputMode();
   });
 
-  // 에러 상태에서 재시도
+  // placeholder 편집 버튼 → 입력 폼으로 전환
+  placeholderEdit.addEventListener("click", () => showInputMode());
+
+  // 에러 상태 재시도
   retryBtn.addEventListener("click", () => {
     const url = input.value.trim() || block.url;
     if (url) fetchMeta(url);

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -30,7 +30,8 @@ export function create(block, { isNew = false } = {}) {
 
   const inputWrap       = node.querySelector(".url-embed-input-wrap");
   const input           = node.querySelector(".url-embed-input");
-  const card            = node.querySelector(".url-embed-card");
+  const cardWrap        = node.querySelector(".url-embed-card-wrap");
+  const cardLink        = node.querySelector(".url-embed-card");
   const titleEl         = node.querySelector(".url-embed-title");
   const descEl          = node.querySelector(".url-embed-description");
   const providerEl      = node.querySelector(".url-embed-provider");
@@ -48,7 +49,7 @@ export function create(block, { isNew = false } = {}) {
   function showInputMode() {
     input.value        = block.url || "";
     inputWrap.hidden   = false;
-    card.hidden        = true;
+    cardWrap.hidden    = true;
     placeholder.hidden = true;
     errorWrap.hidden   = true;
     input.focus();
@@ -58,7 +59,7 @@ export function create(block, { isNew = false } = {}) {
   function showPlaceholder() {
     placeholder.hidden  = false;
     inputWrap.hidden    = true;
-    card.hidden         = true;
+    cardWrap.hidden     = true;
     errorWrap.hidden    = true;
   }
 
@@ -67,7 +68,7 @@ export function create(block, { isNew = false } = {}) {
     titleEl.textContent    = block.title       || block.url || "제목 없음";
     descEl.textContent     = block.description || "";
     providerEl.textContent = block.provider    || "";
-    card.href              = block.url;
+    cardLink.href          = block.url;
 
     if (block.logo) {
       logoEl.src    = block.logo;
@@ -76,11 +77,11 @@ export function create(block, { isNew = false } = {}) {
       logoEl.hidden = true;
     }
 
-    descEl.hidden     = !block.description;
-    card.hidden       = false;
-    inputWrap.hidden  = true;
+    descEl.hidden      = !block.description;
+    cardWrap.hidden    = false;
+    inputWrap.hidden   = true;
     placeholder.hidden = true;
-    errorWrap.hidden  = true;
+    errorWrap.hidden   = true;
   }
 
   /** 입력창 아래에 에러 메시지를 표시한다. 입력창은 그대로 열려 있다. */
@@ -88,7 +89,7 @@ export function create(block, { isNew = false } = {}) {
     errorMsg.textContent  = msg || "메타데이터를 가져올 수 없습니다.";
     errorWrap.hidden      = false;
     inputWrap.hidden      = false;
-    card.hidden           = true;
+    cardWrap.hidden       = true;
     placeholder.hidden    = true;
   }
 

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -93,8 +93,12 @@ export function create(block, { isNew = false } = {}) {
     placeholder.hidden    = true;
   }
 
+  let isFetching = false;
+
   function setLoading(isLoading) {
+    isFetching        = isLoading;
     input.disabled    = isLoading;
+    retryBtn.disabled = isLoading;
     input.placeholder = isLoading ? "가져오는 중..." : "URL을 붙여넣으세요...";
   }
 
@@ -113,7 +117,7 @@ export function create(block, { isNew = false } = {}) {
   // ── URL fetch ─────────────────────────────────────────────────────────────
 
   async function fetchMeta(url) {
-    if (!url) return;
+    if (!url || isFetching) return;
     setLoading(true);
     try {
       const meta = await apiFetchUrlEmbed(url, block.id);
@@ -124,7 +128,7 @@ export function create(block, { isNew = false } = {}) {
         showError(meta.error);
       }
     } catch (err) {
-      showError("서버 오류가 발생했습니다.");
+      showError(err.message || "서버 오류가 발생했습니다.");
       console.error("URL embed fetch 실패:", err);
     } finally {
       setLoading(false);

--- a/static/js/blocks/urlEmbedBlock.js
+++ b/static/js/blocks/urlEmbedBlock.js
@@ -83,11 +83,11 @@ export function create(block, { isNew = false } = {}) {
     errorWrap.hidden  = true;
   }
 
-  /** 에러 메시지만 표시한다. 입력창은 재시도/URL변경 버튼을 통해 연다. */
+  /** 입력창 아래에 에러 메시지를 표시한다. 입력창은 그대로 열려 있다. */
   function showError(msg) {
     errorMsg.textContent  = msg || "메타데이터를 가져올 수 없습니다.";
     errorWrap.hidden      = false;
-    inputWrap.hidden      = true;
+    inputWrap.hidden      = false;
     card.hidden           = true;
     placeholder.hidden    = true;
   }
@@ -156,10 +156,10 @@ export function create(block, { isNew = false } = {}) {
   // placeholder 편집 버튼 → 입력 폼으로 전환
   placeholderEdit.addEventListener("click", () => showInputMode());
 
-  // 에러 상태 재시도 — 저장된 URL로 바로 재요청. URL 없으면 입력창 오픈
+  // 에러 상태 재시도 — 현재 입력창 값을 우선 사용
   retryBtn.addEventListener("click", () => {
-    if (block.url) fetchMeta(block.url);
-    else showInputMode();
+    const url = input.value.trim() || block.url;
+    if (url) fetchMeta(url);
   });
 
   // 로고 로드 실패 시 숨김

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -193,7 +193,7 @@ async function initGallery() {
       const newBlock = await apiCreateBlock(activeDocId, type, parentBlockId, targetDocumentId);
       const afterWrapper = document.querySelector(`[data-block-id="${afterBlockId}"]`);
       if (afterWrapper) {
-        const newWrapper = renderBlock(newBlock, parentBlockId);
+        const newWrapper = renderBlock(newBlock, parentBlockId, { isNew: true });
         afterWrapper.after(newWrapper);
         const nextWrapper = newWrapper.nextElementSibling;
         if (nextWrapper?.dataset?.blockId) {
@@ -234,7 +234,7 @@ async function initGallery() {
         ? document.querySelector(`[data-block-id="${parentBlockId}"] [data-block-children]`)
         : root;
       if (containerEl) {
-        const newWrapper = renderBlock(newBlock, parentBlockId);
+        const newWrapper = renderBlock(newBlock, parentBlockId, { isNew: true });
         containerEl.appendChild(newWrapper);
         // For container blocks with an auto-created child, focus that child
         const firstChildWrapper = newWrapper.querySelector('[data-block-children] > .block-wrapper');

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -48,6 +48,31 @@
   </div>
 </template>
 
+<template id="url-embed-block-template">
+  <div class="notion-block notion-url-embed">
+    <!-- pending / error: URL 입력 폼 -->
+    <div class="url-embed-input-wrap">
+      <span class="url-embed-input-icon" aria-hidden="true">🔗</span>
+      <input type="text" class="url-embed-input" placeholder="URL을 붙여넣으세요...">
+    </div>
+    <!-- error: 에러 메시지 -->
+    <div class="url-embed-error" hidden>
+      <span class="url-embed-error-msg"></span>
+      <button type="button" class="url-embed-retry-btn">재시도</button>
+    </div>
+    <!-- success: 북마크 카드 -->
+    <a class="url-embed-card" href="#" target="_blank" rel="noopener noreferrer" hidden>
+      <div class="url-embed-info">
+        <div class="url-embed-title"></div>
+        <div class="url-embed-description"></div>
+        <div class="url-embed-provider"></div>
+      </div>
+      <img class="url-embed-logo" alt="" loading="lazy" hidden>
+      <button type="button" class="url-embed-edit-btn" aria-label="URL 변경">✎</button>
+    </a>
+  </div>
+</template>
+
 <template id="callout-block-template">
   <div class="notion-block notion-callout">
     <span class="callout-emoji"></span>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -67,15 +67,17 @@
       <button type="button" class="url-embed-placeholder-edit-btn" aria-label="URL 입력">✎ URL 입력</button>
     </div>
     <!-- success: 북마크 카드 -->
-    <a class="url-embed-card" href="#" target="_blank" rel="noopener noreferrer" hidden>
-      <div class="url-embed-info">
-        <div class="url-embed-title"></div>
-        <div class="url-embed-description"></div>
-        <div class="url-embed-provider"></div>
-      </div>
-      <img class="url-embed-logo" alt="" loading="lazy" hidden>
+    <div class="url-embed-card-wrap" hidden>
+      <a class="url-embed-card" href="#" target="_blank" rel="noopener noreferrer">
+        <div class="url-embed-info">
+          <div class="url-embed-title"></div>
+          <div class="url-embed-description"></div>
+          <div class="url-embed-provider"></div>
+        </div>
+        <img class="url-embed-logo" alt="" loading="lazy" hidden>
+      </a>
       <button type="button" class="url-embed-edit-btn" aria-label="URL 변경">✎</button>
-    </a>
+    </div>
   </div>
 </template>
 

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -50,15 +50,21 @@
 
 <template id="url-embed-block-template">
   <div class="notion-block notion-url-embed">
-    <!-- pending / error: URL 입력 폼 -->
-    <div class="url-embed-input-wrap">
+    <!-- 생성 직후: URL 입력 폼 (isNew=true 일 때만 자동 노출) -->
+    <div class="url-embed-input-wrap" hidden>
       <span class="url-embed-input-icon" aria-hidden="true">🔗</span>
       <input type="text" class="url-embed-input" placeholder="URL을 붙여넣으세요...">
     </div>
-    <!-- error: 에러 메시지 -->
+    <!-- error: 에러 메시지 (입력 폼 위에 표시) -->
     <div class="url-embed-error" hidden>
       <span class="url-embed-error-msg"></span>
       <button type="button" class="url-embed-retry-btn">재시도</button>
+    </div>
+    <!-- pending(기존 블록) / 빈 상태: 편집 유도 placeholder -->
+    <div class="url-embed-placeholder" hidden>
+      <span class="url-embed-placeholder-icon" aria-hidden="true">🔗</span>
+      <span class="url-embed-placeholder-text">URL 임베드</span>
+      <button type="button" class="url-embed-placeholder-edit-btn" aria-label="URL 입력">✎ URL 입력</button>
     </div>
     <!-- success: 북마크 카드 -->
     <a class="url-embed-card" href="#" target="_blank" rel="noopener noreferrer" hidden>

--- a/tests/test_url_embed.py
+++ b/tests/test_url_embed.py
@@ -1,0 +1,493 @@
+"""URL 임베드 블록 기능 단위 테스트 (이슈 #36).
+
+커버리지 범위:
+  1. _MetaParser  — OG / Twitter Card / 기본 HTML 태그 파싱
+  2. _is_ssrf_safe — 차단 규칙 (프로토콜, 사설 IP, 루프백)
+  3. fetch_url_metadata — HTTP 성공/실패/비HTML 응답 시나리오
+  4. Repository 레이어 — url_embed 블록 생성·업데이트·타입 변환
+  5. API 레이어 — POST /api/url-embed/fetch, POST /api/documents/{id}/blocks
+"""
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── 1. _MetaParser ────────────────────────────────────────────────────────────
+
+class TestMetaParser:
+  """HTML 소스에서 메타데이터를 올바르게 추출하는지 검증."""
+
+  def _parse(self, html: str):
+    from app.services.url_embed import _MetaParser
+    p = _MetaParser()
+    p.feed(html)
+    return p
+
+  def test_og_title_extracted(self):
+    p = self._parse('<meta property="og:title" content="OG Title">')
+    assert p.best_title == "OG Title"
+
+  def test_og_description_extracted(self):
+    p = self._parse('<meta property="og:description" content="OG Desc">')
+    assert p.best_description == "OG Desc"
+
+  def test_og_image_extracted(self):
+    p = self._parse('<meta property="og:image" content="https://example.com/img.png">')
+    assert p.best_logo == "https://example.com/img.png"
+
+  def test_twitter_card_fallback(self):
+    """OG 태그 없을 때 Twitter Card를 사용한다."""
+    p = self._parse(
+      '<meta name="twitter:title" content="TW Title">'
+      '<meta name="twitter:description" content="TW Desc">'
+    )
+    assert p.best_title == "TW Title"
+    assert p.best_description == "TW Desc"
+
+  def test_og_takes_priority_over_twitter(self):
+    """OG 태그가 Twitter Card보다 우선한다."""
+    p = self._parse(
+      '<meta property="og:title" content="OG Title">'
+      '<meta name="twitter:title" content="TW Title">'
+    )
+    assert p.best_title == "OG Title"
+
+  def test_html_title_fallback(self):
+    """OG / Twitter 없을 때 <title> 태그를 사용한다."""
+    p = self._parse("<title>  페이지 제목  </title>")
+    assert p.best_title == "페이지 제목"
+
+  def test_meta_description_fallback(self):
+    """OG / Twitter 없을 때 meta[name=description]을 사용한다."""
+    p = self._parse('<meta name="description" content="기본 설명">')
+    assert p.best_description == "기본 설명"
+
+  def test_favicon_link_extracted(self):
+    p = self._parse('<link rel="icon" href="/favicon.ico">')
+    assert p.best_logo == "/favicon.ico"
+
+  def test_apple_touch_icon_preferred_over_favicon(self):
+    """apple-touch-icon이 favicon보다 우선한다."""
+    p = self._parse(
+      '<link rel="icon" href="/favicon.ico">'
+      '<link rel="apple-touch-icon" href="/apple.png">'
+    )
+    assert p.best_logo == "/apple.png"
+
+  def test_og_image_preferred_over_apple_icon(self):
+    """og:image가 apple-touch-icon보다 우선한다."""
+    p = self._parse(
+      '<meta property="og:image" content="https://cdn.example.com/og.jpg">'
+      '<link rel="apple-touch-icon" href="/apple.png">'
+    )
+    assert p.best_logo == "https://cdn.example.com/og.jpg"
+
+  def test_no_metadata_returns_empty(self):
+    p = self._parse("<html><head></head><body><p>본문</p></body></html>")
+    assert p.best_title == ""
+    assert p.best_description == ""
+    assert p.best_logo == ""
+
+  def test_parsing_stops_after_head_closes(self):
+    """</head> 이후 본문에 있는 태그는 무시한다."""
+    p = self._parse(
+      "<head><title>HEAD 제목</title></head>"
+      "<body><meta property='og:title' content='BODY 태그'></body>"
+    )
+    assert p.best_title == "HEAD 제목"
+
+  def test_empty_content_attribute_ignored(self):
+    """content 속성이 빈 문자열인 meta 태그는 무시한다."""
+    p = self._parse(
+      '<meta property="og:title" content="">'
+      "<title>폴백 제목</title>"
+    )
+    assert p.best_title == "폴백 제목"
+
+
+# ── 2. _is_ssrf_safe ──────────────────────────────────────────────────────────
+
+class TestIsSSRFSafe:
+  """SSRF 방어 로직이 사설/루프백 주소를 올바르게 차단하는지 검증."""
+
+  def _safe(self, url: str) -> bool:
+    from app.services.url_embed import _is_ssrf_safe
+    return _is_ssrf_safe(url)
+
+  def _mock_resolve(self, ip: str):
+    """getaddrinfo를 특정 IP를 반환하도록 패치하는 컨텍스트 반환."""
+    return patch(
+      "app.services.url_embed.socket.getaddrinfo",
+      return_value=[(None, None, None, None, (ip, 0))],
+    )
+
+  def test_public_ip_allowed(self):
+    with self._mock_resolve("93.184.216.34"):  # example.com
+      assert self._safe("https://example.com") is True
+
+  def test_loopback_blocked(self):
+    with self._mock_resolve("127.0.0.1"):
+      assert self._safe("http://localhost") is False
+
+  def test_private_class_a_blocked(self):
+    with self._mock_resolve("10.0.0.1"):
+      assert self._safe("http://internal.corp") is False
+
+  def test_private_class_b_blocked(self):
+    with self._mock_resolve("172.16.0.1"):
+      assert self._safe("http://internal.corp") is False
+
+  def test_private_class_c_blocked(self):
+    with self._mock_resolve("192.168.1.1"):
+      assert self._safe("http://router.local") is False
+
+  def test_link_local_blocked(self):
+    with self._mock_resolve("169.254.169.254"):  # AWS 메타데이터 엔드포인트
+      assert self._safe("http://169.254.169.254") is False
+
+  def test_ipv6_loopback_blocked(self):
+    with self._mock_resolve("::1"):
+      assert self._safe("http://[::1]") is False
+
+  def test_ftp_protocol_blocked(self):
+    assert self._safe("ftp://example.com/file") is False
+
+  def test_file_protocol_blocked(self):
+    assert self._safe("file:///etc/passwd") is False
+
+  def test_unresolvable_hostname_blocked(self):
+    with patch(
+      "app.services.url_embed.socket.getaddrinfo",
+      side_effect=socket.gaierror("Name not resolved"),
+    ):
+      assert self._safe("http://does-not-exist.invalid") is False
+
+  def test_empty_url_blocked(self):
+    assert self._safe("") is False
+
+  def test_no_scheme_blocked(self):
+    assert self._safe("example.com/path") is False
+
+
+# ── 3. fetch_url_metadata ─────────────────────────────────────────────────────
+
+class TestFetchUrlMetadata:
+  """fetch_url_metadata의 성공/실패 시나리오를 검증."""
+
+  _SAMPLE_HTML = """
+  <html><head>
+    <title>샘플 페이지</title>
+    <meta property="og:title" content="OG 제목">
+    <meta property="og:description" content="OG 설명">
+    <meta property="og:image" content="https://example.com/og.jpg">
+  </head><body></body></html>
+  """
+
+  def _make_mock_response(self, html: str, content_type: str = "text/html; charset=utf-8"):
+    """urllib.request.urlopen 응답을 흉내 내는 컨텍스트 매니저 Mock."""
+    mock_resp = MagicMock()
+    mock_resp.headers.get.return_value = content_type
+    mock_resp.read.return_value = html.encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+  def _fetch(self, url: str, html: str, content_type: str = "text/html"):
+    from app.services.url_embed import fetch_url_metadata
+
+    mock_resp = self._make_mock_response(html, content_type)
+    with (
+      patch("app.services.url_embed._is_ssrf_safe", return_value=True),
+      patch("app.services.url_embed.urllib.request.urlopen", return_value=mock_resp),
+    ):
+      return fetch_url_metadata(url)
+
+  # ── 성공 시나리오 ──────────────────────────────────────────────────────────
+
+  def test_success_returns_og_fields(self):
+    meta = self._fetch("https://example.com", self._SAMPLE_HTML)
+    assert meta.status == "success"
+    assert meta.title == "OG 제목"
+    assert meta.description == "OG 설명"
+    assert meta.logo == "https://example.com/og.jpg"
+
+  def test_provider_extracted_without_www(self):
+    meta = self._fetch("https://www.example.com", self._SAMPLE_HTML)
+    assert meta.provider == "example.com"
+
+  def test_relative_logo_resolved_to_absolute(self):
+    html = (
+      "<html><head>"
+      '<link rel="icon" href="/favicon.ico">'
+      "</head><body></body></html>"
+    )
+    meta = self._fetch("https://example.com/page", html)
+    assert meta.logo == "https://example.com/favicon.ico"
+
+  def test_fetched_at_is_populated(self):
+    meta = self._fetch("https://example.com", self._SAMPLE_HTML)
+    assert meta.fetched_at != ""
+
+  def test_title_truncated_to_200_chars(self):
+    long_title = "A" * 300
+    html = f"<html><head><title>{long_title}</title></head></html>"
+    meta = self._fetch("https://example.com", html)
+    assert len(meta.title) <= 200
+
+  def test_description_truncated_to_500_chars(self):
+    long_desc = "D" * 600
+    html = f'<html><head><meta name="description" content="{long_desc}"></head></html>'
+    meta = self._fetch("https://example.com", html)
+    assert len(meta.description) <= 500
+
+  # ── 실패 시나리오 ──────────────────────────────────────────────────────────
+
+  def test_ssrf_blocked_returns_error(self):
+    from app.services.url_embed import fetch_url_metadata
+
+    with patch("app.services.url_embed._is_ssrf_safe", return_value=False):
+      meta = fetch_url_metadata("http://192.168.1.1")
+    assert meta.status == "error"
+    assert meta.error != ""
+
+  def test_http_error_returns_error(self):
+    import urllib.error
+    from app.services.url_embed import fetch_url_metadata
+
+    with (
+      patch("app.services.url_embed._is_ssrf_safe", return_value=True),
+      patch(
+        "app.services.url_embed.urllib.request.urlopen",
+        side_effect=urllib.error.HTTPError(None, 404, "Not Found", {}, None),
+      ),
+    ):
+      meta = fetch_url_metadata("https://example.com/missing")
+    assert meta.status == "error"
+    assert "404" in meta.error
+
+  def test_url_error_returns_error(self):
+    import urllib.error
+    from app.services.url_embed import fetch_url_metadata
+
+    with (
+      patch("app.services.url_embed._is_ssrf_safe", return_value=True),
+      patch(
+        "app.services.url_embed.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+      ),
+    ):
+      meta = fetch_url_metadata("https://unreachable.example.com")
+    assert meta.status == "error"
+
+  def test_timeout_returns_error(self):
+    from app.services.url_embed import fetch_url_metadata
+
+    with (
+      patch("app.services.url_embed._is_ssrf_safe", return_value=True),
+      patch(
+        "app.services.url_embed.urllib.request.urlopen",
+        side_effect=TimeoutError(),
+      ),
+    ):
+      meta = fetch_url_metadata("https://slow.example.com")
+    assert meta.status == "error"
+    assert "초과" in meta.error
+
+  def test_non_html_content_type_returns_error(self):
+    meta = self._fetch("https://example.com/doc.pdf", "", content_type="application/pdf")
+    assert meta.status == "error"
+
+  def test_malformed_html_does_not_raise(self):
+    """비정형 HTML에서도 예외 없이 부분 결과를 반환한다."""
+    meta = self._fetch("https://example.com", "<<<not valid html>>>")
+    assert meta.status == "success"  # 예외가 없으면 성공으로 처리
+
+
+# ── 4. Repository 레이어 ──────────────────────────────────────────────────────
+
+class TestUrlEmbedRepository:
+  """SQLiteBlockRepository에서 url_embed 블록의 CRUD를 검증."""
+
+  def test_create_url_embed_block(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "url_embed")
+    assert block is not None
+    assert block["type"] == "url_embed"
+    assert block["url"] == ""
+    assert block["status"] == "pending"
+
+  def test_create_url_embed_returns_all_fields(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "url_embed")
+    for field in ("url", "title", "description", "logo", "provider", "fetched_at", "status"):
+      assert field in block, f"필드 누락: {field}"
+
+  def test_update_url_embed_metadata(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "url_embed")
+    patch_data = {
+      "url": "https://example.com",
+      "title": "예시 사이트",
+      "description": "예시 설명",
+      "logo": "https://example.com/favicon.ico",
+      "provider": "example.com",
+      "fetched_at": "2026-04-12T00:00:00+00:00",
+      "status": "success",
+    }
+    assert repo.update_block(block["id"], patch_data)
+    fetched = repo.get_document(doc["id"])
+    embed = fetched.blocks[0]
+    assert embed.type == "url_embed"
+    assert embed.url == "https://example.com"
+    assert embed.title == "예시 사이트"
+    assert embed.status == "success"
+
+  def test_url_embed_persists_across_get_document(self, repo):
+    """저장 후 문서를 다시 불러왔을 때 url_embed 블록이 유지된다."""
+    doc = repo.create_document()
+    repo.create_block(doc["id"], "url_embed")
+    repo.update_block(
+      repo.get_document(doc["id"]).blocks[0].id,
+      {"url": "https://example.com", "title": "저장 테스트", "status": "success"},
+    )
+    refetched = repo.get_document(doc["id"])
+    embed = refetched.blocks[0]
+    assert embed.url == "https://example.com"
+    assert embed.title == "저장 테스트"
+
+  def test_change_type_to_url_embed(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "text")
+    assert repo.change_block_type(block["id"], "url_embed")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "url_embed"
+    assert fetched.blocks[0].status == "pending"
+
+  def test_change_type_from_url_embed_to_text(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "url_embed")
+    assert repo.change_block_type(block["id"], "text")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "text"
+
+  def test_delete_url_embed_block(self, repo):
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "url_embed")
+    assert repo.delete_block(block["id"])
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 0
+
+
+# ── 5. API 레이어 ─────────────────────────────────────────────────────────────
+
+class TestUrlEmbedAPI:
+  """HTTP API를 통한 url_embed 블록 생성·조회·메타데이터 페치를 검증."""
+
+  def test_create_url_embed_block_via_api(self, client):
+    doc = client.post("/api/documents").json()
+    resp = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "url_embed"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "url_embed"
+    assert data["status"] == "pending"
+
+  def test_get_document_includes_url_embed_block(self, client):
+    doc = client.post("/api/documents").json()
+    client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "url_embed"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["type"] == "url_embed"
+
+  def test_patch_url_embed_url_via_blocks_api(self, client):
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "url_embed"},
+    ).json()
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"url": "https://example.com"})
+    assert resp.status_code == 200
+
+  def test_change_type_to_url_embed_via_api(self, client):
+    doc = client.post("/api/documents").json()
+    block = client.post(f"/api/documents/{doc['id']}/blocks", json={"type": "text"}).json()
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": "url_embed"})
+    assert resp.status_code == 200
+
+  def test_fetch_endpoint_ssrf_blocked(self, client):
+    """사설 IP를 가리키는 URL은 status="error"로 응답한다."""
+    with patch("app.services.url_embed._is_ssrf_safe", return_value=False):
+      resp = client.post("/api/url-embed/fetch", json={"url": "http://192.168.1.1"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+  def test_fetch_endpoint_success_updates_block(self, client):
+    """block_id 전달 시 fetch 결과가 블록에 저장된다."""
+    from unittest.mock import MagicMock, patch as mpatch
+
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "url_embed"},
+    ).json()
+
+    mock_meta = MagicMock()
+    mock_meta.url = "https://example.com"
+    mock_meta.title = "Mock Title"
+    mock_meta.description = "Mock Desc"
+    mock_meta.logo = "https://example.com/logo.png"
+    mock_meta.provider = "example.com"
+    mock_meta.fetched_at = "2026-04-12T00:00:00+00:00"
+    mock_meta.status = "success"
+    mock_meta.error = ""
+
+    with mpatch("app.routers.url_embed.fetch_url_metadata", return_value=mock_meta):
+      resp = client.post(
+        "/api/url-embed/fetch",
+        json={"url": "https://example.com", "block_id": block["id"]},
+      )
+
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Mock Title"
+
+    # 블록이 실제로 업데이트됐는지 확인
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    embed = fetched["blocks"][0]
+    assert embed["title"] == "Mock Title"
+    assert embed["status"] == "success"
+
+  def test_fetch_endpoint_invalid_block_id_returns_404(self, client):
+    """존재하지 않는 block_id 전달 시 404를 반환한다."""
+    mock_meta = MagicMock()
+    mock_meta.url = "https://example.com"
+    mock_meta.title = ""
+    mock_meta.description = ""
+    mock_meta.logo = ""
+    mock_meta.provider = "example.com"
+    mock_meta.fetched_at = ""
+    mock_meta.status = "success"
+    mock_meta.error = ""
+
+    with patch("app.routers.url_embed.fetch_url_metadata", return_value=mock_meta):
+      resp = client.post(
+        "/api/url-embed/fetch",
+        json={"url": "https://example.com", "block_id": "nonexistent-id"},
+      )
+    assert resp.status_code == 404
+
+  def test_fetch_endpoint_rejects_empty_url(self, client):
+    resp = client.post("/api/url-embed/fetch", json={"url": ""})
+    assert resp.status_code == 422
+
+  def test_fetch_endpoint_rejects_non_http_url(self, client):
+    resp = client.post("/api/url-embed/fetch", json={"url": "ftp://example.com/file"})
+    assert resp.status_code == 422
+
+  def test_fetch_endpoint_rejects_url_over_max_length(self, client):
+    long_url = "https://example.com/" + "a" * 2048
+    resp = client.post("/api/url-embed/fetch", json={"url": long_url})
+    assert resp.status_code == 422

--- a/tests/test_url_embed.py
+++ b/tests/test_url_embed.py
@@ -187,9 +187,10 @@ class TestFetchUrlMetadata:
   """
 
   def _make_mock_response(self, html: str, content_type: str = "text/html; charset=utf-8"):
-    """urllib.request.urlopen 응답을 흉내 내는 컨텍스트 매니저 Mock."""
+    """build_opener().open() 응답을 흉내 내는 컨텍스트 매니저 Mock."""
     mock_resp = MagicMock()
     mock_resp.headers.get.return_value = content_type
+    mock_resp.headers.get_content_charset.return_value = "utf-8"
     mock_resp.read.return_value = html.encode("utf-8")
     mock_resp.__enter__ = lambda s: s
     mock_resp.__exit__ = MagicMock(return_value=False)
@@ -199,9 +200,11 @@ class TestFetchUrlMetadata:
     from app.services.url_embed import fetch_url_metadata
 
     mock_resp = self._make_mock_response(html, content_type)
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_resp
     with (
       patch("app.services.url_embed._is_ssrf_safe", return_value=True),
-      patch("app.services.url_embed.urllib.request.urlopen", return_value=mock_resp),
+      patch("app.services.url_embed.urllib.request.build_opener", return_value=mock_opener),
     ):
       return fetch_url_metadata(url)
 
@@ -257,12 +260,11 @@ class TestFetchUrlMetadata:
     import urllib.error
     from app.services.url_embed import fetch_url_metadata
 
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = urllib.error.HTTPError(None, 404, "Not Found", {}, None)
     with (
       patch("app.services.url_embed._is_ssrf_safe", return_value=True),
-      patch(
-        "app.services.url_embed.urllib.request.urlopen",
-        side_effect=urllib.error.HTTPError(None, 404, "Not Found", {}, None),
-      ),
+      patch("app.services.url_embed.urllib.request.build_opener", return_value=mock_opener),
     ):
       meta = fetch_url_metadata("https://example.com/missing")
     assert meta.status == "error"
@@ -272,12 +274,11 @@ class TestFetchUrlMetadata:
     import urllib.error
     from app.services.url_embed import fetch_url_metadata
 
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = urllib.error.URLError("connection refused")
     with (
       patch("app.services.url_embed._is_ssrf_safe", return_value=True),
-      patch(
-        "app.services.url_embed.urllib.request.urlopen",
-        side_effect=urllib.error.URLError("connection refused"),
-      ),
+      patch("app.services.url_embed.urllib.request.build_opener", return_value=mock_opener),
     ):
       meta = fetch_url_metadata("https://unreachable.example.com")
     assert meta.status == "error"
@@ -285,12 +286,11 @@ class TestFetchUrlMetadata:
   def test_timeout_returns_error(self):
     from app.services.url_embed import fetch_url_metadata
 
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = TimeoutError()
     with (
       patch("app.services.url_embed._is_ssrf_safe", return_value=True),
-      patch(
-        "app.services.url_embed.urllib.request.urlopen",
-        side_effect=TimeoutError(),
-      ),
+      patch("app.services.url_embed.urllib.request.build_opener", return_value=mock_opener),
     ):
       meta = fetch_url_metadata("https://slow.example.com")
     assert meta.status == "error"


### PR DESCRIPTION
## 관련 이슈

Close #36

## 배경 및 목적

노션 스타일 북마크 카드 형태의 URL 임베드 블록을 추가합니다.
URL을 붙여넣으면 서버가 Open Graph / Twitter Card / HTML 메타태그를 수집하여
제목, 설명, 로고, 도메인을 카드로 표시하고, 클릭 시 해당 링크로 이동합니다.

## 변경 사항

### Backend
- `app/models/blocks.py` — `UrlEmbedBlock` Pydantic 모델 추가 및 `Block` 유니온 등록
- `app/services/url_embed.py` — URL 메타데이터 스크래핑 서비스
  - Open Graph → Twitter Card → HTML 기본 태그 우선순위 적용
  - SSRF 방지: http/https 제한, RFC 1918/4193 사설·루프백 IP 차단
  - 응답 바디 최대 2 MB 제한, 타임아웃 10초
  - 실패 시 `status="error"` 로 graceful fallback
- `app/routers/url_embed.py` — `POST /api/url-embed/fetch` 엔드포인트
  - `block_id` 전달 시 fetch 완료 즉시 블록 업데이트
- `app/repositories/sqlite_blocks.py` — `create_block`, `change_block_type` 에 `url_embed` 케이스 추가
- `app/routers/documents.py`, `app/routers/blocks.py` — `url_embed` 타입 허용
- `main.py` — `url_embed` 라우터 등록

### Frontend
- `static/js/api.js` — `apiFetchUrlEmbed()` 헬퍼 추가
- `static/js/blocks/urlEmbedBlock.js` — 블록 모듈 구현
  - **생성 직후** (`isNew=true`): URL 입력창 자동 오픈
  - **타입 변환 / DB 로드** (`isNew=false`): 편집 유도 placeholder 표시, 수동으로 "✎ URL 입력" 클릭 시 입력창 오픈
  - **fetch 성공**: 북마크 카드 표시, 카드 클릭 → 새 탭 이동, 호버 시 ✎ 버튼으로 URL 재입력
  - **fetch 실패**: 입력창 아래에 에러 메시지 + 재시도 버튼
- `static/js/blockPalette.js` — `BLOCK_PALETTE_ITEMS` 에 `url_embed` 추가 (슬래시 커맨드·타입 변경 드롭다운 동시 반영)
- `static/js/blockRenderers.js` — `urlEmbedBlock` 등록, `renderBlock` 에 `isNew` 옵션 추가
- `static/js/main.js` — `addBlock` / `addBlockAfter` 에서 `renderBlock` 호출 시 `{ isNew: true }` 전달
- `templates/partials/block_templates.html` — `url-embed-block-template` 추가
- `static/css/style.css` — 북마크 카드, 입력 폼, placeholder, 에러 스타일 추가; `display:flex` 로 인한 `[hidden]` 오버라이드 보정

### Test
- `tests/test_url_embed.py` — 54개 단위 테스트 (전체 134개 통과)
  - `TestMetaParser`: OG / Twitter Card / HTML 태그 파싱 및 우선순위
  - `TestIsSSRFSafe`: 프로토콜·사설 IP·루프백 차단 검증
  - `TestFetchUrlMetadata`: HTTP 성공/실패/타임아웃/비HTML 시나리오
  - `TestUrlEmbedRepository`: 블록 CRUD 및 타입 변환
  - `TestUrlEmbedAPI`: 엔드포인트 동작 및 블록 자동 업데이트

## 테스트 결과

```
134 passed in 0.72s
```

## 리뷰 포인트

- `_is_ssrf_safe()` — DNS rebinding 방지를 위해 단일 호스트명의 모든 해석 주소를 검사합니다. TOCTOU는 허용 범위로 판단했습니다.
- `isNew` 플래그 전달 경로 — `addBlock` / `addBlockAfter` 에서만 `{ isNew: true }` 를 전달하며, `renderDocument` (DB 로드·타입 변환 후 리로드) 경로에서는 기본값 `false` 를 사용합니다.
- `display:flex` + `[hidden]` 충돌 — 기존 `.document-children[hidden]` 패턴과 동일하게 명시도 높은 선택자로 보정했습니다.