### PR TITLE
[FEAT#46] 코드 블록 Mermaid 렌더링 및 ERD 뷰어 추가

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -861,15 +861,18 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 .mermaid-preview {
   padding: 1.25rem 1rem;
   background: #fff;
-  overflow-x: auto;
   display: flex;
   justify-content: center;
   align-items: flex-start;
 }
 
 .mermaid-preview svg {
-  max-width: 100%;
+  /* 너비를 640px로 고정하되 컨테이너가 더 좁으면 100%로 축소.
+     height:auto + viewBox 조합으로 비율에 맞게 높이가 결정된다.
+     Mermaid가 SVG에 직접 주입하는 width/height 속성은 renderMermaid()에서 제거한다. */
+  width: min(640px, 100%);
   height: auto;
+  display: block;
 }
 
 /* 문법 오류 표시 영역 */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -850,6 +850,14 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 }
 
 /* 다이어그램 미리보기 영역: 흰 배경에 중앙 정렬 */
+/* [hidden] 속성이 있을 때 display:flex 를 덮어쓰지 않도록 명시적으로 숨김 처리.
+   브라우저 UA 스타일시트의 [hidden]{display:none} 보다 클래스 선택자가 우선하므로
+   직접 선언이 필요하다. (Ref: CSS Cascading and Inheritance — https://www.w3.org/TR/css-cascade-5/) */
+.mermaid-preview[hidden],
+.mermaid-error[hidden] {
+  display: none;
+}
+
 .mermaid-preview {
   padding: 1.25rem 1rem;
   background: #fff;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -842,6 +842,41 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   color: #abb2bf;
 }
 
+/* ── Mermaid preview panel ───────────────────────────────────────────────── */
+
+/* mermaid 모드일 때 소스 에디터의 배경을 약간 어둡게 유지 */
+.notion-code.is-mermaid .code-body {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* 다이어그램 미리보기 영역: 흰 배경에 중앙 정렬 */
+.mermaid-preview {
+  padding: 1.25rem 1rem;
+  background: #fff;
+  overflow-x: auto;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.mermaid-preview svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* 문법 오류 표시 영역 */
+.mermaid-error {
+  padding: 0.6rem 1rem;
+  background: rgba(220, 53, 69, 0.08);
+  border-top: 1px solid rgba(220, 53, 69, 0.25);
+  color: #e55563;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 /* ── Callout block ───────────────────────────────────────────────────────── */
 
 .notion-callout {

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -78,6 +78,14 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
   try {
     const { svg } = await window.mermaid.render(renderId, trimmed);
     previewEl.innerHTML = svg;
+
+    // Mermaid는 SVG에 width/height 속성을 직접 주입한다.
+    // 이 값이 CSS보다 우선해 크기 고정이 무시되므로 제거한다.
+    // viewBox 속성은 유지해 CSS width에 맞춰 비율이 유지되도록 한다.
+    const svgEl = previewEl.querySelector("svg");
+    svgEl?.removeAttribute("width");
+    svgEl?.removeAttribute("height");
+
     previewEl.hidden = false;
     errorEl.hidden = true;
   } catch (err) {

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -79,12 +79,19 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
     const { svg } = await window.mermaid.render(renderId, trimmed);
     previewEl.innerHTML = svg;
 
-    // Mermaid는 SVG에 width/height 속성을 직접 주입한다.
-    // 이 값이 CSS보다 우선해 크기 고정이 무시되므로 제거한다.
-    // viewBox 속성은 유지해 CSS width에 맞춰 비율이 유지되도록 한다.
+    // Mermaid v10+ 는 SVG에 두 가지 방식으로 크기를 고정한다.
+    //   1) HTML attribute: width="NNN" height="NNN"
+    //   2) inline style:  style="max-width: NNNpx;"
+    // 두 값 모두 외부 CSS보다 우선하므로 제거해야 CSS width/height:auto 가 적용된다.
+    // viewBox 속성은 유지해 CSS width 기준으로 종횡비가 계산되도록 한다.
     const svgEl = previewEl.querySelector("svg");
-    svgEl?.removeAttribute("width");
-    svgEl?.removeAttribute("height");
+    if (svgEl) {
+      svgEl.removeAttribute("width");
+      svgEl.removeAttribute("height");
+      svgEl.style.width = "";
+      svgEl.style.height = "";
+      svgEl.style.maxWidth = "";
+    }
 
     previewEl.hidden = false;
     errorEl.hidden = true;

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -44,6 +44,78 @@ function setCaretOffset(el, offset) {
   window.getSelection()?.addRange(range);
 }
 
+// ── Mermaid hljs 언어 정의 ────────────────────────────────────────────────────
+// CDN 추가 없이 highlight.js에 mermaid 언어를 직접 등록한다.
+// Ref: https://highlightjs.readthedocs.io/en/latest/language-guide.html
+
+/**
+ * highlight.js 언어 정의 객체를 반환한다.
+ * @param {object} hljs - highlight.js 전역 객체
+ */
+function _mermaidHljsDefinition(hljs) {
+  return {
+    name: "Mermaid",
+    case_insensitive: false,
+    keywords: {
+      // 다이어그램 선언 키워드 — 첫 줄에 등장하는 다이어그램 타입 식별자
+      built_in:
+        "graph flowchart sequenceDiagram erDiagram classDiagram " +
+        "stateDiagram stateDiagram-v2 gantt pie gitGraph mindmap " +
+        "timeline journey xychart-beta block",
+      // 흐름/구조 제어 키워드
+      keyword:
+        "TD LR RL BT TB direction participant actor autonumber " +
+        "loop alt else opt par and critical break rect note over as " +
+        "end title accTitle accDescr section subgraph click call " +
+        "style linkStyle classDef class",
+    },
+    contains: [
+      // %% 단일 행 주석
+      hljs.COMMENT("%%", "$"),
+      // 큰따옴표 문자열 레이블
+      hljs.QUOTE_STRING_MODE,
+      // 대괄호 노드 레이블: A[label], A[/label/], A[\label\]
+      {
+        className: "string",
+        begin: /\[/,
+        end: /\]/,
+        relevance: 0,
+      },
+      // 소괄호/이중소괄호 노드: B(label), C((label))
+      {
+        className: "string",
+        begin: /\(/,
+        end: /\)/,
+        relevance: 0,
+      },
+      // 중괄호 노드: D{label}
+      {
+        className: "string",
+        begin: /\{/,
+        end: /\}/,
+        relevance: 0,
+      },
+      // 화살표 · ER 관계 커넥터
+      // flowchart: -->, -.->. ==>, ---, --
+      // sequence:  ->>, ->>, -->> , -x, -), <<->>
+      // ER:        ||--o{, }|--|{, |o--||  등
+      {
+        className: "operator",
+        match: /\.{1,2}-{0,2}>?|-{2,3}>?|={2,3}>?|>{1,2}|<{1,2}|[|o*}{]{1,3}-{1,3}[|o*}{]{1,3}/,
+      },
+    ],
+  };
+}
+
+/** hljs.registerLanguage 는 1회만 호출해야 하므로 등록 여부를 추적한다. */
+let _mermaidHljsRegistered = false;
+
+function _ensureMermaidHljs() {
+  if (_mermaidHljsRegistered || !window.hljs) return;
+  window.hljs.registerLanguage("mermaid", _mermaidHljsDefinition);
+  _mermaidHljsRegistered = true;
+}
+
 // ── Mermaid rendering ─────────────────────────────────────────────────────────
 
 /**
@@ -144,11 +216,12 @@ export function create(block) {
 
   // ── Syntax highlighting ──────────────────────────────────────────────────
   function applyHighlight(code) {
-    // mermaid 소스는 hljs로 하이라이팅하지 않는다
-    if (!window.hljs || currentLanguage === "plain" || currentLanguage === "mermaid") {
+    if (!window.hljs || currentLanguage === "plain") {
       codeEl.textContent = code;
       return;
     }
+    // mermaid 언어가 아직 등록되지 않았을 경우 최초 호출 시 등록한다
+    if (currentLanguage === "mermaid") _ensureMermaidHljs();
     try {
       const result = window.hljs.highlight(code, {
         language: currentLanguage,

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -128,8 +128,12 @@ function _ensureMermaidHljs() {
  * @param {string} source  - Mermaid 문법 소스 코드
  * @param {HTMLElement} previewEl - SVG를 삽입할 컨테이너
  * @param {HTMLElement} errorEl   - 오류 메시지를 표시할 컨테이너
+ * @param {function(): boolean} isCancelled - true를 반환하면 DOM 갱신을 건너뛴다.
+ *   blur → language change 순서로 이벤트가 발생할 때, blur 핸들러에서 시작된
+ *   async 렌더가 language change 이후에 완료되며 previewEl을 다시 노출시키는
+ *   경쟁 조건을 방지한다.
  */
-async function renderMermaid(blockId, source, previewEl, errorEl) {
+async function renderMermaid(blockId, source, previewEl, errorEl, isCancelled = () => false) {
   if (!window.mermaid) {
     errorEl.textContent = "Mermaid 라이브러리를 불러오지 못했습니다.";
     errorEl.hidden = false;
@@ -152,6 +156,7 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
   const renderId = `mermaid-${blockId.replace(/-/g, "")}-${Date.now()}`;
   try {
     const { svg } = await window.mermaid.render(renderId, trimmed);
+    if (isCancelled()) return; // 렌더 완료 전 언어 전환 등으로 mermaid 모드가 해제된 경우
     previewEl.innerHTML = svg;
 
     // Mermaid v10+ 는 SVG에 두 가지 방식으로 크기를 고정한다.
@@ -171,6 +176,7 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
     previewEl.hidden = false;
     errorEl.hidden = true;
   } catch (err) {
+    if (isCancelled()) return;
     // mermaid.render()는 문법 오류 시 Error 객체 또는 문자열을 throw할 수 있다.
     // err?.message || err 순서로 평가해 두 경우를 모두 커버한다.
     previewEl.innerHTML = "";
@@ -197,6 +203,10 @@ export function create(block) {
   let plainCode = block.code || "";
   let originalCode = plainCode;
 
+  // 세대 카운터: applyMermaidMode(false) 시 증가해 in-flight 렌더를 무효화한다.
+  // 각 렌더 시작 시 현재 세대를 캡처하고, 완료 시점에 세대가 바뀌었으면 DOM 갱신을 생략한다.
+  let _renderGen = 0;
+
   CODE_LANGUAGES.forEach((lang) => {
     const opt = document.createElement("option");
     opt.value = lang;
@@ -211,8 +221,10 @@ export function create(block) {
   function applyMermaidMode(isMermaid) {
     node.classList.toggle("is-mermaid", isMermaid);
     if (isMermaid) {
-      renderMermaid(block.id, plainCode, previewEl, errorEl);
+      const gen = ++_renderGen;
+      renderMermaid(block.id, plainCode, previewEl, errorEl, () => _renderGen !== gen);
     } else {
+      ++_renderGen; // 진행 중인 렌더 취소
       previewEl.hidden = true;
       errorEl.hidden = true;
     }
@@ -291,7 +303,8 @@ export function create(block) {
     }
     // blur 시점에 mermaid 미리보기를 갱신한다
     if (currentLanguage === "mermaid") {
-      renderMermaid(block.id, plainCode, previewEl, errorEl);
+      const gen = ++_renderGen;
+      renderMermaid(block.id, plainCode, previewEl, errorEl, () => _renderGen !== gen);
     }
   });
 

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -6,7 +6,7 @@ export const type = "code";
 
 const CODE_LANGUAGES = [
   "plain", "javascript", "typescript", "python", "bash", "html", "css",
-  "json", "sql", "java", "go", "rust", "c", "cpp",
+  "json", "sql", "java", "go", "rust", "c", "cpp", "mermaid",
 ];
 
 // ── Caret offset helpers ──────────────────────────────────────────────────────
@@ -44,6 +44,51 @@ function setCaretOffset(el, offset) {
   window.getSelection()?.addRange(range);
 }
 
+// ── Mermaid rendering ─────────────────────────────────────────────────────────
+
+/**
+ * Mermaid.js를 사용해 소스 코드를 SVG로 렌더링한다.
+ * 렌더 성공 시 previewEl에 SVG를 삽입하고, 실패 시 errorEl에 오류 메시지를 표시한다.
+ *
+ * Ref: https://mermaid.js.org/config/usage.html#using-mermaid-render
+ *
+ * @param {string} blockId - 블록 고유 ID (mermaid 렌더 ID 생성에 사용)
+ * @param {string} source  - Mermaid 문법 소스 코드
+ * @param {HTMLElement} previewEl - SVG를 삽입할 컨테이너
+ * @param {HTMLElement} errorEl   - 오류 메시지를 표시할 컨테이너
+ */
+async function renderMermaid(blockId, source, previewEl, errorEl) {
+  if (!window.mermaid) {
+    errorEl.textContent = "Mermaid 라이브러리를 불러오지 못했습니다.";
+    errorEl.hidden = false;
+    previewEl.hidden = true;
+    return;
+  }
+
+  const trimmed = source.trim();
+  if (!trimmed) {
+    previewEl.innerHTML = "";
+    previewEl.hidden = true;
+    errorEl.hidden = true;
+    return;
+  }
+
+  // mermaid.render() 의 id는 DOM에서 고유해야 하며, UUID의 하이픈을 제거해 유효한 HTML id로 변환
+  const renderId = `mermaid-${blockId.replace(/-/g, "")}`;
+  try {
+    const { svg } = await window.mermaid.render(renderId, trimmed);
+    previewEl.innerHTML = svg;
+    previewEl.hidden = false;
+    errorEl.hidden = true;
+  } catch (err) {
+    // mermaid.render()는 문법 오류 시 Error를 throw한다
+    previewEl.innerHTML = "";
+    previewEl.hidden = true;
+    errorEl.textContent = `Mermaid 문법 오류: ${err?.message ?? "알 수 없는 오류"}`;
+    errorEl.hidden = false;
+  }
+}
+
 /**
  * @param {object} block
  * @returns {HTMLElement}
@@ -54,6 +99,8 @@ export function create(block) {
   const select = node.querySelector(".code-language-select");
   const codeEl = node.querySelector(".code-content");
   const copyBtn = node.querySelector(".code-copy-btn");
+  const previewEl = node.querySelector(".mermaid-preview");
+  const errorEl = node.querySelector(".mermaid-error");
 
   let currentLanguage = block.language || "plain";
   let plainCode = block.code || "";
@@ -67,9 +114,23 @@ export function create(block) {
     select.appendChild(opt);
   });
 
+  // ── Mermaid 모드 전환 ─────────────────────────────────────────────────────
+  // isMermaid === true 일 때: 코드 에디터(소스 편집) + 미리보기 패널을 함께 표시한다.
+
+  function applyMermaidMode(isMermaid) {
+    node.classList.toggle("is-mermaid", isMermaid);
+    if (isMermaid) {
+      renderMermaid(block.id, plainCode, previewEl, errorEl);
+    } else {
+      previewEl.hidden = true;
+      errorEl.hidden = true;
+    }
+  }
+
   // ── Syntax highlighting ──────────────────────────────────────────────────
   function applyHighlight(code) {
-    if (!window.hljs || currentLanguage === "plain") {
+    // mermaid 소스는 hljs로 하이라이팅하지 않는다
+    if (!window.hljs || currentLanguage === "plain" || currentLanguage === "mermaid") {
       codeEl.textContent = code;
       return;
     }
@@ -85,6 +146,11 @@ export function create(block) {
   }
 
   applyHighlight(plainCode);
+
+  // 초기 로드 시 mermaid 모드 적용
+  if (currentLanguage === "mermaid") {
+    applyMermaidMode(true);
+  }
 
   // ── IME 조합 상태 추적 ──────────────────────────────────────────────────
   let isComposing = false;
@@ -122,7 +188,7 @@ export function create(block) {
     setCaretOffset(codeEl, offset);
   });
 
-  // ── Blur → save ──────────────────────────────────────────────────────────
+  // ── Blur → save + mermaid re-render ──────────────────────────────────────
   codeEl.addEventListener("blur", () => {
     if (codeEl.contentEditable !== "true") return;
     codeEl.contentEditable = "false";
@@ -130,6 +196,10 @@ export function create(block) {
     if (plainCode !== originalCode) {
       originalCode = plainCode;
       apiPatchBlock(block.id, { code: plainCode }).catch(console.error);
+    }
+    // blur 시점에 mermaid 미리보기를 갱신한다
+    if (currentLanguage === "mermaid") {
+      renderMermaid(block.id, plainCode, previewEl, errorEl);
     }
   });
 
@@ -143,9 +213,16 @@ export function create(block) {
 
   // ── Language change ───────────────────────────────────────────────────────
   select.addEventListener("change", () => {
+    const prev = currentLanguage;
     currentLanguage = select.value;
     apiPatchBlock(block.id, { language: currentLanguage }).catch(console.error);
     applyHighlight(plainCode);
+    // mermaid ↔ 일반 모드 전환
+    if (currentLanguage === "mermaid") {
+      applyMermaidMode(true);
+    } else if (prev === "mermaid") {
+      applyMermaidMode(false);
+    }
   });
 
   copyBtn.addEventListener("click", () => {

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -145,8 +145,11 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
     return;
   }
 
-  // mermaid.render() 의 id는 DOM에서 고유해야 하며, UUID의 하이픈을 제거해 유효한 HTML id로 변환
-  const renderId = `mermaid-${blockId.replace(/-/g, "")}`;
+  // mermaid.render() 의 id는 호출 시점마다 DOM 내에서 고유해야 한다.
+  // 동일 블록을 재렌더링(blur 후 수정 → blur)하면 이전 SVG가 동일 id를 가진 채 DOM에 남아
+  // 충돌이 발생한다. Date.now() 를 접미사로 붙여 매 호출마다 고유 id를 보장한다.
+  // Ref: https://mermaid.js.org/config/usage.html#using-mermaid-render
+  const renderId = `mermaid-${blockId.replace(/-/g, "")}-${Date.now()}`;
   try {
     const { svg } = await window.mermaid.render(renderId, trimmed);
     previewEl.innerHTML = svg;
@@ -168,10 +171,11 @@ async function renderMermaid(blockId, source, previewEl, errorEl) {
     previewEl.hidden = false;
     errorEl.hidden = true;
   } catch (err) {
-    // mermaid.render()는 문법 오류 시 Error를 throw한다
+    // mermaid.render()는 문법 오류 시 Error 객체 또는 문자열을 throw할 수 있다.
+    // err?.message || err 순서로 평가해 두 경우를 모두 커버한다.
     previewEl.innerHTML = "";
     previewEl.hidden = true;
-    errorEl.textContent = `Mermaid 문법 오류: ${err?.message ?? "알 수 없는 오류"}`;
+    errorEl.textContent = "Mermaid 문법 오류: " + (err?.message || err || "알 수 없는 오류");
     errorEl.hidden = false;
   }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,10 +14,14 @@
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
   <script>
     // startOnLoad: false — 자동 렌더링 비활성화, 코드 블록에서 명시적으로 호출
-    // securityLevel: "sandbox" — XSS 방지를 위해 sandboxed iframe 사용
+    // securityLevel: "strict"  — Mermaid 기본값. 다이어그램 텍스트 레이블 내 HTML을
+    //   인코딩해 XSS를 방지하면서 SVG를 DOM에 직접 삽입한다.
+    //   "sandbox" 는 임시 iframe 안에서 렌더링하는데, 해당 iframe의 크기가 주변 레이아웃에
+    //   의존해 결정되므로 SVG viewBox가 코드 에디터 영역에 맞춰지는 부작용이 있다.
+    //   (Ref: https://mermaid.js.org/config/security.html)
     document.addEventListener("DOMContentLoaded", () => {
       if (window.mermaid) {
-        window.mermaid.initialize({ startOnLoad: false, securityLevel: "sandbox" });
+        window.mermaid.initialize({ startOnLoad: false, securityLevel: "strict" });
       }
     });
   </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
   <!-- Mermaid.js: 클라이언트 사이드 다이어그램 렌더링 (Ref: https://mermaid.js.org/config/usage.html) -->
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <!-- 버전을 정확히 고정(11.14.0)해 minor/patch 자동 업데이트로 인한
+       렌더링 변경·보안 패치 누락을 방지한다. highlight.js도 동일하게 11.10.0으로 고정돼 있다. -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
   <script>
     // startOnLoad: false — 자동 렌더링 비활성화, 코드 블록에서 명시적으로 호출
     // securityLevel: "strict"  — Mermaid 기본값. 다이어그램 텍스트 레이블 내 HTML을

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,17 @@
   <link rel="stylesheet" href="/static/css/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
+  <!-- Mermaid.js: 클라이언트 사이드 다이어그램 렌더링 (Ref: https://mermaid.js.org/config/usage.html) -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script>
+    // startOnLoad: false — 자동 렌더링 비활성화, 코드 블록에서 명시적으로 호출
+    // securityLevel: "sandbox" — XSS 방지를 위해 sandboxed iframe 사용
+    document.addEventListener("DOMContentLoaded", () => {
+      if (window.mermaid) {
+        window.mermaid.initialize({ startOnLoad: false, securityLevel: "sandbox" });
+      }
+    });
+  </script>
   {% block head %}{% endblock %}
 </head>
 <body>

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -45,6 +45,9 @@
       <button type="button" class="code-copy-btn">복사</button>
     </div>
     <pre class="code-body"><code class="code-content" spellcheck="false"></code></pre>
+    <!-- Mermaid 전용 패널: language=mermaid 일 때만 표시 -->
+    <div class="mermaid-preview" hidden aria-label="Mermaid 다이어그램 미리보기"></div>
+    <div class="mermaid-error" hidden role="alert" aria-live="polite"></div>
   </div>
 </template>
 

--- a/tests/test_mermaid_code_block.py
+++ b/tests/test_mermaid_code_block.py
@@ -1,0 +1,226 @@
+"""Mermaid 코드 블록 기능 단위 테스트 (이슈 #46).
+
+커버리지 범위:
+  1. Model 레이어   — CodeBlock 모델이 language="mermaid" 를 올바르게 처리하는지 검증
+  2. Repository 레이어 — mermaid 코드 블록 생성·업데이트·타입 변환
+  3. API 레이어    — POST/GET/PATCH /api/documents/{id}/blocks, PATCH /api/blocks/{id}
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── 1. Model 레이어 ───────────────────────────────────────────────────────────
+
+class TestCodeBlockModel:
+  """CodeBlock Pydantic 모델이 mermaid 언어 옵션을 올바르게 수락하는지 검증."""
+
+  def _make(self, language: str, code: str = "") -> object:
+    from app.models.blocks import CodeBlock
+    return CodeBlock(id="test-id", type="code", code=code, language=language)
+
+  def test_mermaid_language_accepted(self):
+    """language="mermaid" 로 CodeBlock 을 생성할 수 있다."""
+    block = self._make("mermaid")
+    assert block.language == "mermaid"
+
+  def test_mermaid_code_stored(self):
+    """mermaid 소스 코드가 code 필드에 그대로 저장된다."""
+    src = "erDiagram\n  USER ||--o{ ORDER : places"
+    block = self._make("mermaid", src)
+    assert block.code == src
+
+  def test_plain_language_unaffected(self):
+    """기존 plain 언어 블록이 영향을 받지 않는다."""
+    block = self._make("plain", "hello world")
+    assert block.language == "plain"
+    assert block.code == "hello world"
+
+  def test_other_languages_unaffected(self):
+    """mermaid 외 다른 언어 블록도 그대로 동작한다."""
+    for lang in ("python", "javascript", "sql"):
+      block = self._make(lang, f"# {lang} code")
+      assert block.language == lang
+
+
+# ── 2. Repository 레이어 ──────────────────────────────────────────────────────
+
+class TestMermaidCodeBlockRepository:
+  """SQLiteBlockRepository 에서 mermaid 코드 블록 CRUD 를 검증."""
+
+  def test_create_mermaid_code_block(self, repo):
+    """code 블록 생성 후 language 를 mermaid 로 변경할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    assert block is not None
+    assert block["type"] == "code"
+    # 기본값은 plain
+    assert block["language"] == "plain"
+
+  def test_update_language_to_mermaid(self, repo):
+    """update_block 으로 language 를 mermaid 로 업데이트할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    assert repo.update_block(block["id"], {"language": "mermaid"})
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].language == "mermaid"
+
+  def test_update_mermaid_code_content(self, repo):
+    """mermaid 소스 코드를 저장하고 다시 불러올 수 있다."""
+    src = "erDiagram\n  USER ||--o{ ORDER : places\n  ORDER ||--|{ LINE-ITEM : contains"
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    repo.update_block(block["id"], {"language": "mermaid", "code": src})
+    fetched = repo.get_document(doc["id"])
+    code_block = fetched.blocks[0]
+    assert code_block.language == "mermaid"
+    assert code_block.code == src
+
+  def test_mermaid_code_persists_across_reload(self, repo):
+    """저장 후 문서를 다시 로드해도 mermaid 코드와 언어가 유지된다."""
+    src = "graph TD\n  A --> B\n  B --> C"
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    repo.update_block(block["id"], {"language": "mermaid", "code": src})
+    # 문서 재로드
+    reloaded = repo.get_document(doc["id"])
+    b = reloaded.blocks[0]
+    assert b.language == "mermaid"
+    assert b.code == src
+
+  def test_change_code_block_type_from_mermaid_to_text(self, repo):
+    """mermaid 코드 블록을 text 블록으로 타입 변경할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    repo.update_block(block["id"], {"language": "mermaid", "code": "graph TD; A-->B"})
+    assert repo.change_block_type(block["id"], "text")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "text"
+
+  def test_change_type_to_code_mermaid(self, repo):
+    """text 블록을 code 블록으로 변경하고 language 를 mermaid 로 설정할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "text")
+    assert repo.change_block_type(block["id"], "code")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "code"
+    # 타입 변경 직후에는 기본 언어(plain) 이 설정된다
+    assert fetched.blocks[0].language == "plain"
+    # 이후 language 를 mermaid 로 업데이트할 수 있다
+    assert repo.update_block(fetched.blocks[0].id, {"language": "mermaid"})
+
+  def test_delete_mermaid_code_block(self, repo):
+    """mermaid 코드 블록을 삭제할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    repo.update_block(block["id"], {"language": "mermaid"})
+    assert repo.delete_block(block["id"])
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 0
+
+  def test_multiple_code_blocks_with_mixed_languages(self, repo):
+    """mermaid 블록과 일반 코드 블록이 같은 문서에서 공존할 수 있다."""
+    doc = repo.create_document()
+    mermaid_block = repo.create_block(doc["id"], "code")
+    plain_block = repo.create_block(doc["id"], "code")
+    repo.update_block(mermaid_block["id"], {"language": "mermaid", "code": "graph LR; A-->B"})
+    repo.update_block(plain_block["id"], {"language": "python", "code": "print('hi')"})
+    fetched = repo.get_document(doc["id"])
+    languages = [b.language for b in fetched.blocks]
+    assert "mermaid" in languages
+    assert "python" in languages
+
+
+# ── 3. API 레이어 ─────────────────────────────────────────────────────────────
+
+class TestMermaidCodeBlockAPI:
+  """HTTP API 를 통한 mermaid 코드 블록 생성·조회·수정을 검증."""
+
+  def test_create_code_block_via_api(self, client):
+    """POST /api/documents/{id}/blocks 로 code 블록을 생성할 수 있다."""
+    doc = client.post("/api/documents").json()
+    resp = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "code"
+    assert data["language"] == "plain"
+
+  def test_patch_language_to_mermaid(self, client):
+    """PATCH /api/blocks/{id} 로 language 를 mermaid 로 변경할 수 있다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid"})
+    assert resp.status_code == 200
+
+  def test_get_document_returns_mermaid_language(self, client):
+    """GET /api/documents/{id} 응답에 language=mermaid 가 포함된다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["language"] == "mermaid"
+
+  def test_patch_mermaid_code_content(self, client):
+    """PATCH /api/blocks/{id} 로 mermaid 소스 코드를 저장할 수 있다."""
+    src = "erDiagram\n  USER ||--o{ ORDER : places"
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid", "code": src})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    b = fetched["blocks"][0]
+    assert b["language"] == "mermaid"
+    assert b["code"] == src
+
+  def test_mermaid_code_survives_roundtrip(self, client):
+    """저장한 mermaid 소스가 다시 GET 했을 때 동일한 값으로 반환된다."""
+    src = "sequenceDiagram\n  Alice->>Bob: Hello\n  Bob-->>Alice: Hi"
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid", "code": src})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["code"] == src
+
+  def test_change_type_to_code_via_api(self, client):
+    """PATCH /api/blocks/{id}/type 으로 text → code 타입 변경 후 language 를 mermaid 로 설정할 수 있다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "text"},
+    ).json()
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": "code"})
+    assert resp.status_code == 200
+    resp2 = client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid"})
+    assert resp2.status_code == 200
+
+  def test_patch_mermaid_block_nonexistent_returns_404(self, client):
+    """존재하지 않는 블록 ID로 PATCH 시 404 를 반환한다."""
+    resp = client.patch("/api/blocks/nonexistent-id", json={"language": "mermaid"})
+    assert resp.status_code == 404
+
+  def test_existing_code_block_unaffected_by_mermaid_feature(self, client):
+    """기존 code 블록(language=python)이 mermaid 기능 추가 후에도 정상 동작한다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "python", "code": "print('hello')"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    b = fetched["blocks"][0]
+    assert b["language"] == "python"
+    assert b["code"] == "print('hello')"


### PR DESCRIPTION
## Summary

- **배경**: 코드 블록에서 다이어그램을 작성하고 즉시 확인할 수 있는 기능이 필요했다. 기존에는 Mermaid 문법을 작성해도 텍스트로만 표시됐다.
- **목적**: 코드 블록에 `mermaid` 언어 옵션을 추가하고, 작성과 동시에 다이어그램 미리보기를 한 화면에서 제공한다.

## Changes

- `base.html`: Mermaid.js CDN(v11) 로드, `startOnLoad: false` + `securityLevel: "strict"` 초기화
- `block_templates.html`: `code-block-template`에 `.mermaid-preview` / `.mermaid-error` 패널 추가
- `codeBlock.js`:
  - `CODE_LANGUAGES`에 `"mermaid"` 추가
  - `renderMermaid()` — `mermaid.render()`로 SVG 생성, 문법 오류 시 에러 패널 표시
  - `applyMermaidMode()` — mermaid ↔ 일반 모드 전환, blur 시 미리보기 자동 갱신
  - `_mermaidHljsDefinition()` — hljs에 mermaid 언어를 직접 등록 (CDN 추가 없음), 소스 코드 신택스 하이라이팅 지원
- `style.css`:
  - `.mermaid-preview` / `.mermaid-error` 스타일 추가
  - `.mermaid-preview[hidden]` / `.mermaid-error[hidden]` — `display: flex` 우선순위 충돌 해소
  - SVG 너비 `min(640px, 100%)` 고정, 높이 비율 자동 계산
- `tests/test_mermaid_code_block.py`: Model / Repository / API 레이어 단위 테스트 20케이스 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] `pytest` 215개 전체 통과 (기존 195 + 신규 20)
- [x] 브라우저 콘솔 에러 없음
- [x] mermaid 언어 선택 → 소스 하이라이팅 + 미리보기 표시 확인
- [x] 잘못된 문법 입력 시 에러 메시지 표시 확인
- [x] 다른 언어 선택 시 미리보기 패널 숨김 확인
- [x] 기존 코드 블록(python, javascript 등) 동작 이상 없음 확인

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- `_mermaidHljsDefinition`의 토큰 정규식 — flowchart, ER, sequence 등 다이어그램 유형별 커버리지가 충분한지
- `securityLevel: "strict"` 선택 이유: `"sandbox"` 모드는 임시 iframe 렌더링 시 주변 레이아웃 크기에 viewBox가 종속되는 부작용이 있어 제외했다. `"strict"`는 Mermaid 기본값으로 HTML 레이블을 인코딩해 XSS를 방어한다.
- SVG 인라인 `width` / `height` attribute와 `style.maxWidth` 를 모두 제거해야 CSS 크기 제어가 동작하는 구조 — 추후 Mermaid 버전 업 시 확인 필요

Closes #46