### PR TITLE
[FEAT#39] 텍스트 블록 슬래시 커맨드 기반 블록 전환 UX 개선

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2154,3 +2154,116 @@ body.sidebar-collapsed .sidebar-tab-chevron {
     flex-direction: column;
   }
 }
+
+/* ── Inline Slash Command Menu ──────────────────────────────────────────────────
+ *
+ * 텍스트 블록에서 '/' 입력 시 나타나는 인라인 블록 타입 전환 드롭다운.
+ *
+ * 배치 방향:
+ *   기본 — 앵커 요소 위쪽 (position: fixed; bottom 지정)
+ *   fallback — 상단 공간 부족 시 아래쪽 (JS 에서 data-direction="down" 부여)
+ *
+ * ARIA: role="listbox" / role="option" 구조를 따른다.
+ * 참고: WAI-ARIA 1.2 Listbox Pattern
+ *       https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
+ * ────────────────────────────────────────────────────────────────────────────── */
+
+.inline-slash-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 200px;
+  max-width: 320px;
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  padding: 4px 0;
+
+  /* 부드러운 등장 애니메이션 */
+  animation: inline-slash-menu-in 0.12s ease-out;
+}
+
+/* 위쪽으로 열릴 때 transform origin을 아래쪽으로 설정 */
+.inline-slash-menu[data-direction="up"] {
+  transform-origin: bottom left;
+}
+
+/* 아래쪽으로 열릴 때 transform origin을 위쪽으로 설정 */
+.inline-slash-menu[data-direction="down"] {
+  transform-origin: top left;
+}
+
+@keyframes inline-slash-menu-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* 각 블록 타입 옵션 버튼 */
+.inline-slash-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--text-primary, #1a1a1a);
+  text-align: left;
+  transition: background 0.08s;
+
+  /* 버튼 기본 리셋 */
+  outline: none;
+}
+
+.inline-slash-menu__item:hover,
+.inline-slash-menu__item.is-highlighted {
+  background: var(--hover-bg, #f0f0f0);
+}
+
+/* 키보드 포커스 링: 마우스 사용자에게는 숨기고 키보드 사용자에게만 표시 */
+.inline-slash-menu__item:focus-visible {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: -2px;
+}
+
+/* 아이콘 영역 */
+.inline-slash-menu__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border-radius: 4px;
+  background: var(--surface-raised, #f5f5f5);
+  color: var(--text-secondary, #555);
+  border: 1px solid var(--border, #e0e0e0);
+}
+
+/* 레이블 */
+.inline-slash-menu__label {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: inherit;
+}
+
+/* 필터 결과 없음 메시지 */
+.inline-slash-menu__empty {
+  padding: 10px 16px;
+  font-size: 0.8rem;
+  color: var(--text-muted, #999);
+  text-align: center;
+}

--- a/static/js/blocks/inlineSlashMenu.js
+++ b/static/js/blocks/inlineSlashMenu.js
@@ -204,6 +204,12 @@ export function openInlineSlashMenu(anchorEl, blockId, currentBlockType, { reloa
    */
   async function executeItem(item) {
     close();
+    // anchorEl.contentEditable 을 미리 "false" 로 설정한다.
+    // reloadDocument() 가 DOM 을 재구성하면서 node 가 제거될 때 브라우저가
+    // blur 이벤트를 발생시킨다. 이 시점에 textEditing.js 의 blur 핸들러가
+    // "if (node.contentEditable !== 'true') return" 으로 조기 반환하도록 해
+    // '/' 텍스트가 API 에 저장되는 것을 방지한다.
+    anchorEl.contentEditable = "false";
     try {
       if (item.level != null) {
         // heading 전환: text 타입 + level 변경

--- a/static/js/blocks/inlineSlashMenu.js
+++ b/static/js/blocks/inlineSlashMenu.js
@@ -97,6 +97,12 @@ function positionMenu(menuEl, anchorEl) {
 
 // ── 핵심 공개 API ─────────────────────────────────────────────────────────────
 
+// 활성 메뉴의 close 함수를 보관하는 레지스트리.
+// closeAllInlineSlashMenus() 가 DOM 만 제거하면 anchorEl 의 keydown 리스너와
+// document mousedown 리스너가 정리되지 않아 이벤트 핸들러가 누적된다.
+// 각 메뉴 인스턴스의 close() 를 직접 호출해 완전한 cleanup 을 보장한다.
+const _activeCleanups = new Set();
+
 /**
  * 인라인 슬래시 커맨드 메뉴를 연다.
  * 메뉴가 이미 열려 있으면 기존 것을 닫고 새로 연다.
@@ -106,11 +112,15 @@ function positionMenu(menuEl, anchorEl) {
  * @param {string}      currentBlockType - 현재 블록 타입 (heading level 분기에 사용)
  * @param {object}      opts
  * @param {Function}   [opts.reloadDocument] - 블록 전환 완료 후 문서 재렌더링 콜백
+ * @param {Function}   [opts.onClose]        - 메뉴가 닫힐 때 호출되는 콜백
+ *   호출자(textEditing.js)가 slashMenu 상태를 null 로 동기화하는 데 사용한다.
+ *   외부 클릭·Enter·Esc 등 메뉴 자체가 닫히는 경우에도 호출자가 상태를 인지할 수 있도록
+ *   onClose 를 통해 상태를 동기화한다.
  *
  * @returns {{ updateQuery: (q:string)=>void, close: ()=>void }}
  *   열린 메뉴의 제어 핸들을 반환한다 (textEditing.js 에서 query 업데이트에 사용).
  */
-export function openInlineSlashMenu(anchorEl, blockId, currentBlockType, { reloadDocument = null } = {}) {
+export function openInlineSlashMenu(anchorEl, blockId, currentBlockType, { reloadDocument = null, onClose = null } = {}) {
   // 기존 메뉴 제거 (중복 방지)
   closeAllInlineSlashMenus();
 
@@ -308,15 +318,29 @@ export function openInlineSlashMenu(anchorEl, blockId, currentBlockType, { reloa
     menuEl.remove();
     anchorEl.removeEventListener("keydown", onKeydown, { capture: true });
     removeOutsideListener();
+    _activeCleanups.delete(close);
+    // 호출자에게 닫힘 사실을 통보해 slashMenu 상태를 동기화한다.
+    // 외부 클릭·Enter·Esc 등 메뉴 자체가 닫히는 경우에도 호출자가 상태를 인지할 수 있도록
+    // 한다. (참고: Observer 패턴 — GoF Design Patterns §5.7)
+    onClose?.();
   }
+
+  // 레지스트리에 등록: closeAllInlineSlashMenus 가 리스너까지 완전히 정리할 수 있도록 한다.
+  _activeCleanups.add(close);
 
   return { updateQuery, close };
 }
 
 /**
- * 페이지에 열려 있는 모든 인라인 슬래시 메뉴를 제거한다.
- * (예: 다른 블록 클릭 시 기존 메뉴 정리)
+ * 페이지에 열려 있는 모든 인라인 슬래시 메뉴를 닫는다.
+ *
+ * DOM 요소만 제거하면 anchorEl 의 keydown(capture) 리스너와
+ * document mousedown 리스너가 정리되지 않아 핸들러가 누적된다.
+ * 레지스트리(_activeCleanups)에 등록된 각 메뉴의 close() 를 직접 호출해
+ * 리스너까지 완전히 정리한다.
  */
 export function closeAllInlineSlashMenus() {
-  document.querySelectorAll(".inline-slash-menu").forEach((el) => el.remove());
+  // Set 을 복사한 뒤 순회한다: close() 내부에서 _activeCleanups.delete 가 호출되므로
+  // 원본을 순회하면 반복 중 컬렉션이 변경되어 일부 항목이 건너뛰어질 수 있다.
+  new Set(_activeCleanups).forEach((fn) => fn());
 }

--- a/static/js/blocks/inlineSlashMenu.js
+++ b/static/js/blocks/inlineSlashMenu.js
@@ -49,7 +49,7 @@ export function filterSlashItems(query) {
   return SLASH_MENU_ITEMS.filter(
     (item) =>
       item.label.toLowerCase().includes(q) ||
-      item.keywords.some((k) => k.includes(q)),
+      item.keywords.some((k) => k.toLowerCase().includes(q)),
   );
 }
 
@@ -75,7 +75,10 @@ function positionMenu(menuEl, anchorEl) {
   // position: fixed 로 viewport 좌표 직접 지정
   menuEl.style.position = "fixed";
   menuEl.style.left = `${rect.left}px`;
-  menuEl.style.minWidth = `${rect.width}px`;
+  // rect.width 가 maxWidth(320px)를 초과하면 CSS 규칙상 min-width 가 max-width 를
+  // 무력화해 메뉴가 viewport 밖으로 나갈 수 있다. Math.min 으로 clamp 해 충돌을 방지한다.
+  // 참고: CSS Cascading — https://www.w3.org/TR/css-sizing-3/#min-max-widths
+  menuEl.style.minWidth = `${Math.min(rect.width, 320)}px`;
   menuEl.style.maxWidth = "320px";
   menuEl.style.zIndex = "9999";
 

--- a/static/js/blocks/inlineSlashMenu.js
+++ b/static/js/blocks/inlineSlashMenu.js
@@ -1,0 +1,313 @@
+// ── Inline Slash Command Menu ─────────────────────────────────────────────────
+//
+// 텍스트 블록에서 '/' 입력 시 포커스를 유지한 상태로 인라인 드롭다운을 노출한다.
+// 기본적으로 앵커 요소 위쪽(top)에 표시하며, 상단 공간이 부족하면 아래로 fallback한다.
+//
+// 참고: Notion slash command UX — https://www.notion.so/help/guides
+// ARIA 패턴: WAI-ARIA 1.2 Listbox Pattern — https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
+
+import { apiChangeBlockType, apiPatchBlock } from "../api.js";
+
+// ── 슬래시 메뉴 아이템 정의 ───────────────────────────────────────────────────
+//
+// type: API 타입 문자열 (BlockTypeChange.type 허용 목록 기반)
+// label: 드롭다운에 표시할 한국어 레이블
+// icon: 단순 텍스트/이모지 아이콘
+// keywords: 영어 필터링 키워드 (사용자가 영문으로 검색할 때 매핑)
+// level: text 블록의 heading 레벨 (1~3, text 타입 전용 옵션)
+//
+// 제한: page·database·db_row 는 별도 생성 흐름이 필요하므로 제외
+// (PATCH /api/blocks/{id}/type 에서도 허용하지 않음 — BlockTypeChange 리터럴 참고)
+
+/** @type {Array<{type:string, label:string, icon:string, keywords:string[], level?:number}>} */
+export const SLASH_MENU_ITEMS = [
+  { type: "text",      label: "텍스트",      icon: "T",   keywords: ["text", "paragraph", "plain", "텍스트"] },
+  { type: "text",      label: "제목 1",      icon: "H1",  keywords: ["h1", "heading1", "제목1", "heading"], level: 1 },
+  { type: "text",      label: "제목 2",      icon: "H2",  keywords: ["h2", "heading2", "제목2"],            level: 2 },
+  { type: "text",      label: "제목 3",      icon: "H3",  keywords: ["h3", "heading3", "제목3"],            level: 3 },
+  { type: "toggle",    label: "토글",        icon: "▶",   keywords: ["toggle", "collapsible", "토글"] },
+  { type: "quote",     label: "인용",        icon: "\"",  keywords: ["quote", "blockquote", "인용"] },
+  { type: "code",      label: "코드",        icon: "⟨⟩",  keywords: ["code", "snippet", "pre", "코드"] },
+  { type: "callout",   label: "콜아웃",      icon: "💡",  keywords: ["callout", "note", "tip", "콜아웃"] },
+  { type: "image",     label: "이미지",      icon: "▣",   keywords: ["image", "photo", "picture", "이미지"] },
+  { type: "divider",   label: "구분선",      icon: "—",   keywords: ["divider", "separator", "hr", "rule", "구분선"] },
+  { type: "url_embed", label: "URL 임베드", icon: "🔗",   keywords: ["url", "link", "embed", "bookmark", "임베드"] },
+];
+
+// ── 필터링 ────────────────────────────────────────────────────────────────────
+
+/**
+ * query 문자열로 슬래시 메뉴 아이템을 필터링한다.
+ * 대소문자·완전일치 구분 없이 label 또는 keywords에 포함되면 통과.
+ *
+ * @param {string} query
+ * @returns {typeof SLASH_MENU_ITEMS}
+ */
+export function filterSlashItems(query) {
+  if (!query) return SLASH_MENU_ITEMS;
+  const q = query.toLowerCase();
+  return SLASH_MENU_ITEMS.filter(
+    (item) =>
+      item.label.toLowerCase().includes(q) ||
+      item.keywords.some((k) => k.includes(q)),
+  );
+}
+
+// ── 드롭다운 배치 ─────────────────────────────────────────────────────────────
+
+const MENU_ESTIMATED_HEIGHT = 300; // px — 정확한 높이를 DOM 삽입 전에 추정하는 값
+
+/**
+ * 메뉴 요소를 앵커 요소 기준으로 viewport 안에 배치한다.
+ * 기본 방향: 위쪽. 상단 공간이 부족하면 아래쪽으로 fallback.
+ *
+ * @param {HTMLElement} menuEl
+ * @param {HTMLElement} anchorEl - 텍스트 블록의 contentEditable 요소
+ */
+function positionMenu(menuEl, anchorEl) {
+  // block-wrapper 전체 영역을 앵커 기준으로 삼는다.
+  const wrapperEl = anchorEl.closest(".block-wrapper") ?? anchorEl;
+  const rect = wrapperEl.getBoundingClientRect();
+
+  const spaceAbove = rect.top;
+  const spaceBelow = window.innerHeight - rect.bottom;
+
+  // position: fixed 로 viewport 좌표 직접 지정
+  menuEl.style.position = "fixed";
+  menuEl.style.left = `${rect.left}px`;
+  menuEl.style.minWidth = `${rect.width}px`;
+  menuEl.style.maxWidth = "320px";
+  menuEl.style.zIndex = "9999";
+
+  if (spaceAbove >= MENU_ESTIMATED_HEIGHT || spaceAbove >= spaceBelow) {
+    // 위쪽에 충분한 공간이 있거나, 위쪽이 더 넓음 → 위쪽 표시
+    menuEl.style.bottom = `${window.innerHeight - rect.top + 4}px`;
+    menuEl.style.top = "auto";
+    menuEl.dataset.direction = "up";
+  } else {
+    // 아래쪽 fallback
+    menuEl.style.top = `${rect.bottom + 4}px`;
+    menuEl.style.bottom = "auto";
+    menuEl.dataset.direction = "down";
+  }
+}
+
+// ── 핵심 공개 API ─────────────────────────────────────────────────────────────
+
+/**
+ * 인라인 슬래시 커맨드 메뉴를 연다.
+ * 메뉴가 이미 열려 있으면 기존 것을 닫고 새로 연다.
+ *
+ * @param {HTMLElement} anchorEl   - 포커스를 유지해야 하는 contentEditable 요소
+ * @param {string}      blockId    - 대상 블록 ID
+ * @param {string}      currentBlockType - 현재 블록 타입 (heading level 분기에 사용)
+ * @param {object}      opts
+ * @param {Function}   [opts.reloadDocument] - 블록 전환 완료 후 문서 재렌더링 콜백
+ *
+ * @returns {{ updateQuery: (q:string)=>void, close: ()=>void }}
+ *   열린 메뉴의 제어 핸들을 반환한다 (textEditing.js 에서 query 업데이트에 사용).
+ */
+export function openInlineSlashMenu(anchorEl, blockId, currentBlockType, { reloadDocument = null } = {}) {
+  // 기존 메뉴 제거 (중복 방지)
+  closeAllInlineSlashMenus();
+
+  let filteredItems = SLASH_MENU_ITEMS;
+  let highlightedIdx = 0;
+
+  // ── DOM 생성 ───────────────────────────────────────────────────────────────
+
+  const menuEl = document.createElement("div");
+  menuEl.className = "inline-slash-menu";
+  // ARIA listbox 역할: 키보드-only 사용자가 옵션 목록임을 인식할 수 있도록 한다.
+  // 참고: WAI-ARIA 1.2 §6.12 listbox — https://www.w3.org/TR/wai-aria-1.2/#listbox
+  menuEl.setAttribute("role", "listbox");
+  menuEl.setAttribute("aria-label", "블록 타입 선택");
+
+  // 빈 상태 메시지 (필터 결과 없을 때 표시)
+  const emptyEl = document.createElement("div");
+  emptyEl.className = "inline-slash-menu__empty";
+  emptyEl.textContent = "일치하는 블록이 없습니다";
+  emptyEl.hidden = true;
+
+  document.body.appendChild(menuEl);
+  positionMenu(menuEl, anchorEl);
+
+  // ── 렌더링 ────────────────────────────────────────────────────────────────
+
+  function render() {
+    menuEl.innerHTML = "";
+
+    if (filteredItems.length === 0) {
+      menuEl.appendChild(emptyEl);
+      emptyEl.hidden = false;
+      return;
+    }
+
+    emptyEl.hidden = true;
+
+    // highlightedIdx 가 범위를 벗어나지 않도록 보정
+    if (highlightedIdx >= filteredItems.length) highlightedIdx = 0;
+
+    filteredItems.forEach((item, idx) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "inline-slash-menu__item";
+      // ARIA option 역할: listbox 내의 선택 가능한 항목
+      btn.setAttribute("role", "option");
+      btn.setAttribute("aria-selected", String(idx === highlightedIdx));
+
+      const iconEl = document.createElement("span");
+      iconEl.className = "inline-slash-menu__icon";
+      iconEl.textContent = item.icon;
+      iconEl.setAttribute("aria-hidden", "true");
+
+      const labelEl = document.createElement("span");
+      labelEl.className = "inline-slash-menu__label";
+      labelEl.textContent = item.label;
+
+      btn.appendChild(iconEl);
+      btn.appendChild(labelEl);
+
+      if (idx === highlightedIdx) btn.classList.add("is-highlighted");
+
+      // mousedown preventDefault: 클릭해도 anchorEl 포커스를 빼앗지 않는다.
+      // (blur → 저장 로직이 실행되지 않도록 막는 핵심 처리)
+      btn.addEventListener("mousedown", (e) => e.preventDefault());
+      btn.addEventListener("mousemove", () => {
+        if (highlightedIdx === idx) return;
+        highlightedIdx = idx;
+        render();
+      });
+      btn.addEventListener("click", () => executeItem(item));
+
+      menuEl.appendChild(btn);
+    });
+
+    // 선택된 항목이 스크롤 영역 안에 보이도록 스크롤
+    const highlighted = menuEl.querySelector(".is-highlighted");
+    highlighted?.scrollIntoView({ block: "nearest" });
+  }
+
+  render();
+
+  // ── 블록 타입 실행 ────────────────────────────────────────────────────────
+
+  /**
+   * 선택된 아이템에 따라 블록 타입을 변환한다.
+   *
+   * heading(H1~H3) 처리:
+   *   - 이미 text 타입이면 level 만 PATCH
+   *   - 다른 타입이면 type change → text 로 변환 후 level PATCH
+   *
+   * 참고: PATCH /api/blocks/{id}/type 은 page·database·db_row 를 허용하지 않음
+   * (BlockTypeChange 리터럴 타입 참고 — app/routers/blocks.py)
+   */
+  async function executeItem(item) {
+    close();
+    try {
+      if (item.level != null) {
+        // heading 전환: text 타입 + level 변경
+        if (currentBlockType !== "text") {
+          await apiChangeBlockType(blockId, "text");
+        }
+        await apiPatchBlock(blockId, { level: item.level, text: "", formatted_text: "" });
+      } else {
+        await apiChangeBlockType(blockId, item.type);
+      }
+    } catch (err) {
+      console.error("[InlineSlashMenu] 블록 타입 변환 실패:", err);
+    } finally {
+      reloadDocument?.();
+    }
+  }
+
+  // ── 키보드 내비게이션 ─────────────────────────────────────────────────────
+
+  /**
+   * anchorEl 에서 발생한 keydown 이벤트를 가로채 메뉴 내비게이션을 처리한다.
+   * capture 단계에서 등록해 다른 핸들러보다 먼저 실행된다.
+   */
+  function onKeydown(e) {
+    if (!menuEl.isConnected) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        highlightedIdx = (highlightedIdx + 1) % Math.max(filteredItems.length, 1);
+        render();
+        break;
+
+      case "ArrowUp":
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        highlightedIdx =
+          (highlightedIdx - 1 + Math.max(filteredItems.length, 1)) %
+          Math.max(filteredItems.length, 1);
+        render();
+        break;
+
+      case "Enter":
+        // 필터 결과가 있을 때만 Enter 로 확정
+        if (filteredItems.length > 0) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          executeItem(filteredItems[highlightedIdx]);
+        }
+        break;
+
+      case "Escape":
+        // Esc: 메뉴 닫기. textEditing.js 의 Esc 핸들러로 전파하지 않도록 막는다.
+        e.stopImmediatePropagation();
+        close();
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  anchorEl.addEventListener("keydown", onKeydown, { capture: true });
+
+  // ── 외부 클릭 닫기 ────────────────────────────────────────────────────────
+
+  // setTimeout 0: openInlineSlashMenu 를 트리거한 input 이벤트가 끝난 뒤 등록해
+  // 즉시 닫히는 경쟁 조건을 방지한다.
+  let removeOutsideListener = () => {};
+  setTimeout(() => {
+    if (!menuEl.isConnected) return;
+    function onOutside(e) {
+      if (menuEl.contains(e.target) || anchorEl.contains(e.target)) return;
+      close();
+    }
+    document.addEventListener("mousedown", onOutside, true);
+    removeOutsideListener = () => document.removeEventListener("mousedown", onOutside, true);
+  }, 0);
+
+  // ── 공개 제어 핸들 ────────────────────────────────────────────────────────
+
+  function updateQuery(query) {
+    filteredItems = filterSlashItems(query);
+    highlightedIdx = 0;
+    render();
+    // 내용이 바뀌면 위치도 재계산 (메뉴 높이 변화 대응)
+    positionMenu(menuEl, anchorEl);
+  }
+
+  function close() {
+    if (!menuEl.isConnected) return;
+    menuEl.remove();
+    anchorEl.removeEventListener("keydown", onKeydown, { capture: true });
+    removeOutsideListener();
+  }
+
+  return { updateQuery, close };
+}
+
+/**
+ * 페이지에 열려 있는 모든 인라인 슬래시 메뉴를 제거한다.
+ * (예: 다른 블록 클릭 시 기존 메뉴 정리)
+ */
+export function closeAllInlineSlashMenus() {
+  document.querySelectorAll(".inline-slash-menu").forEach((el) => el.remove());
+}

--- a/static/js/blocks/textBlock.js
+++ b/static/js/blocks/textBlock.js
@@ -24,6 +24,7 @@ export function create(block, { callbacks = {} } = {}) {
   if (block.level) node.dataset.level = String(block.level);
 
   makeTextEditable(node, block.id, {
+    currentBlockType: block.type,
     addBlock: callbacks.addBlock,
     addBlockAfter: callbacks.addBlockAfter,
     reloadDocument: callbacks.reloadDocument,

--- a/static/js/blocks/textEditing.js
+++ b/static/js/blocks/textEditing.js
@@ -88,11 +88,20 @@ export function makeTextEditable(node, blockId, {
     if (node.contentEditable !== "true") return;
 
     // 슬래시 메뉴가 열려 있을 때 blur 가 발생하면 메뉴를 닫고 저장을 건너뛴다.
-    // (메뉴 항목 클릭 시 mousedown preventDefault 로 blur 자체를 막지만,
-    //  외부 요소로 포커스가 이동하는 경우의 안전망 처리)
+    // ─ 두 가지 상황에서 이 경로가 실행된다:
+    //   ① 메뉴 항목 클릭 시: mousedown preventDefault 로 blur 자체가 막히므로 도달 안 함
+    //   ② 외부 요소로 포커스 이동 또는 executeItem→reloadDocument 가 DOM 을 재구성해
+    //      node 가 제거될 때 브라우저가 blur 를 발생시키는 경우
+    // ─ 이 때 '/' 이후 query 텍스트가 API 에 저장되는 것을 막기 위해
+    //   슬래시 입력 이전 상태로 텍스트를 복원한 뒤 즉시 반환한다.
     if (slashMenu) {
       slashMenu.close();
       slashMenu = null;
+      node.textContent = slashPreText; // '/' 이전 상태 복원 (query 텍스트 제거)
+      node.contentEditable = "false";
+      editingTarget.classList.remove("is-editing");
+      clearEditingNode();
+      return; // ← '/' 포함 텍스트를 저장하지 않고 종료
     }
 
     node.contentEditable = "false";

--- a/static/js/blocks/textEditing.js
+++ b/static/js/blocks/textEditing.js
@@ -50,9 +50,11 @@ export function makeTextEditable(node, blockId, {
 
   // ── 인라인 슬래시 메뉴 상태 ───────────────────────────────────────────────
   // slashMenu: openInlineSlashMenu() 가 반환하는 { updateQuery, close } 핸들
-  // slashPreText: '/' 입력 직전의 textContent 스냅샷 (Esc 시 복원)
+  // slashPreText: '/' 입력 직전의 textContent 스냅샷 (blur 시 저장 복원에 사용)
+  // slashPreHtml:  '/' 입력 직전의 innerHTML 스냅샷 (Esc·blur 시 인라인 포맷 보존 복원에 사용)
   let slashMenu = null;
   let slashPreText = "";
+  let slashPreHtml = "";
 
   // is-editing 은 가장 가까운 .notion-block 에 적용
   const editingTarget = node.closest(".notion-block") ?? node;
@@ -87,21 +89,17 @@ export function makeTextEditable(node, blockId, {
     if (isInsideToolbar(e.relatedTarget)) return;
     if (node.contentEditable !== "true") return;
 
-    // 슬래시 메뉴가 열려 있을 때 blur 가 발생하면 메뉴를 닫고 저장을 건너뛴다.
+    // 슬래시 메뉴가 열려 있을 때 blur 가 발생하면 메뉴를 닫고 HTML 을 복원한다.
     // ─ 두 가지 상황에서 이 경로가 실행된다:
     //   ① 메뉴 항목 클릭 시: mousedown preventDefault 로 blur 자체가 막히므로 도달 안 함
     //   ② 외부 요소로 포커스 이동 또는 executeItem→reloadDocument 가 DOM 을 재구성해
     //      node 가 제거될 때 브라우저가 blur 를 발생시키는 경우
-    // ─ 이 때 '/' 이후 query 텍스트가 API 에 저장되는 것을 막기 위해
-    //   슬래시 입력 이전 상태로 텍스트를 복원한 뒤 즉시 반환한다.
+    // ─ '/' 이후 query 텍스트 및 인라인 포맷이 손실되지 않도록 slashPreHtml 로 복원한 뒤
+    //   아래 일반 저장 로직으로 fall-through 해 슬래시 이전 내용을 정상 저장한다.
     if (slashMenu) {
-      slashMenu.close();
-      slashMenu = null;
-      node.textContent = slashPreText; // '/' 이전 상태 복원 (query 텍스트 제거)
-      node.contentEditable = "false";
-      editingTarget.classList.remove("is-editing");
-      clearEditingNode();
-      return; // ← '/' 포함 텍스트를 저장하지 않고 종료
+      slashMenu.close(); // onClose 콜백이 slashMenu = null 을 처리한다
+      node.innerHTML = slashPreHtml; // '/' 이전 HTML 복원 (query 텍스트 + 포맷 보존)
+      // return 없이 fall-through → 아래 일반 저장 로직이 slashPreHtml 내용을 저장한다
     }
 
     node.contentEditable = "false";
@@ -156,9 +154,8 @@ export function makeTextEditable(node, blockId, {
       // 메뉴가 이미 열려 있는 상태: '/' 이후 query 를 추출해 업데이트
       const slashIdx = text.lastIndexOf("/");
       if (slashIdx === -1) {
-        // '/'가 지워지면 메뉴 닫기
+        // '/'가 지워지면 메뉴 닫기. onClose 콜백이 slashMenu = null 을 처리한다.
         slashMenu.close();
-        slashMenu = null;
       } else {
         slashMenu.updateQuery(text.slice(slashIdx + 1));
       }
@@ -169,7 +166,25 @@ export function makeTextEditable(node, blockId, {
     // 기존 텍스트에 '/'가 없었고 지금 있다면 방금 입력된 것으로 간주한다.
     if (text.endsWith("/") && !originalText.includes("/")) {
       slashPreText = text.slice(0, -1); // '/' 이전 텍스트 스냅샷 저장
-      slashMenu = openInlineSlashMenu(node, blockId, currentBlockType, { reloadDocument });
+
+      // TreeWalker 로 마지막 텍스트 노드에서 '/' 를 제거한 innerHTML 스냅샷을 저장한다.
+      // textContent 복원은 <b>·<a> 등 인라인 포맷을 제거하므로 innerHTML 로 보존한다.
+      const clone = node.cloneNode(true);
+      const walker = document.createTreeWalker(clone, NodeFilter.SHOW_TEXT);
+      let lastTextNode = null;
+      while (walker.nextNode()) lastTextNode = walker.currentNode;
+      if (lastTextNode?.textContent.endsWith("/")) {
+        lastTextNode.textContent = lastTextNode.textContent.slice(0, -1);
+      }
+      slashPreHtml = clone.innerHTML;
+
+      slashMenu = openInlineSlashMenu(node, blockId, currentBlockType, {
+        reloadDocument,
+        // 메뉴가 자체적으로 닫힐 때(외부 클릭·Enter·Esc) slashMenu 를 null 로 동기화.
+        // 이 콜백이 없으면 메뉴가 닫힌 뒤에도 input 핸들러가 updateQuery 를 계속
+        // 호출하거나 Enter 처리가 차단된 상태로 남는 상태 불일치가 발생한다.
+        onClose: () => { slashMenu = null; },
+      });
     }
   });
 
@@ -180,12 +195,13 @@ export function makeTextEditable(node, blockId, {
     if (e.key === "Escape") {
       e.preventDefault();
 
-      // 슬래시 메뉴가 열려 있으면 메뉴만 닫고 텍스트를 슬래시 이전 상태로 복원
+      // 슬래시 메뉴가 열려 있으면 메뉴만 닫고 텍스트를 슬래시 이전 상태로 복원.
+      // onClose 콜백이 slashMenu = null 을 처리하므로 여기서는 별도 설정 불필요.
       if (slashMenu) {
         slashMenu.close();
-        slashMenu = null;
-        // '/' 이후 입력한 query 를 포함한 텍스트를 슬래시 입력 전 스냅샷으로 되돌린다.
-        node.textContent = slashPreText;
+        // '/' 이후 query 텍스트를 제거하고 슬래시 입력 전 HTML 로 복원한다.
+        // textContent 복원은 <b>·<a> 등 인라인 포맷을 제거하므로 innerHTML 로 복원한다.
+        node.innerHTML = slashPreHtml;
         return;
       }
 

--- a/static/js/blocks/textEditing.js
+++ b/static/js/blocks/textEditing.js
@@ -4,7 +4,7 @@
 // contenteditable 편집 로직을 캡슐화한다.
 
 import { apiPatchBlock, apiChangeBlockType } from "../api.js";
-import { openBlockPalette } from "../blockPalette.js";
+import { openInlineSlashMenu } from "./inlineSlashMenu.js";
 import {
   sanitizeHtml,
   setEditingNode,
@@ -22,9 +22,10 @@ import {
  * @param {string}   [opts.htmlField='formatted_text'] - Rich-HTML field name
  * @param {string}   [opts.levelField='level']         - Heading level field name
  * @param {Function} [opts.onEnter]                    - Called on Enter (instead of add block after)
- * @param {boolean}  [opts.enableSlash=true]           - Enable '/' block palette trigger
+ * @param {boolean}  [opts.enableSlash=true]           - Enable '/' inline slash menu trigger
  * @param {boolean}  [opts.enableHeading=true]         - Enable '# ' heading promotion
  * @param {boolean}  [opts.enableTypeShortcuts=true]   - Enable '> ' → toggle conversion
+ * @param {string}   [opts.currentBlockType='text']    - Current block type (for heading conversion)
  * @param {Function} [opts.addBlock]                   - callbacks.addBlock
  * @param {Function} [opts.addBlockAfter]              - callbacks.addBlockAfter
  * @param {Function} [opts.reloadDocument]             - callbacks.reloadDocument
@@ -37,6 +38,7 @@ export function makeTextEditable(node, blockId, {
   enableSlash = true,
   enableHeading = true,
   enableTypeShortcuts = true,
+  currentBlockType = "text",
   addBlock = null,
   addBlockAfter = null,
   reloadDocument = null,
@@ -45,6 +47,12 @@ export function makeTextEditable(node, blockId, {
   let originalText = node.textContent;
   let currentLevel = node.dataset.level ? Number(node.dataset.level) : null;
   let escaped = false;
+
+  // ── 인라인 슬래시 메뉴 상태 ───────────────────────────────────────────────
+  // slashMenu: openInlineSlashMenu() 가 반환하는 { updateQuery, close } 핸들
+  // slashPreText: '/' 입력 직전의 textContent 스냅샷 (Esc 시 복원)
+  let slashMenu = null;
+  let slashPreText = "";
 
   // is-editing 은 가장 가까운 .notion-block 에 적용
   const editingTarget = node.closest(".notion-block") ?? node;
@@ -78,6 +86,15 @@ export function makeTextEditable(node, blockId, {
   node.addEventListener("blur", (e) => {
     if (isInsideToolbar(e.relatedTarget)) return;
     if (node.contentEditable !== "true") return;
+
+    // 슬래시 메뉴가 열려 있을 때 blur 가 발생하면 메뉴를 닫고 저장을 건너뛴다.
+    // (메뉴 항목 클릭 시 mousedown preventDefault 로 blur 자체를 막지만,
+    //  외부 요소로 포커스가 이동하는 경우의 안전망 처리)
+    if (slashMenu) {
+      slashMenu.close();
+      slashMenu = null;
+    }
+
     node.contentEditable = "false";
     editingTarget.classList.remove("is-editing");
     clearEditingNode();
@@ -116,20 +133,53 @@ export function makeTextEditable(node, blockId, {
     }
   });
 
-  // ── Keydown: formatting shortcuts + heading promotion + slash ────────────
-  node.addEventListener("keydown", (e) => {
-    if (enableSlash && e.key === "/" && node.contentEditable === "true" && !node.textContent.trim()) {
-      e.preventDefault();
-      node.blur();
-      const slashParentId = node.closest(".block-wrapper")?.dataset.parentBlockId || null;
-      openBlockPalette(node, slashParentId, null, addBlock);
+  // ── Input: 인라인 슬래시 메뉴 트리거 및 query 업데이트 ────────────────────
+  //
+  // '/' 문자를 keydown 에서 preventDefault 하지 않고 실제 텍스트에 입력되게 허용한다.
+  // input 이벤트에서 텍스트에 '/'가 새로 추가됐는지 감지해 메뉴를 연다.
+  // 이후 타이핑은 '/' 이후의 query 를 추출해 필터링에 반영한다.
+  node.addEventListener("input", () => {
+    if (!enableSlash || node.contentEditable !== "true") return;
+
+    const text = node.textContent;
+
+    if (slashMenu) {
+      // 메뉴가 이미 열려 있는 상태: '/' 이후 query 를 추출해 업데이트
+      const slashIdx = text.lastIndexOf("/");
+      if (slashIdx === -1) {
+        // '/'가 지워지면 메뉴 닫기
+        slashMenu.close();
+        slashMenu = null;
+      } else {
+        slashMenu.updateQuery(text.slice(slashIdx + 1));
+      }
       return;
     }
 
+    // 슬래시가 새로 입력됐는지 확인 — lastIndexOf 로 마지막 '/' 위치를 찾는다.
+    // 기존 텍스트에 '/'가 없었고 지금 있다면 방금 입력된 것으로 간주한다.
+    if (text.endsWith("/") && !originalText.includes("/")) {
+      slashPreText = text.slice(0, -1); // '/' 이전 텍스트 스냅샷 저장
+      slashMenu = openInlineSlashMenu(node, blockId, currentBlockType, { reloadDocument });
+    }
+  });
+
+  // ── Keydown: formatting shortcuts + heading promotion ────────────────────
+  node.addEventListener("keydown", (e) => {
     if (node.contentEditable !== "true") return;
 
     if (e.key === "Escape") {
       e.preventDefault();
+
+      // 슬래시 메뉴가 열려 있으면 메뉴만 닫고 텍스트를 슬래시 이전 상태로 복원
+      if (slashMenu) {
+        slashMenu.close();
+        slashMenu = null;
+        // '/' 이후 입력한 query 를 포함한 텍스트를 슬래시 입력 전 스냅샷으로 되돌린다.
+        node.textContent = slashPreText;
+        return;
+      }
+
       escaped = true;
       node.innerHTML = originalHtml;
       node.contentEditable = "false";
@@ -139,6 +189,11 @@ export function makeTextEditable(node, blockId, {
     }
 
     if (e.key === "Enter" && !e.shiftKey) {
+      // 슬래시 메뉴가 열려 있는 경우, Enter 는 inlineSlashMenu.js 의 keydown
+      // 핸들러(capture)가 먼저 처리한다. 이 핸들러는 나중에 등록됐으므로
+      // 여기서는 건너뛰어 이중 실행을 방지한다.
+      if (slashMenu) return;
+
       if (enableHeading) {
         const raw = node.textContent;
         const exactPrefix = raw.match(/^(#{1,3})$/);

--- a/tests/test_slash_command_block_change.py
+++ b/tests/test_slash_command_block_change.py
@@ -1,0 +1,379 @@
+"""슬래시 커맨드 기반 블록 타입 전환 단위 테스트 (Issue #39).
+
+인라인 슬래시 커맨드 메뉴에서 블록 타입을 전환할 때 백엔드에서 수행되는
+change_block_type / patch_block 로직을 repository 레이어와 API 레이어 양쪽에서
+검증한다.
+
+테스트 범위:
+  - 슬래시 커맨드가 지원하는 모든 전환 대상 타입 (SLASH_MENU_ITEMS 와 동기화)
+  - 전환 후 콘텐츠 초기화 및 기본값 확인
+  - heading level 변환 (text 타입 내부 level PATCH)
+  - 지원하지 않는 타입으로의 전환 거부 (page / database / db_row)
+  - 컨테이너 → 단순 타입 전환 시 자식 블록 삭제
+  - 단순 타입 → 컨테이너 전환 시 자식 auto-생성
+  - API 레이어: 허용/거부 응답 코드 검증
+  - API 레이어: 전환 후 GET 문서에서 타입 반영 확인
+
+참고:
+  - Notion slash command UX: https://www.notion.so/help/guides
+  - BlockTypeChange 리터럴 허용 타입: app/routers/blocks.py
+  - change_block_type 구현: app/repositories/sqlite_blocks.py
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────────────────
+
+def _create_doc(repo):
+  """빈 문서를 하나 생성하고 반환한다."""
+  return repo.create_document()
+
+
+def _create_doc_and_block(repo, block_type="text"):
+  """문서와 지정 타입 블록을 하나 생성해 (doc_dict, block_dict) 튜플로 반환한다.
+
+  create_document() → {"id": ..., "title": ..., ...}
+  create_block()    → {"id": ..., "type": ..., ...}  (document_id 미포함)
+  """
+  doc = _create_doc(repo)
+  block = repo.create_block(doc["id"], block_type)
+  return doc, block
+
+
+# ── Repository 레이어 테스트 ──────────────────────────────────────────────────
+
+class TestSlashMenuSupportedTypes:
+  """슬래시 커맨드 메뉴가 노출하는 모든 전환 타입이 성공적으로 변환된다.
+
+  SLASH_MENU_ITEMS (inlineSlashMenu.js) 와 일치하는 타입 목록:
+    text, toggle, quote, code, callout, image, divider, url_embed
+  """
+
+  @pytest.mark.parametrize("target_type", [
+    "text",
+    "toggle",
+    "quote",
+    "code",
+    "callout",
+    "image",
+    "divider",
+    "url_embed",
+  ])
+  def test_change_from_text_to_supported_type(self, repo, target_type):
+    """text 블록에서 슬래시 커맨드 지원 타입으로 전환이 성공한다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    result = repo.change_block_type(block["id"], target_type)
+    assert result is True
+
+    fetched = repo.get_document(doc["id"])
+    top_block = fetched.blocks[0]
+    assert top_block.type == target_type
+
+  @pytest.mark.parametrize("source_type,target_type", [
+    ("toggle",  "text"),
+    ("quote",   "text"),
+    ("callout", "code"),
+    ("code",    "toggle"),
+    ("image",   "callout"),
+    ("url_embed", "divider"),
+  ])
+  def test_cross_type_conversion(self, repo, source_type, target_type):
+    """컨테이너·단순 블록 간 교차 전환이 모두 성공한다."""
+    doc, block = _create_doc_and_block(repo, source_type)
+    assert repo.change_block_type(block["id"], target_type)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == target_type
+
+
+class TestDefaultValuesAfterConversion:
+  """전환 후 각 타입의 기본값이 올바르게 초기화된다.
+
+  change_block_type 은 content_json 을 새 타입의 기본값으로 리셋한다.
+  (기존 내용을 보존하지 않음 — 슬래시 커맨드 전환 의도와 일치)
+  """
+
+  def test_to_text_resets_text_and_level(self, repo):
+    """text 로 전환하면 text 필드가 빈 문자열로 초기화된다."""
+    doc, block = _create_doc_and_block(repo, "code")
+    repo.update_block(block["id"], {"code": "print('hi')", "language": "python"})
+    repo.change_block_type(block["id"], "text")
+    fetched = repo.get_document(doc["id"])
+    text_block = fetched.blocks[0]
+    assert text_block.type == "text"
+    assert text_block.text == ""
+
+  def test_to_code_resets_code_and_language(self, repo):
+    """code 로 전환하면 code·language 가 기본값으로 초기화된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "code")
+    fetched = repo.get_document(doc["id"])
+    code = fetched.blocks[0]
+    assert code.code == ""
+    assert code.language == "plain"
+
+  def test_to_callout_resets_emoji_and_color(self, repo):
+    """callout 로 전환하면 emoji·color 가 기본값으로 초기화된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "callout")
+    fetched = repo.get_document(doc["id"])
+    callout = fetched.blocks[0]
+    assert callout.emoji == "💡"
+    assert callout.color == "yellow"
+
+  def test_to_url_embed_resets_status_to_pending(self, repo):
+    """url_embed 로 전환하면 status 가 'pending' 으로 초기화된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "url_embed")
+    fetched = repo.get_document(doc["id"])
+    embed = fetched.blocks[0]
+    assert embed.status == "pending"
+    assert embed.url == ""
+
+  def test_to_image_resets_url_and_caption(self, repo):
+    """image 로 전환하면 url·caption 이 빈 문자열로 초기화된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "image")
+    fetched = repo.get_document(doc["id"])
+    image = fetched.blocks[0]
+    assert image.url == ""
+    assert image.caption == ""
+
+  def test_to_divider_has_no_content_fields(self, repo):
+    """divider 로 전환하면 내용 없이 type 만 변경된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "divider")
+    fetched = repo.get_document(doc["id"])
+    divider = fetched.blocks[0]
+    assert divider.type == "divider"
+
+
+class TestHeadingLevelConversion:
+  """슬래시 커맨드 H1~H3 전환: text 타입 + level PATCH 조합.
+
+  인라인 슬래시 메뉴에서 heading 아이템 선택 시의 흐름:
+    1. 이미 text 타입 → change_block_type 생략, level PATCH 만 수행
+    2. 다른 타입   → change_block_type("text") 후 level PATCH
+
+  이 테스트는 각 단계를 개별적으로 검증한다.
+  """
+
+  @pytest.mark.parametrize("level", [1, 2, 3])
+  def test_patch_level_on_text_block(self, repo, level):
+    """text 블록의 level PATCH 가 올바르게 저장된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.update_block(block["id"], {"level": level, "text": "", "formatted_text": ""})
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].level == level
+
+  @pytest.mark.parametrize("source_type", ["code", "toggle", "quote", "callout"])
+  def test_change_to_text_then_patch_level(self, repo, source_type):
+    """비-text 블록에서 text 로 전환한 뒤 level PATCH 를 적용할 수 있다."""
+    doc, block = _create_doc_and_block(repo, source_type)
+    # Step 1: type 전환
+    assert repo.change_block_type(block["id"], "text")
+    # Step 2: heading level 설정
+    assert repo.update_block(block["id"], {"level": 1, "text": "", "formatted_text": ""})
+    fetched = repo.get_document(doc["id"])
+    top = fetched.blocks[0]
+    assert top.type == "text"
+    assert top.level == 1
+
+  def test_heading_level_is_cleared_when_converting_away(self, repo):
+    """heading 블록을 다른 타입으로 전환하면 level 정보가 content_json 에 남지 않는다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.update_block(block["id"], {"level": 2})
+    repo.change_block_type(block["id"], "code")
+    fetched = repo.get_document(doc["id"])
+    code = fetched.blocks[0]
+    assert code.type == "code"
+    # CodeBlock 에는 level 속성 자체가 없어야 한다.
+    assert not hasattr(code, "level")
+
+
+class TestUnsupportedTypeConversion:
+  """슬래시 커맨드에서 허용되지 않는 타입으로의 전환이 거부된다.
+
+  page·database·db_row 는 별도 생성 흐름이 필요하며
+  PATCH /api/blocks/{id}/type 에서 허용하지 않는다.
+  (BlockTypeChange 리터럴 타입에 포함되지 않음)
+  """
+
+  @pytest.mark.parametrize("blocked_type", ["page", "database", "db_row"])
+  def test_change_to_blocked_type_returns_false(self, repo, blocked_type):
+    """page / database / db_row 로의 전환 시도는 False 를 반환한다."""
+    _, block = _create_doc_and_block(repo, "text")
+    result = repo.change_block_type(block["id"], blocked_type)
+    assert result is False
+
+  def test_change_to_unknown_type_returns_false(self, repo):
+    """완전히 알 수 없는 타입으로의 전환도 False 를 반환한다."""
+    _, block = _create_doc_and_block(repo, "text")
+    assert repo.change_block_type(block["id"], "nonexistent_type") is False
+
+  def test_block_unchanged_after_rejected_conversion(self, repo):
+    """거부된 전환 후에도 블록 타입이 원래 값을 유지한다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "page")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "text"
+
+
+class TestContainerChildHandling:
+  """컨테이너 블록 전환 시 자식 블록 정리 및 auto-생성 규칙 검증."""
+
+  def test_converting_from_container_deletes_all_children(self, repo):
+    """toggle → text 전환 시 toggle 의 자식 블록이 모두 삭제된다."""
+    doc = _create_doc(repo)
+    parent = repo.create_block(doc["id"], "toggle")
+    # auto-child 1개 포함 상태에서 추가 자식 2개 생성
+    repo.create_block(doc["id"], "text", parent_block_id=parent["id"])
+    repo.create_block(doc["id"], "code", parent_block_id=parent["id"])
+
+    repo.change_block_type(parent["id"], "text")
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 1
+    assert fetched.blocks[0].type == "text"
+
+  def test_converting_to_container_auto_creates_one_child(self, repo):
+    """text → toggle 전환 시 자식 텍스트 블록이 1개 자동 생성된다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], "toggle")
+    fetched = repo.get_document(doc["id"])
+    toggle = fetched.blocks[0]
+    assert toggle.type == "toggle"
+    assert len(toggle.children) == 1
+    assert toggle.children[0].type == "text"
+
+  @pytest.mark.parametrize("container_type", ["toggle", "quote", "callout"])
+  def test_all_container_types_auto_create_child_on_conversion(self, repo, container_type):
+    """toggle·quote·callout 모두 전환 후 자식 텍스트 블록 1개를 auto-생성한다."""
+    doc, block = _create_doc_and_block(repo, "text")
+    repo.change_block_type(block["id"], container_type)
+    fetched = repo.get_document(doc["id"])
+    container = fetched.blocks[0]
+    assert container.type == container_type
+    assert len(container.children) == 1
+
+
+class TestNonExistentBlock:
+  """존재하지 않는 블록 ID 로 전환 시도 시 False 를 반환한다."""
+
+  def test_change_type_of_nonexistent_block(self, repo):
+    assert repo.change_block_type("does-not-exist", "text") is False
+
+
+# ── API 레이어 테스트 ─────────────────────────────────────────────────────────
+
+class TestSlashCommandAPI:
+  """HTTP PATCH /api/blocks/{id}/type 엔드포인트 동작 검증.
+
+  슬래시 커맨드는 프론트엔드에서 이 엔드포인트를 호출한다.
+  """
+
+  def _setup(self, client, block_type="text"):
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": block_type},
+    ).json()
+    return doc, block
+
+  # ── 정상 전환 ────────────────────────────────────────────────────────────
+
+  @pytest.mark.parametrize("target_type", [
+    "text", "toggle", "quote", "code", "callout", "image", "divider", "url_embed",
+  ])
+  def test_supported_type_returns_200(self, client, target_type):
+    """슬래시 커맨드 지원 타입으로의 전환은 HTTP 200 을 반환한다."""
+    _, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": target_type})
+    assert resp.status_code == 200
+
+  def test_response_body_contains_block_id(self, client):
+    """전환 성공 응답 본문에 블록 id 가 포함된다."""
+    _, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": "toggle"})
+    assert resp.json()["id"] == block["id"]
+
+  def test_get_document_reflects_new_type(self, client):
+    """전환 후 GET /api/documents/{id} 에서 변경된 타입이 반환된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}/type", json={"type": "code"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["type"] == "code"
+
+  # ── heading level PATCH (슬래시 커맨드 H1~H3 흐름의 두 번째 단계) ─────────
+
+  @pytest.mark.parametrize("level", [1, 2, 3])
+  def test_patch_heading_level_returns_200(self, client, level):
+    """text 블록에 heading level PATCH 가 성공한다."""
+    _, block = self._setup(client, "text")
+    resp = client.patch(
+      f"/api/blocks/{block['id']}",
+      json={"level": level, "text": "", "formatted_text": ""},
+    )
+    assert resp.status_code == 200
+
+  def test_heading_level_persisted_after_patch(self, client):
+    """level PATCH 후 GET 문서에서 heading level 이 반영된다."""
+    doc, block = self._setup(client, "text")
+    client.patch(f"/api/blocks/{block['id']}", json={"level": 2})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["level"] == 2
+
+  # ── 허용하지 않는 타입 거부 ───────────────────────────────────────────────
+
+  @pytest.mark.parametrize("blocked_type", ["page", "database", "db_row"])
+  def test_blocked_types_return_422(self, client, blocked_type):
+    """page / database / db_row 로의 전환 요청은 HTTP 422 를 반환한다.
+
+    BlockTypeChange 리터럴에 포함되지 않으므로 Pydantic 검증에서 거부된다.
+    """
+    _, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": blocked_type})
+    assert resp.status_code == 422
+
+  def test_unknown_type_returns_422(self, client):
+    """알 수 없는 타입 문자열은 HTTP 422 를 반환한다."""
+    _, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": "banana"})
+    assert resp.status_code == 422
+
+  def test_nonexistent_block_returns_404(self, client):
+    """존재하지 않는 블록 ID 로의 전환 요청은 HTTP 404 를 반환한다."""
+    resp = client.patch("/api/blocks/no-such-id/type", json={"type": "text"})
+    assert resp.status_code == 404
+
+  # ── 복합 시나리오 ─────────────────────────────────────────────────────────
+
+  def test_toggle_to_text_then_verify_no_children(self, client):
+    """슬래시 커맨드로 toggle → text 전환 후 문서에 자식 블록이 남지 않는다."""
+    doc, block = self._setup(client, "toggle")
+    # toggle 생성 시 auto-child 1개 포함
+    client.patch(f"/api/blocks/{block['id']}/type", json={"type": "text"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert len(fetched["blocks"]) == 1
+    text_block = fetched["blocks"][0]
+    assert text_block["type"] == "text"
+    assert "children" not in text_block or text_block.get("children") == []
+
+  def test_text_to_callout_auto_creates_child(self, client):
+    """슬래시 커맨드로 text → callout 전환 후 자식 텍스트 블록이 자동 생성된다."""
+    doc, block = self._setup(client, "text")
+    client.patch(f"/api/blocks/{block['id']}/type", json={"type": "callout"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    callout = fetched["blocks"][0]
+    assert callout["type"] == "callout"
+    assert len(callout["children"]) == 1
+    assert callout["children"][0]["type"] == "text"
+
+  def test_multiple_conversions_in_sequence(self, client):
+    """동일 블록에 대해 여러 번 연속 전환이 각각 성공한다 (슬래시 커맨드 재실행)."""
+    _, block = self._setup(client, "text")
+    block_id = block["id"]
+
+    for target in ["code", "quote", "image", "text"]:
+      resp = client.patch(f"/api/blocks/{block_id}/type", json={"type": target})
+      assert resp.status_code == 200


### PR DESCRIPTION
## 관련 이슈

Close #39

## 배경 및 목적

텍스트 블록에서 `/` 입력 시 포커스를 잃고 별도 팔레트가 열리는 기존 방식 대신,
포커스를 유지한 채 커서 위치 기준 인라인 드롭다운을 노출하는 방식으로 UX를 개선합니다.
Notion 스타일의 슬래시 커맨드 경험을 구현하고 접근성(ARIA)을 갖춥니다.

## 변경 사항

### Frontend
- `static/js/blocks/inlineSlashMenu.js` (신규) — 인라인 슬래시 커맨드 드롭다운 컴포넌트
  - `SLASH_MENU_ITEMS`: 11개 블록 타입 (text, H1~H3, toggle, quote, code, callout, image, divider, url_embed)
  - `filterSlashItems(query)`: label·keywords 기반 대소문자 무관 필터링
  - `positionMenu()`: `position: fixed` + viewport 공간 기준 위/아래 자동 배치 (`data-direction` 어트리뷰트)
  - `openInlineSlashMenu()`: WAI-ARIA `role="listbox/option"` 패턴, 키보드 내비게이션 (↑↓ Enter Esc), 외부 클릭 닫기
  - `_activeCleanups` 레지스트리: 중복 메뉴 방지 및 keydown/mousedown 리스너 완전 정리
  - `onClose` 콜백: 메뉴가 자체 닫힐 때 호출자 상태 동기화 (Observer 패턴)
- `static/js/blocks/textEditing.js` — `makeTextEditable` 슬래시 메뉴 연동
  - `input` 이벤트에서 `/` 감지 후 `openInlineSlashMenu()` 호출 (포커스 유지)
  - `slashPreHtml`: TreeWalker로 `'/'` 직전 innerHTML 스냅샷 저장 (인라인 포맷 보존)
  - `blur` 핸들러: 슬래시 메뉴 열림 시 `slashPreHtml` 복원 후 일반 저장 로직으로 fall-through
  - `Esc` 핸들러: `textContent` 대신 `innerHTML` 복원으로 `<b>·<a>` 등 포맷 손실 방지
- `static/js/blocks/textBlock.js` — `currentBlockType` 옵션 전달 추가
- `static/css/style.css` — 인라인 슬래시 메뉴 스타일 (animation, ARIA highlight, 빈 상태 메시지)

### Backend / Test
- `tests/test_slash_command_block_change.py` (신규) — 61개 단위 테스트
  - `TestSlashMenuSupportedTypes`: 허용 타입 8종 + 교차 전환 6종
  - `TestDefaultValuesAfterConversion`: 타입 변환 후 기본값 검증
  - `TestHeadingLevelConversion`: level 필드 PATCH 및 타입 전환 시 level 초기화
  - `TestUnsupportedTypeConversion`: page·database·db_row → 변환 거부 검증
  - `TestContainerChildHandling`: 컨테이너↔단순 블록 전환 시 자식 블록 생성/삭제
  - `TestSlashCommandAPI`: HTTP 200/422/404, 순차 타입 전환

## 테스트 결과

```
195 passed in 1.16s
```

## 리뷰 포인트

- `input` 이벤트 기반 슬래시 감지: `keydown`에서 `preventDefault`하면 `'/'` 문자 자체가 입력되지 않아 `input` 이벤트로 감지합니다. `text.endsWith("/") && !originalText.includes("/")` 조건으로 새 입력 여부를 판단합니다.
- keydown 핸들러 우선순위: `textEditing.js`가 먼저 등록(capture), `inlineSlashMenu.js`가 나중 등록(capture). 같은 요소에서 등록 순서상 inlineSlashMenu가 먼저 실행되어 Enter/Esc를 가로챕니다. `if (slashMenu) return` 가드로 이중 실행을 방지합니다.
- `slashPreHtml` TreeWalker: `textContent` 복원은 인라인 포맷(`<b>`, `<a>`)을 제거하므로 클론 노드의 마지막 텍스트 노드에서만 `'/'`를 제거해 `innerHTML` 스냅샷을 보존합니다.
- blur fall-through: 슬래시 메뉴 열림 중 외부 blur 발생 시 `slashPreHtml`로 복원 후 early return 없이 일반 저장 로직으로 진행해 슬래시 이전 내용이 API에 저장되도록 합니다.