### PR TITLE
[FEAT#59] 이미지 블록 액션 UI — 크게 보기(라이트박스) / 더보기 드롭다운 도입

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1113,7 +1113,13 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 /* 이미지를 감싸는 래퍼 — action overlay의 position 기준점 */
 .image-media-wrap {
   position: relative;
-  line-height: 0; /* img 하단 공백 제거 */
+}
+
+/* img 기본값(inline)으로 생기는 하단 공백 제거.
+   line-height: 0 을 래퍼에 주면 자식 텍스트(플레이스홀더·버튼)가 상속해
+   텍스트가 잘리므로, img 자체에 display: block 을 적용한다. */
+.image-media-wrap img {
+  display: block;
 }
 
 /* 액션 overlay: 기본 숨김, 이미지 hover 시 노출 */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1108,6 +1108,167 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   display: none;
 }
 
+/* ── Image action overlay ────────────────────────────────────────────────── */
+
+/* 이미지를 감싸는 래퍼 — action overlay의 position 기준점 */
+.image-media-wrap {
+  position: relative;
+  line-height: 0; /* img 하단 공백 제거 */
+}
+
+/* 액션 overlay: 기본 숨김, 이미지 hover 시 노출 */
+.image-media-wrap:hover .image-actions,
+.image-media-wrap:focus-within .image-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.image-actions {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+  /* 편집 중에는 부모가 is-editing 클래스를 가지므로 overlay를 숨김 */
+}
+
+.notion-image-wrap.is-editing .image-actions {
+  display: none;
+}
+
+.image-action-btn {
+  padding: 0.28rem 0.6rem;
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  white-space: nowrap;
+  transition: background 0.12s;
+}
+
+.image-action-btn:hover,
+.image-action-btn:focus-visible {
+  background: rgba(255, 255, 255, 1);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ── 더보기 드롭다운 ─────────────────────────────────────────────────────── */
+
+/* 드롭다운 기준점: 더보기 버튼 기준 상대 위치 */
+.image-more-btn {
+  position: relative;
+}
+
+.image-more-menu {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  right: 0;
+  z-index: 300;
+  min-width: 130px;
+  margin: 0;
+  padding: 0.3rem 0;
+  list-style: none;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px -4px var(--shadow);
+  animation: fade-slide-up 0.14s ease both;
+}
+
+.image-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.48rem 0.85rem;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.84rem;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.image-menu-item:hover,
+.image-menu-item:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.image-menu-item--danger {
+  color: #c0392b;
+}
+
+.image-menu-item--danger:hover,
+.image-menu-item--danger:focus-visible {
+  background: #fdecea;
+}
+
+/* ── 라이트박스 overlay ──────────────────────────────────────────────────── */
+
+.image-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.82);
+  animation: fade-in 0.18s ease both;
+}
+
+/* 라이트박스가 열린 동안 배경 스크롤 잠금 */
+body.lightbox-open {
+  overflow: hidden;
+}
+
+.image-lightbox-img {
+  max-width: min(92vw, 1200px);
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 6px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+  user-select: none;
+}
+
+.image-lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1.2rem;
+  padding: 0.4rem 0.7rem;
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.15s;
+}
+
+.image-lightbox-close:hover,
+.image-lightbox-close:focus-visible {
+  background: rgba(255, 255, 255, 0.3);
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 /* ── Block palette ───────────────────────────────────────────────────────── */
 
 .block-palette {

--- a/static/js/blocks/imageBlock.js
+++ b/static/js/blocks/imageBlock.js
@@ -1,18 +1,30 @@
 // ── Image Block ───────────────────────────────────────────────────────────────
 
-import { apiPatchBlock, apiUploadImage } from "../api.js";
+import { apiPatchBlock, apiUploadImage, apiDeleteBlock } from "../api.js";
 
 export const type = "image";
 
 /**
+ * 이미지 블록 DOM을 생성합니다.
+ *
+ * 이미지가 있을 때: hover 시 우상단에 '크게 보기' / '···' 버튼 노출.
+ * 이미지가 없을 때: 플레이스홀더 클릭으로 편집 패널 진입.
+ *
  * @param {object} block
+ * @param {{ callbacks: object }} opts — blockRenderers.js가 전달하는 콜백 묶음
  * @returns {HTMLElement}
  */
-export function create(block) {
+export function create(block, { callbacks } = {}) {
   const template = document.getElementById("image-block-template");
   const node = template.content.firstElementChild.cloneNode(true);
+
+  const mediaWrap = node.querySelector(".image-media-wrap");
   const image = node.querySelector(".notion-image");
   const caption = node.querySelector(".notion-caption");
+  const actionsEl = node.querySelector(".image-actions");
+  const viewBtn = node.querySelector(".image-view-btn");
+  const moreBtn = node.querySelector(".image-more-btn");
+  const moreMenu = node.querySelector(".image-more-menu");
 
   let currentUrl = block.url || "";
   image.src = currentUrl;
@@ -21,11 +33,23 @@ export function create(block) {
 
   if (!block.caption) caption.classList.add("is-empty");
 
+  // 이미지가 없으면 플레이스홀더로 교체
   const placeholder = document.createElement("div");
   placeholder.className = "image-placeholder";
   placeholder.textContent = "이미지를 추가하려면 클릭하세요";
-  if (!currentUrl) image.replaceWith(placeholder);
+  if (!currentUrl) {
+    image.replaceWith(placeholder);
+  }
 
+  // 액션 버튼은 이미지가 있을 때만 표시
+  actionsEl.hidden = !currentUrl;
+
+  // ── 편집 패널 ────────────────────────────────────────────────────────────
+
+  /**
+   * 이미지 변경 편집 패널을 열고 anchorEl 자리를 교체합니다.
+   * @param {HTMLElement} anchorEl — image 또는 placeholder
+   */
   function openEditPanel(anchorEl) {
     const panel = buildImageEditPanel({
       currentUrl,
@@ -33,13 +57,17 @@ export function create(block) {
         if (newUrl && newUrl !== currentUrl) {
           currentUrl = newUrl;
           image.src = newUrl;
+          image.alt = caption.textContent.trim();
           apiPatchBlock(block.id, { url: newUrl }).catch(console.error);
         }
+        // 편집 완료 후 이미지 또는 플레이스홀더 복원
         panel.replaceWith(currentUrl ? image : placeholder);
+        actionsEl.hidden = !currentUrl;
         node.classList.remove("is-editing");
       },
       onCancel() {
         panel.replaceWith(currentUrl ? image : placeholder);
+        actionsEl.hidden = !currentUrl;
         node.classList.remove("is-editing");
       },
     });
@@ -47,10 +75,95 @@ export function create(block) {
     anchorEl.replaceWith(panel);
   }
 
-  image.addEventListener("click", () => openEditPanel(image));
+  // 플레이스홀더 클릭 → 편집 패널 (이미지 없을 때)
   placeholder.addEventListener("click", () => openEditPanel(placeholder));
 
-  // ── Caption editing ──────────────────────────────────────────────────────
+  // ── 크게 보기 (라이트박스) ───────────────────────────────────────────────
+
+  viewBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    openLightbox(currentUrl, caption.textContent.trim());
+  });
+
+  // ── 더보기 드롭다운 ──────────────────────────────────────────────────────
+
+  /** 드롭다운 열기/닫기 */
+  function toggleMenu(open) {
+    moreMenu.hidden = !open;
+    moreBtn.setAttribute("aria-expanded", String(open));
+    if (open) {
+      // 첫 번째 메뉴 항목에 포커스
+      const first = moreMenu.querySelector("[role='menuitem']");
+      first?.focus();
+    }
+  }
+
+  moreBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggleMenu(moreMenu.hidden); // 토글
+  });
+
+  // 메뉴 항목 키보드 탐색 (ArrowUp / ArrowDown)
+  moreMenu.addEventListener("keydown", (e) => {
+    const items = [...moreMenu.querySelectorAll("[role='menuitem']")];
+    const idx = items.indexOf(document.activeElement);
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      items[(idx + 1) % items.length]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      items[(idx - 1 + items.length) % items.length]?.focus();
+    }
+  });
+
+  // ESC로 드롭다운 닫기
+  node.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !moreMenu.hidden) {
+      e.stopPropagation();
+      toggleMenu(false);
+      moreBtn.focus();
+    }
+  });
+
+  // 외부 클릭 시 드롭다운 닫기 (캡처 단계에서 처리하여 다른 블록과 충돌 방지)
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (!node.contains(e.target)) toggleMenu(false);
+    },
+    { capture: true },
+  );
+
+  // 드롭다운 메뉴 액션 처리
+  moreMenu.addEventListener("click", async (e) => {
+    const btn = e.target.closest("[data-action]");
+    if (!btn) return;
+
+    toggleMenu(false);
+
+    switch (btn.dataset.action) {
+      case "change-image":
+        // 현재 이미지(또는 플레이스홀더) 자리에 편집 패널 열기
+        openEditPanel(currentUrl ? image : placeholder);
+        break;
+
+      case "edit-caption":
+        caption.focus();
+        break;
+
+      case "delete":
+        try {
+          await apiDeleteBlock(block.id);
+          callbacks?.reloadDocument?.();
+        } catch (err) {
+          console.error("이미지 블록 삭제 실패:", err);
+        }
+        break;
+    }
+  });
+
+  // ── 캡션 편집 ────────────────────────────────────────────────────────────
+
   let originalCaption = block.caption || "";
   let captionEscaped = false;
   caption.contentEditable = "true";
@@ -87,7 +200,64 @@ export function create(block) {
   return node;
 }
 
-// ── Image edit panel (URL / file upload) ─────────────────────────────────────
+// ── 라이트박스 ────────────────────────────────────────────────────────────────
+
+/**
+ * 전체화면 이미지 뷰어를 열고 ESC / 배경 클릭 / 닫기 버튼으로 종료합니다.
+ *
+ * 접근성:
+ *   - role="dialog" + aria-modal="true" 로 스크린리더에 모달임을 알림
+ *   - 열릴 때 닫기 버튼으로 포커스 이동
+ *   - ESC 키로 종료
+ *   - body.lightbox-open으로 배경 스크롤 잠금
+ *
+ * @param {string} src
+ * @param {string} alt
+ */
+function openLightbox(src, alt) {
+  const overlay = document.createElement("div");
+  overlay.className = "image-lightbox-overlay";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-label", "이미지 크게 보기");
+
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "image-lightbox-close";
+  closeBtn.setAttribute("aria-label", "닫기");
+  closeBtn.textContent = "✕";
+
+  const img = document.createElement("img");
+  img.className = "image-lightbox-img";
+  img.src = src;
+  img.alt = alt;
+
+  overlay.append(closeBtn, img);
+  document.body.append(overlay);
+  document.body.classList.add("lightbox-open");
+
+  // 포커스를 닫기 버튼으로 이동 (접근성)
+  closeBtn.focus();
+
+  function close() {
+    overlay.remove();
+    document.body.classList.remove("lightbox-open");
+    document.removeEventListener("keydown", onKeyDown);
+  }
+
+  function onKeyDown(e) {
+    if (e.key === "Escape") close();
+  }
+
+  closeBtn.addEventListener("click", close);
+  // 오버레이 배경(이미지 외부) 클릭 시 닫기
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener("keydown", onKeyDown);
+}
+
+// ── 이미지 편집 패널 (URL / 파일 업로드) ─────────────────────────────────────
 
 /**
  * URL 입력과 파일 업로드를 탭으로 전환할 수 있는 편집 패널을 반환합니다.

--- a/static/js/blocks/imageBlock.js
+++ b/static/js/blocks/imageBlock.js
@@ -217,6 +217,9 @@ export function create(block, { callbacks } = {}) {
  * @param {string} alt
  */
 function openLightbox(src, alt) {
+  // 닫힌 후 포커스를 복원할 트리거 요소를 미리 저장 (WCAG 2.4.3)
+  const previousFocus = document.activeElement;
+
   const overlay = document.createElement("div");
   overlay.className = "image-lightbox-overlay";
   overlay.setAttribute("role", "dialog");
@@ -238,17 +241,51 @@ function openLightbox(src, alt) {
   document.body.append(overlay);
   document.body.classList.add("lightbox-open");
 
-  // 포커스를 닫기 버튼으로 이동 (접근성)
+  // 열릴 때 포커스를 닫기 버튼으로 이동
   closeBtn.focus();
 
   function close() {
     overlay.remove();
     document.body.classList.remove("lightbox-open");
     document.removeEventListener("keydown", onKeyDown);
+    // 닫힌 후 트리거 요소로 포커스 복원 (WCAG 2.4.3 Focus Order)
+    previousFocus?.focus();
   }
 
+  // 포커스 트랩 — overlay 내 포커스 가능 요소 목록을 Tab/Shift+Tab으로 순환
+  // (ARIA Authoring Practices Guide — Modal Dialog Pattern)
   function onKeyDown(e) {
-    if (e.key === "Escape") close();
+    if (e.key === "Escape") {
+      close();
+      return;
+    }
+
+    if (e.key === "Tab") {
+      const focusable = [
+        ...overlay.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ].filter((el) => !el.disabled);
+
+      if (focusable.length === 0) { e.preventDefault(); return; }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab: 첫 요소에서 뒤로 가면 마지막 요소로 순환
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: 마지막 요소에서 앞으로 가면 첫 요소로 순환
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
   }
 
   closeBtn.addEventListener("click", close);

--- a/static/js/blocks/imageBlock.js
+++ b/static/js/blocks/imageBlock.js
@@ -18,7 +18,6 @@ export function create(block, { callbacks } = {}) {
   const template = document.getElementById("image-block-template");
   const node = template.content.firstElementChild.cloneNode(true);
 
-  const mediaWrap = node.querySelector(".image-media-wrap");
   const image = node.querySelector(".notion-image");
   const caption = node.querySelector(".notion-caption");
   const actionsEl = node.querySelector(".image-actions");
@@ -51,6 +50,13 @@ export function create(block, { callbacks } = {}) {
    * @param {HTMLElement} anchorEl — image 또는 placeholder
    */
   function openEditPanel(anchorEl) {
+    // onCommit / onCancel 공통 teardown — DRY
+    const closePanel = () => {
+      panel.replaceWith(currentUrl ? image : placeholder);
+      actionsEl.hidden = !currentUrl;
+      node.classList.remove("is-editing");
+    };
+
     const panel = buildImageEditPanel({
       currentUrl,
       onCommit(newUrl) {
@@ -60,16 +66,9 @@ export function create(block, { callbacks } = {}) {
           image.alt = caption.textContent.trim();
           apiPatchBlock(block.id, { url: newUrl }).catch(console.error);
         }
-        // 편집 완료 후 이미지 또는 플레이스홀더 복원
-        panel.replaceWith(currentUrl ? image : placeholder);
-        actionsEl.hidden = !currentUrl;
-        node.classList.remove("is-editing");
+        closePanel();
       },
-      onCancel() {
-        panel.replaceWith(currentUrl ? image : placeholder);
-        actionsEl.hidden = !currentUrl;
-        node.classList.remove("is-editing");
-      },
+      onCancel: closePanel,
     });
     node.classList.add("is-editing");
     anchorEl.replaceWith(panel);

--- a/static/js/blocks/imageBlock.js
+++ b/static/js/blocks/imageBlock.js
@@ -86,6 +86,13 @@ export function create(block, { callbacks } = {}) {
 
   // ── 더보기 드롭다운 ──────────────────────────────────────────────────────
 
+  // 외부 클릭 핸들러 — toggleMenu(true) 때만 등록, false 때 해제
+  // 블록당 하나의 named 함수를 재사용해 addEventListener/removeEventListener가
+  // 동일 참조로 짝을 맞출 수 있도록 한다.
+  const handleOutsideClick = (e) => {
+    if (!node.contains(e.target)) toggleMenu(false);
+  };
+
   /** 드롭다운 열기/닫기 */
   function toggleMenu(open) {
     moreMenu.hidden = !open;
@@ -94,6 +101,11 @@ export function create(block, { callbacks } = {}) {
       // 첫 번째 메뉴 항목에 포커스
       const first = moreMenu.querySelector("[role='menuitem']");
       first?.focus();
+      // 열릴 때만 외부 클릭 감지 시작
+      document.addEventListener("click", handleOutsideClick, { capture: true });
+    } else {
+      // 닫힐 때 리스너 즉시 해제 → 블록이 많아도 클릭당 1회만 실행
+      document.removeEventListener("click", handleOutsideClick, { capture: true });
     }
   }
 
@@ -123,15 +135,6 @@ export function create(block, { callbacks } = {}) {
       moreBtn.focus();
     }
   });
-
-  // 외부 클릭 시 드롭다운 닫기 (캡처 단계에서 처리하여 다른 블록과 충돌 방지)
-  document.addEventListener(
-    "click",
-    (e) => {
-      if (!node.contains(e.target)) toggleMenu(false);
-    },
-    { capture: true },
-  );
 
   // 드롭다운 메뉴 액션 처리
   moreMenu.addEventListener("click", async (e) => {

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -4,7 +4,43 @@
 
 <template id="image-block-template">
   <figure class="notion-block notion-image-wrap">
-    <img class="notion-image" alt="" loading="lazy" />
+    <!-- 이미지/플레이스홀더/편집 패널을 감싸는 래퍼 (action overlay 기준점) -->
+    <div class="image-media-wrap">
+      <img class="notion-image" alt="" loading="lazy" />
+      <!-- 이미지 로드 상태일 때만 표시되는 액션 overlay -->
+      <div class="image-actions" aria-label="이미지 액션" hidden>
+        <button
+          type="button"
+          class="image-action-btn image-view-btn"
+          aria-label="크게 보기"
+        >크게 보기</button>
+        <button
+          type="button"
+          class="image-action-btn image-more-btn"
+          aria-label="더보기"
+          aria-expanded="false"
+          aria-haspopup="menu"
+        >···</button>
+        <!-- 더보기 드롭다운 메뉴 -->
+        <ul class="image-more-menu" role="menu" hidden>
+          <li role="none">
+            <button type="button" class="image-menu-item" data-action="change-image" role="menuitem">
+              이미지 변경
+            </button>
+          </li>
+          <li role="none">
+            <button type="button" class="image-menu-item" data-action="edit-caption" role="menuitem">
+              캡션 편집
+            </button>
+          </li>
+          <li role="none">
+            <button type="button" class="image-menu-item image-menu-item--danger" data-action="delete" role="menuitem">
+              삭제
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
     <figcaption class="notion-caption" data-placeholder="캡션 추가..."></figcaption>
   </figure>
 </template>

--- a/tests/test_image_block_actions.py
+++ b/tests/test_image_block_actions.py
@@ -1,0 +1,390 @@
+"""이미지 블록 액션 UI 관련 단위 테스트 (이슈 #59).
+
+커버리지 범위:
+  1. Repository 레이어 — image 블록 생성·URL 수정·caption 수정·삭제
+  2. API 레이어        — PATCH url/caption, DELETE, 잘못된 ID 처리
+  3. process_image 서비스 — 압축·썸네일 생성·WebP 변환 검증
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+
+# ── 1. Repository 레이어 ──────────────────────────────────────────────────────
+
+class TestImageBlockRepository:
+  """SQLiteBlockRepository에서 image 블록의 CRUD를 검증."""
+
+  def test_create_image_block(self, repo):
+    """image 블록 생성 시 기본 필드가 올바르게 초기화된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    assert block is not None
+    assert block["type"] == "image"
+    assert block["url"] == ""
+    assert block["caption"] == ""
+
+  def test_create_image_block_returns_required_fields(self, repo):
+    """image 블록에 url·caption 필드가 반드시 포함된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    for field in ("id", "type", "url", "caption"):
+      assert field in block, f"필드 누락: {field}"
+
+  def test_update_image_url(self, repo):
+    """url 필드 수정이 정상적으로 반영된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    new_url = "https://example.com/photo.jpg"
+    assert repo.update_block(block["id"], {"url": new_url})
+
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].url == new_url
+
+  def test_update_image_caption(self, repo):
+    """caption 필드 수정이 정상적으로 반영된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    assert repo.update_block(block["id"], {"caption": "고양이 사진"})
+
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].caption == "고양이 사진"
+
+  def test_update_url_and_caption_together(self, repo):
+    """url과 caption을 동시에 수정해도 모두 반영된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    repo.update_block(block["id"], {
+      "url": "https://example.com/img.webp",
+      "caption": "예시 이미지",
+    })
+
+    fetched = repo.get_document(doc["id"])
+    img = fetched.blocks[0]
+    assert img.url == "https://example.com/img.webp"
+    assert img.caption == "예시 이미지"
+
+  def test_update_nonexistent_block_returns_false(self, repo):
+    """존재하지 않는 블록 수정 시 False를 반환한다."""
+    result = repo.update_block("does-not-exist", {"url": "https://example.com/a.jpg"})
+    assert result is False
+
+  def test_delete_image_block(self, repo):
+    """image 블록 삭제 후 문서에서 블록이 사라진다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    assert repo.delete_block(block["id"])
+
+    fetched = repo.get_document(doc["id"])
+    assert len(fetched.blocks) == 0
+
+  def test_delete_nonexistent_block_returns_false(self, repo):
+    """존재하지 않는 블록 삭제 시 False를 반환한다."""
+    assert repo.delete_block("does-not-exist") is False
+
+  def test_image_persists_across_document_reload(self, repo):
+    """저장 후 문서를 다시 불러와도 url·caption이 유지된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+    repo.update_block(block["id"], {
+      "url": "https://example.com/persist.png",
+      "caption": "유지 테스트",
+    })
+
+    refetched = repo.get_document(doc["id"])
+    img = refetched.blocks[0]
+    assert img.url == "https://example.com/persist.png"
+    assert img.caption == "유지 테스트"
+
+  def test_change_type_to_image(self, repo):
+    """다른 타입 블록을 image로 변환하면 url·caption이 기본값으로 초기화된다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "text")
+
+    assert repo.change_block_type(block["id"], "image")
+
+    fetched = repo.get_document(doc["id"])
+    img = fetched.blocks[0]
+    assert img.type == "image"
+    assert img.url == ""
+    assert img.caption == ""
+
+  def test_change_type_from_image_to_text(self, repo):
+    """image 블록을 text로 변환할 수 있다."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "image")
+
+    assert repo.change_block_type(block["id"], "text")
+
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].type == "text"
+
+
+# ── 2. API 레이어 ─────────────────────────────────────────────────────────────
+
+class TestImageBlockAPI:
+  """HTTP API를 통한 image 블록 생성·조회·수정·삭제를 검증."""
+
+  def _create_image_block(self, client) -> tuple[dict, dict]:
+    """테스트용 문서와 image 블록을 생성해 반환하는 헬퍼."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "image"},
+    ).json()
+    return doc, block
+
+  def test_create_image_block_returns_201(self, client):
+    """image 블록 생성 요청은 201을 반환한다."""
+    doc = client.post("/api/documents").json()
+    resp = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "image"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "image"
+
+  def test_get_document_includes_image_block(self, client):
+    """생성된 image 블록이 문서 조회 결과에 포함된다."""
+    doc, _ = self._create_image_block(client)
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["type"] == "image"
+
+  def test_patch_image_url(self, client):
+    """PATCH /api/blocks/{id} 로 url 수정이 200을 반환한다."""
+    _, block = self._create_image_block(client)
+    resp = client.patch(
+      f"/api/blocks/{block['id']}",
+      json={"url": "https://example.com/new.jpg"},
+    )
+    assert resp.status_code == 200
+
+  def test_patch_image_caption(self, client):
+    """PATCH /api/blocks/{id} 로 caption 수정이 200을 반환한다."""
+    _, block = self._create_image_block(client)
+    resp = client.patch(
+      f"/api/blocks/{block['id']}",
+      json={"caption": "수정된 캡션"},
+    )
+    assert resp.status_code == 200
+
+  def test_patch_url_reflected_in_document(self, client):
+    """url 수정 후 문서 재조회 시 변경 값이 반영된다."""
+    doc, block = self._create_image_block(client)
+    new_url = "https://example.com/updated.webp"
+
+    client.patch(f"/api/blocks/{block['id']}", json={"url": new_url})
+
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["url"] == new_url
+
+  def test_patch_caption_reflected_in_document(self, client):
+    """caption 수정 후 문서 재조회 시 변경 값이 반영된다."""
+    doc, block = self._create_image_block(client)
+
+    client.patch(f"/api/blocks/{block['id']}", json={"caption": "갱신된 캡션"})
+
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["caption"] == "갱신된 캡션"
+
+  def test_patch_nonexistent_block_returns_404(self, client):
+    """존재하지 않는 블록 수정 시 404를 반환한다."""
+    resp = client.patch(
+      "/api/blocks/nonexistent-id",
+      json={"url": "https://example.com/x.jpg"},
+    )
+    assert resp.status_code == 404
+
+  def test_patch_no_fields_returns_422(self, client):
+    """수정 필드가 없는 PATCH 요청은 422를 반환한다."""
+    _, block = self._create_image_block(client)
+    resp = client.patch(f"/api/blocks/{block['id']}", json={})
+    assert resp.status_code == 422
+
+  def test_delete_image_block_returns_204(self, client):
+    """DELETE /api/blocks/{id} 는 204를 반환한다."""
+    _, block = self._create_image_block(client)
+    resp = client.delete(f"/api/blocks/{block['id']}")
+    assert resp.status_code == 204
+
+  def test_delete_removes_block_from_document(self, client):
+    """블록 삭제 후 문서 재조회 시 블록이 목록에서 사라진다."""
+    doc, block = self._create_image_block(client)
+
+    client.delete(f"/api/blocks/{block['id']}")
+
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert len(fetched["blocks"]) == 0
+
+  def test_delete_nonexistent_block_returns_404(self, client):
+    """존재하지 않는 블록 삭제 시 404를 반환한다."""
+    resp = client.delete("/api/blocks/nonexistent-id")
+    assert resp.status_code == 404
+
+  def test_change_type_to_image_via_api(self, client):
+    """PATCH /api/blocks/{id}/type 으로 image 타입 전환이 200을 반환한다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "text"},
+    ).json()
+
+    resp = client.patch(f"/api/blocks/{block['id']}/type", json={"type": "image"})
+    assert resp.status_code == 200
+
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["type"] == "image"
+
+
+# ── 3. process_image 서비스 ───────────────────────────────────────────────────
+
+class TestProcessImageService:
+  """app.services.image.process_image 의 압축·썸네일·형식 변환을 검증."""
+
+  def _make_png_bytes(self, width: int = 100, height: int = 80) -> bytes:
+    """PIL로 단색 PNG 이미지를 생성해 bytes로 반환하는 헬퍼."""
+    from PIL import Image as PilImage
+    img = PilImage.new("RGB", (width, height), color=(120, 200, 150))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+  def test_returns_url_and_thumbnail_url(self, tmp_path, monkeypatch):
+    """process_image가 url과 thumbnail_url 두 키를 반환한다."""
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    result = img_svc.process_image(self._make_png_bytes())
+
+    assert "url" in result
+    assert "thumbnail_url" in result
+
+  def test_output_is_webp(self, tmp_path, monkeypatch):
+    """압축된 원본 이미지는 WebP 형식으로 저장된다."""
+    from PIL import Image as PilImage
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    result = img_svc.process_image(self._make_png_bytes())
+    # url 경로: /static/uploads/<name>.webp
+    assert result["url"].endswith(".webp")
+
+  def test_thumbnail_is_webp(self, tmp_path, monkeypatch):
+    """썸네일 이미지도 WebP 형식으로 저장된다."""
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    result = img_svc.process_image(self._make_png_bytes())
+    assert result["thumbnail_url"].endswith(".webp")
+
+  def test_large_image_downscaled(self, tmp_path, monkeypatch):
+    """MAX_DIMENSION을 초과하는 이미지는 지정 크기 이내로 축소된다."""
+    from PIL import Image as PilImage
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    # MAX_DIMENSION(1920)보다 큰 이미지 생성
+    big_png = self._make_png_bytes(width=3000, height=2000)
+    result = img_svc.process_image(big_png)
+
+    # 저장된 파일을 열어 실제 크기 확인
+    saved_name = result["url"].split("/")[-1]
+    saved_path = tmp_path / saved_name
+    with PilImage.open(saved_path) as saved:
+      assert max(saved.size) <= img_svc.MAX_DIMENSION
+
+  def test_small_image_not_upscaled(self, tmp_path, monkeypatch):
+    """MAX_DIMENSION보다 작은 이미지는 확대되지 않는다."""
+    from PIL import Image as PilImage
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    small_png = self._make_png_bytes(width=200, height=150)
+    result = img_svc.process_image(small_png)
+
+    saved_name = result["url"].split("/")[-1]
+    saved_path = tmp_path / saved_name
+    with PilImage.open(saved_path) as saved:
+      assert saved.size == (200, 150)
+
+  def test_thumbnail_fits_within_thumbnail_size(self, tmp_path, monkeypatch):
+    """썸네일은 THUMBNAIL_SIZE 이내 크기로 생성된다."""
+    from PIL import Image as PilImage
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    big_png = self._make_png_bytes(width=1000, height=800)
+    result = img_svc.process_image(big_png)
+
+    thumb_name = result["thumbnail_url"].split("/")[-1]
+    thumb_path = tmp_path / "thumbnails" / thumb_name
+    with PilImage.open(thumb_path) as thumb:
+      max_side = max(thumb.size)
+      assert max_side <= max(img_svc.THUMBNAIL_SIZE)
+
+  def test_rgba_image_processed_without_error(self, tmp_path, monkeypatch):
+    """RGBA (투명도 있는) 이미지도 오류 없이 처리된다."""
+    from PIL import Image as PilImage
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    img = PilImage.new("RGBA", (100, 100), color=(255, 0, 0, 128))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+
+    result = img_svc.process_image(buf.getvalue())
+    assert "url" in result
+
+  def test_url_path_has_correct_prefix(self, tmp_path, monkeypatch):
+    """반환된 url은 /static/uploads/ 로 시작한다."""
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    result = img_svc.process_image(self._make_png_bytes())
+    assert result["url"].startswith("/static/uploads/")
+
+  def test_thumbnail_url_path_has_correct_prefix(self, tmp_path, monkeypatch):
+    """반환된 thumbnail_url은 /static/uploads/thumbnails/ 로 시작한다."""
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    result = img_svc.process_image(self._make_png_bytes())
+    assert result["thumbnail_url"].startswith("/static/uploads/thumbnails/")
+
+  def test_each_call_generates_unique_filename(self, tmp_path, monkeypatch):
+    """두 번 호출하면 서로 다른 파일 이름이 생성된다."""
+    from app.services import image as img_svc
+
+    monkeypatch.setattr(img_svc, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(img_svc, "THUMBNAILS_DIR", tmp_path / "thumbnails")
+
+    r1 = img_svc.process_image(self._make_png_bytes())
+    r2 = img_svc.process_image(self._make_png_bytes())
+    assert r1["url"] != r2["url"]


### PR DESCRIPTION
## Summary

- **배경:** 이미지 블록은 클릭 시 즉시 편집 패널이 열리는 단일 인터랙션만 제공해, 크게 보기나 삭제 같은 추가 액션이 불가능했습니다.
- **목적:** 이미지 우상단에 `크게 보기` / `···` 버튼을 도입하여, 라이트박스 뷰어와 드롭다운 액션 메뉴를 통해 명시적 액션 중심 UX로 전환합니다.

Closes #59

## Changes

- **`templates/partials/block_templates.html`** — `image-media-wrap` 래퍼 추가, 크게 보기·더보기 버튼 및 드롭다운 메뉴(`이미지 변경` / `캡션 편집` / `삭제`) 마크업 삽입. ARIA 속성(`aria-expanded`, `aria-haspopup`, `role="menu/menuitem"`) 포함
- **`static/css/style.css`** — action overlay(hover/focus-within 노출), 라이트박스 overlay, 더보기 드롭다운, 위험 액션 색상 등 161줄 스타일 추가
- **`static/js/blocks/imageBlock.js`** — 이미지 직접 클릭 편집 제거 및 아래 기능 구현
  - `openLightbox()` — ESC / 배경 클릭 / 닫기 버튼 종료, `body.lightbox-open` 스크롤 잠금, 포커스 이동
  - `toggleMenu()` — ArrowUp/Down 키보드 탐색, ESC 닫힘 + 버튼 포커스 복귀, 외부 클릭 자동 닫힘(capture)
  - 드롭다운 삭제 액션: `apiDeleteBlock` → `callbacks.reloadDocument`
- **`tests/test_image_block_actions.py`** — 단위 테스트 33개 신규 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [x] 브라우저 콘솔 에러 없음
- [x] `uv run pytest` — 248개 전부 통과 (기존 215개 + 신규 33개, 회귀 없음)
- [x] 이미지 있는 블록: hover 시 버튼 노출, 크게 보기 라이트박스 동작
- [x] 더보기 → 이미지 변경 / 캡션 편집 / 삭제 각 액션 정상 수행
- [x] ESC / 외부 클릭으로 라이트박스·드롭다운 닫힘 확인
- [x] 플레이스홀더 클릭 → 편집 패널 진입 (기존 동작 회귀 없음)
- [x] 키보드(Tab / ArrowUp·Down / ESC) 탐색 동작 확인

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [x] 문서 업데이트 필요 시 반영

## Review Points

- **`imageBlock.js` `openEditPanel`:** `actionsEl.hidden` 갱신이 `onCommit` / `onCancel` 양쪽에 중복됩니다. 공통 헬퍼로 추출할지 검토 부탁드립니다.
- **외부 클릭 리스너 누수:** `document.addEventListener(..., { capture: true })` 가 블록이 DOM에서 제거된 뒤에도 유지될 수 있습니다. `AbortController` 기반 정리가 필요한지 의견 부탁드립니다.
- **라이트박스 포커스 트랩:** 현재 닫기 버튼 하나만 포커스되므로 Tab이 배경으로 빠져나갈 수 있습니다. 완전한 포커스 트랩 범위를 어디까지 잡을지 판단 부탁드립니다.