### PR TITLE
[FEAT#60] Mermaid 다이어그램 이미지 미리보기 및 크게 보기·다운로드 액션 추가

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -853,9 +853,38 @@ body.sidebar-collapsed .sidebar-tab-chevron {
 /* [hidden] 속성이 있을 때 display:flex 를 덮어쓰지 않도록 명시적으로 숨김 처리.
    브라우저 UA 스타일시트의 [hidden]{display:none} 보다 클래스 선택자가 우선하므로
    직접 선언이 필요하다. (Ref: CSS Cascading and Inheritance — https://www.w3.org/TR/css-cascade-5/) */
-.mermaid-preview[hidden],
+.mermaid-panel[hidden],
+.mermaid-media-wrap[hidden],
+.mermaid-actions[hidden],
 .mermaid-error[hidden] {
   display: none;
+}
+
+/* 미리보기 래퍼: 액션 overlay의 position 기준점 */
+.mermaid-media-wrap {
+  position: relative;
+}
+
+/* 프리뷰 hover / 포커스 이동 시 액션 overlay 노출 */
+.mermaid-media-wrap:hover .mermaid-actions,
+.mermaid-media-wrap:focus-within .mermaid-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* 이미지 블록과 동일한 액션 overlay 패턴 적용.
+   기본 opacity:0 / pointer-events:none — CSS hover가 제어한다.
+   [hidden] 속성이 없을 때만 overlay가 DOM에 존재하므로 transition이 자연스럽게 동작한다. */
+.mermaid-actions {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
 }
 
 .mermaid-preview {
@@ -875,8 +904,15 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   display: block;
 }
 
-/* 문법 오류 표시 영역 */
+/* ── 문법 오류 표시 영역 ─────────────────────────────────────────────────── */
+
+/* 오류 메시지와 재시도 버튼을 가로로 배치.
+   flex-wrap: wrap 으로 긴 오류 메시지가 버튼을 밀어내지 않도록 한다. */
 .mermaid-error {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
   padding: 0.6rem 1rem;
   background: rgba(220, 53, 69, 0.08);
   border-top: 1px solid rgba(220, 53, 69, 0.25);
@@ -884,8 +920,55 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
   font-size: 0.78rem;
   line-height: 1.5;
+}
+
+.mermaid-error-msg {
+  flex: 1 1 60%;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+/* 재시도 버튼: 오류 스타일과 시각적으로 일관된 인라인 버튼 */
+.mermaid-retry-btn {
+  flex-shrink: 0;
+  padding: 0.18rem 0.55rem;
+  border: 1px solid rgba(220, 53, 69, 0.45);
+  border-radius: 4px;
+  background: transparent;
+  color: #e55563;
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s;
+}
+
+.mermaid-retry-btn:hover,
+.mermaid-retry-btn:focus-visible {
+  background: rgba(220, 53, 69, 0.1);
+  outline: 2px solid rgba(220, 53, 69, 0.5);
+  outline-offset: 1px;
+}
+
+/* ── Mermaid 라이트박스 SVG 컨테이너 ────────────────────────────────────── */
+
+/* 이미지 라이트박스(.image-lightbox-overlay, .image-lightbox-close)를 재사용하고
+   SVG 전용 컨테이너 스타일만 추가한다. */
+.mermaid-lightbox-svg {
+  max-width: min(92vw, 1100px);
+  max-height: 90vh;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+  overflow: auto;
+}
+
+.mermaid-lightbox-svg svg {
+  /* 라이트박스 내에서 SVG가 전체 너비를 채우도록 한다 */
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 /* ── Callout block ───────────────────────────────────────────────────────── */

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -261,6 +261,18 @@ function openMermaidLightbox(previewEl) {
   // 열릴 때 포커스를 닫기 버튼으로 이동
   closeBtn.focus();
 
+  // 라이트박스가 열린 후 DOM이 변경되지 않으므로 focusable 목록을 1회만 계산한다.
+  // onKeyDown 내부에서 매 Tab 이벤트마다 querySelectorAll 을 실행하면 불필요한
+  // DOM 순회 비용이 발생한다. (ARIA APG — Managing Focus: Focusable Elements)
+  // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+  const focusable = [
+    ...overlay.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
+  ].filter((el) => !el.disabled);
+  const focusFirst = focusable[0] ?? null;
+  const focusLast = focusable[focusable.length - 1] ?? null;
+
   function close() {
     overlay.remove();
     document.body.classList.remove("lightbox-open");
@@ -269,7 +281,7 @@ function openMermaidLightbox(previewEl) {
     previousFocus?.focus();
   }
 
-  // 포커스 트랩 — overlay 내 포커스 가능 요소 목록을 Tab/Shift+Tab으로 순환
+  // 포커스 트랩 — overlay 내 포커스 가능 요소를 Tab/Shift+Tab으로 순환
   // (ARIA Authoring Practices Guide — Modal Dialog Pattern)
   function onKeyDown(e) {
     if (e.key === "Escape") {
@@ -278,26 +290,17 @@ function openMermaidLightbox(previewEl) {
     }
 
     if (e.key === "Tab") {
-      const focusable = [
-        ...overlay.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        ),
-      ].filter((el) => !el.disabled);
-
       if (focusable.length === 0) { e.preventDefault(); return; }
 
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-
       if (e.shiftKey) {
-        if (document.activeElement === first) {
+        if (document.activeElement === focusFirst) {
           e.preventDefault();
-          last.focus();
+          focusLast.focus();
         }
       } else {
-        if (document.activeElement === last) {
+        if (document.activeElement === focusLast) {
           e.preventDefault();
-          first.focus();
+          focusFirst.focus();
         }
       }
     }

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -120,31 +120,51 @@ function _ensureMermaidHljs() {
 
 /**
  * Mermaid.js를 사용해 소스 코드를 SVG로 렌더링한다.
- * 렌더 성공 시 previewEl에 SVG를 삽입하고, 실패 시 errorEl에 오류 메시지를 표시한다.
+ *
+ * 렌더 결과에 따라 DOM을 갱신한다.
+ * - 성공: previewEl 에 SVG 삽입, mediaWrapEl 표시, actionsEl 활성화
+ * - 빈 입력: previewEl 초기화, mediaWrapEl 및 오류 숨김
+ * - 실패: opreviewEl 초기화, errorMsgEl 에 오류 메시지 표시
  *
  * Ref: https://mermaid.js.org/config/usage.html#using-mermaid-render
  *
- * @param {string} blockId - 블록 고유 ID (mermaid 렌더 ID 생성에 사용)
- * @param {string} source  - Mermaid 문법 소스 코드
- * @param {HTMLElement} previewEl - SVG를 삽입할 컨테이너
- * @param {HTMLElement} errorEl   - 오류 메시지를 표시할 컨테이너
- * @param {function(): boolean} isCancelled - true를 반환하면 DOM 갱신을 건너뛴다.
+ * @param {string} blockId       - 블록 고유 ID (mermaid 렌더 ID 생성에 사용)
+ * @param {string} source        - Mermaid 문법 소스 코드
+ * @param {object} opts
+ * @param {HTMLElement} opts.previewEl    - SVG를 삽입할 컨테이너
+ * @param {HTMLElement} opts.errorEl      - 오류 영역 전체 컨테이너
+ * @param {HTMLElement} opts.errorMsgEl   - 오류 메시지 텍스트 span
+ * @param {HTMLElement} opts.mediaWrapEl  - 미리보기 래퍼 (hidden 관리)
+ * @param {HTMLElement} opts.actionsEl    - 액션 버튼 overlay (hidden 관리)
+ * @param {function(): boolean} opts.isCancelled
+ *   true를 반환하면 DOM 갱신을 건너뛴다.
  *   blur → language change 순서로 이벤트가 발생할 때, blur 핸들러에서 시작된
  *   async 렌더가 language change 이후에 완료되며 previewEl을 다시 노출시키는
  *   경쟁 조건을 방지한다.
  */
-async function renderMermaid(blockId, source, previewEl, errorEl, isCancelled = () => false) {
+async function renderMermaid(blockId, source, opts = {}) {
+  const {
+    previewEl,
+    errorEl,
+    errorMsgEl,
+    mediaWrapEl,
+    actionsEl,
+    isCancelled = () => false,
+  } = opts;
+
   if (!window.mermaid) {
-    errorEl.textContent = "Mermaid 라이브러리를 불러오지 못했습니다.";
+    errorMsgEl.textContent = "Mermaid 라이브러리를 불러오지 못했습니다.";
     errorEl.hidden = false;
-    previewEl.hidden = true;
+    mediaWrapEl.hidden = true;
+    actionsEl.hidden = true;
     return;
   }
 
   const trimmed = source.trim();
   if (!trimmed) {
     previewEl.innerHTML = "";
-    previewEl.hidden = true;
+    mediaWrapEl.hidden = true;
+    actionsEl.hidden = true;
     errorEl.hidden = true;
     return;
   }
@@ -173,18 +193,171 @@ async function renderMermaid(blockId, source, previewEl, errorEl, isCancelled = 
       svgEl.style.maxWidth = "";
     }
 
-    previewEl.hidden = false;
+    mediaWrapEl.hidden = false;
+    actionsEl.hidden = false; // CSS hover가 opacity 제어 — hidden 해제로 상호작용 허용
     errorEl.hidden = true;
   } catch (err) {
     if (isCancelled()) return;
     // mermaid.render()는 문법 오류 시 Error 객체 또는 문자열을 throw할 수 있다.
     // err?.message || err 순서로 평가해 두 경우를 모두 커버한다.
     previewEl.innerHTML = "";
-    previewEl.hidden = true;
-    errorEl.textContent = "Mermaid 문법 오류: " + (err?.message || err || "알 수 없는 오류");
+    mediaWrapEl.hidden = true;
+    actionsEl.hidden = true;
+    errorMsgEl.textContent = "Mermaid 문법 오류: " + (err?.message || err || "알 수 없는 오류");
     errorEl.hidden = false;
   }
 }
+
+// ── Mermaid 크게 보기 (라이트박스) ───────────────────────────────────────────
+
+/**
+ * 현재 렌더된 SVG를 전체화면 오버레이에서 표시한다.
+ *
+ * 이미지 블록의 openLightbox 와 동일한 접근성 패턴을 따른다.
+ *   - role="dialog" + aria-modal="true" 로 스크린리더에 모달임을 알림
+ *   - 열릴 때 닫기 버튼으로 포커스 이동 (WCAG 2.4.3)
+ *   - ESC 키 및 배경 클릭으로 닫기
+ *   - 포커스 트랩 (ARIA Authoring Practices Guide — Modal Dialog Pattern)
+ *   - 닫힐 때 트리거 요소로 포커스 복원
+ *
+ * Ref: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+ *
+ * @param {HTMLElement} previewEl - 미리보기 컨테이너 (SVG 포함)
+ */
+function openMermaidLightbox(previewEl) {
+  const svgEl = previewEl.querySelector("svg");
+  if (!svgEl) return; // 렌더된 SVG가 없으면 라이트박스를 열지 않는다.
+
+  // 닫힌 후 포커스를 복원할 트리거 요소를 미리 저장 (WCAG 2.4.3)
+  const previousFocus = document.activeElement;
+
+  // 이미지 라이트박스와 동일한 overlay/close 스타일 재사용
+  const overlay = document.createElement("div");
+  overlay.className = "image-lightbox-overlay";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-label", "다이어그램 크게 보기");
+
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "image-lightbox-close";
+  closeBtn.setAttribute("aria-label", "닫기");
+  closeBtn.textContent = "✕";
+
+  // SVG를 복제해 라이트박스 내 독립적인 뷰어에 삽입
+  const svgWrap = document.createElement("div");
+  svgWrap.className = "mermaid-lightbox-svg";
+  const svgClone = svgEl.cloneNode(true);
+  // 라이트박스에서도 Mermaid 고정 크기 속성 제거
+  svgClone.removeAttribute("width");
+  svgClone.removeAttribute("height");
+  svgClone.style.maxWidth = "";
+  svgWrap.appendChild(svgClone);
+
+  overlay.append(closeBtn, svgWrap);
+  document.body.append(overlay);
+  document.body.classList.add("lightbox-open");
+
+  // 열릴 때 포커스를 닫기 버튼으로 이동
+  closeBtn.focus();
+
+  function close() {
+    overlay.remove();
+    document.body.classList.remove("lightbox-open");
+    document.removeEventListener("keydown", onKeyDown);
+    // 닫힌 후 트리거 요소로 포커스 복원 (WCAG 2.4.3 Focus Order)
+    previousFocus?.focus();
+  }
+
+  // 포커스 트랩 — overlay 내 포커스 가능 요소 목록을 Tab/Shift+Tab으로 순환
+  // (ARIA Authoring Practices Guide — Modal Dialog Pattern)
+  function onKeyDown(e) {
+    if (e.key === "Escape") {
+      close();
+      return;
+    }
+
+    if (e.key === "Tab") {
+      const focusable = [
+        ...overlay.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ].filter((el) => !el.disabled);
+
+      if (focusable.length === 0) { e.preventDefault(); return; }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+  }
+
+  closeBtn.addEventListener("click", close);
+  // 오버레이 배경(SVG 외부) 클릭 시 닫기
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener("keydown", onKeyDown);
+}
+
+// ── Mermaid SVG 다운로드 ──────────────────────────────────────────────────────
+
+/**
+ * 현재 렌더된 SVG를 .svg 파일로 다운로드한다.
+ *
+ * 파일명: mermaid-diagram-<타임스탬프>.svg
+ * 다운로드 실패 시 버튼 텍스트로 오류 안내를 제공한 뒤 원래 상태로 복원한다.
+ *
+ * Ref:
+ *   - XMLSerializer: https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer
+ *   - URL.createObjectURL: https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
+ *
+ * @param {HTMLElement} previewEl   - 미리보기 컨테이너 (SVG 포함)
+ * @param {HTMLButtonElement} downloadBtn - 다운로드 버튼 (피드백 표시용)
+ */
+function downloadMermaidSvg(previewEl, downloadBtn) {
+  const svgEl = previewEl.querySelector("svg");
+  if (!svgEl) return;
+
+  try {
+    // SVG 직렬화 시 xmlns 선언이 누락되면 일부 뷰어에서 렌더링 불가.
+    // cloneNode 후 속성을 추가해 원본 DOM에 영향을 주지 않는다.
+    const svgCopy = svgEl.cloneNode(true);
+    if (!svgCopy.getAttribute("xmlns")) {
+      svgCopy.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    }
+    const svgStr = new XMLSerializer().serializeToString(svgCopy);
+    const blob = new Blob([svgStr], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `mermaid-diagram-${Date.now()}.svg`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    console.error("SVG 다운로드 실패:", err);
+    // 다운로드 실패 시 버튼 텍스트로 사용자에게 안내
+    const original = downloadBtn.textContent;
+    downloadBtn.textContent = "다운로드 실패";
+    setTimeout(() => { downloadBtn.textContent = original; }, 2000);
+  }
+}
+
+// ── Block create ─────────────────────────────────────────────────────────────
 
 /**
  * @param {object} block
@@ -193,11 +366,21 @@ async function renderMermaid(blockId, source, previewEl, errorEl, isCancelled = 
 export function create(block) {
   const template = document.getElementById("code-block-template");
   const node = template.content.firstElementChild.cloneNode(true);
+
   const select = node.querySelector(".code-language-select");
   const codeEl = node.querySelector(".code-content");
   const copyBtn = node.querySelector(".code-copy-btn");
+
+  // ── Mermaid 전용 패널 요소 ────────────────────────────────────────────────
+  const panelEl = node.querySelector(".mermaid-panel");
+  const mediaWrapEl = node.querySelector(".mermaid-media-wrap");
   const previewEl = node.querySelector(".mermaid-preview");
+  const actionsEl = node.querySelector(".mermaid-actions");
+  const viewBtn = node.querySelector(".mermaid-view-btn");
+  const downloadBtn = node.querySelector(".mermaid-download-btn");
   const errorEl = node.querySelector(".mermaid-error");
+  const errorMsgEl = node.querySelector(".mermaid-error-msg");
+  const retryBtn = node.querySelector(".mermaid-retry-btn");
 
   let currentLanguage = block.language || "plain";
   let plainCode = block.code || "";
@@ -215,17 +398,36 @@ export function create(block) {
     select.appendChild(opt);
   });
 
+  // ── renderMermaid opts 빌더 ───────────────────────────────────────────────
+  // 매 호출마다 동일한 opts 구조를 생성하는 헬퍼로 코드 중복을 줄인다.
+  function buildRenderOpts(gen) {
+    return {
+      previewEl,
+      errorEl,
+      errorMsgEl,
+      mediaWrapEl,
+      actionsEl,
+      isCancelled: () => _renderGen !== gen,
+    };
+  }
+
   // ── Mermaid 모드 전환 ─────────────────────────────────────────────────────
   // isMermaid === true 일 때: 코드 에디터(소스 편집) + 미리보기 패널을 함께 표시한다.
 
   function applyMermaidMode(isMermaid) {
     node.classList.toggle("is-mermaid", isMermaid);
+    panelEl.hidden = !isMermaid;
+
     if (isMermaid) {
       const gen = ++_renderGen;
-      renderMermaid(block.id, plainCode, previewEl, errorEl, () => _renderGen !== gen);
+      renderMermaid(block.id, plainCode, buildRenderOpts(gen));
     } else {
       ++_renderGen; // 진행 중인 렌더 취소
-      previewEl.hidden = true;
+      // 패널 자체가 hidden 이므로 내부 상태는 재진입 시 renderMermaid 가 덮어쓴다.
+      // 그러나 명시적으로 초기화해 DOM을 일관된 상태로 유지한다.
+      previewEl.innerHTML = "";
+      mediaWrapEl.hidden = true;
+      actionsEl.hidden = true;
       errorEl.hidden = true;
     }
   }
@@ -304,7 +506,7 @@ export function create(block) {
     // blur 시점에 mermaid 미리보기를 갱신한다
     if (currentLanguage === "mermaid") {
       const gen = ++_renderGen;
-      renderMermaid(block.id, plainCode, previewEl, errorEl, () => _renderGen !== gen);
+      renderMermaid(block.id, plainCode, buildRenderOpts(gen));
     }
   });
 
@@ -330,11 +532,31 @@ export function create(block) {
     }
   });
 
+  // ── 복사 버튼 ────────────────────────────────────────────────────────────
   copyBtn.addEventListener("click", () => {
     navigator.clipboard.writeText(plainCode).then(() => {
       copyBtn.textContent = "복사됨";
       setTimeout(() => { copyBtn.textContent = "복사"; }, 1500);
     }).catch(console.error);
+  });
+
+  // ── 크게 보기 버튼 ───────────────────────────────────────────────────────
+  viewBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    openMermaidLightbox(previewEl);
+  });
+
+  // ── 다운로드 버튼 ────────────────────────────────────────────────────────
+  downloadBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    downloadMermaidSvg(previewEl, downloadBtn);
+  });
+
+  // ── 재시도 버튼 ──────────────────────────────────────────────────────────
+  // 렌더 실패 시 표시되는 "재시도" 버튼 — 현재 소스 코드로 renderMermaid 를 재호출한다.
+  retryBtn.addEventListener("click", () => {
+    const gen = ++_renderGen;
+    renderMermaid(block.id, plainCode, buildRenderOpts(gen));
   });
 
   return node;

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -82,8 +82,30 @@
     </div>
     <pre class="code-body"><code class="code-content" spellcheck="false"></code></pre>
     <!-- Mermaid 전용 패널: language=mermaid 일 때만 표시 -->
-    <div class="mermaid-preview" hidden aria-label="Mermaid 다이어그램 미리보기"></div>
-    <div class="mermaid-error" hidden role="alert" aria-live="polite"></div>
+    <div class="mermaid-panel" hidden>
+      <!-- 미리보기 래퍼: 액션 overlay의 position 기준점 -->
+      <div class="mermaid-media-wrap" hidden>
+        <div class="mermaid-preview" aria-label="Mermaid 다이어그램 미리보기"></div>
+        <!-- 렌더 성공 시 프리뷰 우상단에 표시되는 액션 버튼 -->
+        <div class="mermaid-actions" aria-label="다이어그램 액션" hidden>
+          <button
+            type="button"
+            class="image-action-btn mermaid-view-btn"
+            aria-label="크게 보기"
+          >크게 보기</button>
+          <button
+            type="button"
+            class="image-action-btn mermaid-download-btn"
+            aria-label="다운로드"
+          >다운로드</button>
+        </div>
+      </div>
+      <!-- 렌더 실패 시 표시: 오류 메시지 + 재시도 버튼 -->
+      <div class="mermaid-error" role="alert" aria-live="polite" hidden>
+        <span class="mermaid-error-msg"></span>
+        <button type="button" class="mermaid-retry-btn">재시도</button>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/tests/test_mermaid_diagram_preview.py
+++ b/tests/test_mermaid_diagram_preview.py
@@ -10,8 +10,6 @@ Python 단위 테스트에서는 해당 데이터를 올바르게 저장·제공
 """
 from __future__ import annotations
 
-import pytest
-
 
 # ── Mermaid 다이어그램 예시 ────────────────────────────────────────────────────
 

--- a/tests/test_mermaid_diagram_preview.py
+++ b/tests/test_mermaid_diagram_preview.py
@@ -1,0 +1,305 @@
+"""Mermaid 다이어그램 미리보기 기능 단위 테스트 (이슈 #60).
+
+이슈 #60 에서 추가된 기능의 백엔드 검증 범위:
+  1. Model 레이어   — 다양한 Mermaid 다이어그램 타입의 CodeBlock 모델 검증
+  2. Repository 레이어 — 복잡한 다이어그램 코드의 저장/조회 왕복(round-trip) 검증
+  3. API 레이어    — 미리보기에 필요한 응답 필드 구조 및 엣지 케이스 검증
+
+프론트엔드(SVG 렌더링·크게 보기·다운로드)는 브라우저 환경에서만 실행 가능하므로
+Python 단위 테스트에서는 해당 데이터를 올바르게 저장·제공하는 서버 측 동작을 검증한다.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Mermaid 다이어그램 예시 ────────────────────────────────────────────────────
+
+# 실제 서비스에서 자주 사용되는 대표 다이어그램 타입별 예시 소스
+FLOWCHART_SRC = "graph TD\n  A[시작] --> B{조건}\n  B -- 예 --> C[처리]\n  B -- 아니오 --> D[종료]"
+SEQUENCE_SRC = (
+  "sequenceDiagram\n"
+  "  participant 사용자\n"
+  "  participant 서버\n"
+  "  사용자->>서버: 로그인 요청\n"
+  "  서버-->>사용자: 토큰 발급"
+)
+ER_SRC = (
+  "erDiagram\n"
+  "  USER ||--o{ ORDER : places\n"
+  "  ORDER ||--|{ LINE-ITEM : contains\n"
+  "  PRODUCT }|..|{ LINE-ITEM : includes"
+)
+CLASS_SRC = (
+  "classDiagram\n"
+  "  class Animal {\n"
+  "    +String name\n"
+  "    +move()\n"
+  "  }\n"
+  "  class Dog {\n"
+  "    +bark()\n"
+  "  }\n"
+  "  Animal <|-- Dog"
+)
+GANTT_SRC = (
+  "gantt\n"
+  "  title 프로젝트 일정\n"
+  "  section 기획\n"
+  "    요구사항 분석: a1, 2024-01-01, 7d\n"
+  "  section 개발\n"
+  "    기능 구현: a2, after a1, 14d"
+)
+# 특수 문자 및 다국어 레이블 포함 다이어그램 — 직렬화 안전성 검증용
+SPECIAL_CHAR_SRC = (
+  "graph LR\n"
+  '  A["사용자 <입력>"] --> B["API & 서버"]\n'
+  '  B --> C["DB (SQLite)"]\n'
+  "  C --> B"
+)
+
+
+# ── 1. Model 레이어 ───────────────────────────────────────────────────────────
+
+class TestMermaidDiagramModel:
+  """CodeBlock 모델이 다양한 Mermaid 다이어그램 타입의 소스를 올바르게 수락하는지 검증."""
+
+  def _make(self, code: str) -> object:
+    from app.models.blocks import CodeBlock
+    return CodeBlock(id="test-id", type="code", code=code, language="mermaid")
+
+  def test_flowchart_diagram_accepted(self):
+    """flowchart(graph TD) 타입 다이어그램 소스를 저장할 수 있다."""
+    block = self._make(FLOWCHART_SRC)
+    assert block.language == "mermaid"
+    assert block.code == FLOWCHART_SRC
+
+  def test_sequence_diagram_accepted(self):
+    """sequenceDiagram 타입 다이어그램 소스를 저장할 수 있다."""
+    block = self._make(SEQUENCE_SRC)
+    assert block.code == SEQUENCE_SRC
+
+  def test_er_diagram_accepted(self):
+    """erDiagram 타입 다이어그램 소스를 저장할 수 있다."""
+    block = self._make(ER_SRC)
+    assert block.code == ER_SRC
+
+  def test_class_diagram_accepted(self):
+    """classDiagram 타입 다이어그램 소스를 저장할 수 있다."""
+    block = self._make(CLASS_SRC)
+    assert block.code == CLASS_SRC
+
+  def test_gantt_diagram_accepted(self):
+    """gantt 타입 다이어그램 소스를 저장할 수 있다."""
+    block = self._make(GANTT_SRC)
+    assert block.code == GANTT_SRC
+
+  def test_empty_diagram_source_accepted(self):
+    """빈 문자열 소스도 허용된다 (프론트엔드가 빈 상태를 처리한다)."""
+    block = self._make("")
+    assert block.code == ""
+
+  def test_special_characters_preserved(self):
+    """꺾쇠·앰퍼샌드·괄호 등 특수 문자가 포함된 소스가 그대로 저장된다."""
+    block = self._make(SPECIAL_CHAR_SRC)
+    assert block.code == SPECIAL_CHAR_SRC
+
+  def test_multiline_source_preserved(self):
+    """개행 문자가 포함된 다중 행 소스가 손상 없이 저장된다."""
+    multiline = "graph TD\n  A --> B\n  B --> C\n  C --> D"
+    block = self._make(multiline)
+    assert "\n" in block.code
+    assert block.code == multiline
+
+
+# ── 2. Repository 레이어 ──────────────────────────────────────────────────────
+
+class TestMermaidDiagramRepository:
+  """SQLiteBlockRepository 에서 Mermaid 다이어그램 데이터의 CRUD 를 검증."""
+
+  def _create_mermaid_block(self, repo, code: str = FLOWCHART_SRC) -> tuple[dict, dict]:
+    """테스트용 문서와 mermaid 코드 블록을 생성해 반환하는 헬퍼."""
+    doc = repo.create_document()
+    block = repo.create_block(doc["id"], "code")
+    repo.update_block(block["id"], {"language": "mermaid", "code": code})
+    return doc, block
+
+  def test_flowchart_survives_roundtrip(self, repo):
+    """flowchart 다이어그램 소스가 저장·조회 왕복 후 동일하게 반환된다."""
+    doc, block = self._create_mermaid_block(repo, FLOWCHART_SRC)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == FLOWCHART_SRC
+
+  def test_sequence_diagram_survives_roundtrip(self, repo):
+    """sequenceDiagram 소스가 저장·조회 왕복 후 동일하게 반환된다."""
+    doc, block = self._create_mermaid_block(repo, SEQUENCE_SRC)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == SEQUENCE_SRC
+
+  def test_er_diagram_survives_roundtrip(self, repo):
+    """erDiagram 소스가 저장·조회 왕복 후 동일하게 반환된다."""
+    doc, block = self._create_mermaid_block(repo, ER_SRC)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == ER_SRC
+
+  def test_special_characters_survive_roundtrip(self, repo):
+    """특수 문자가 포함된 소스가 SQLite 저장 후에도 그대로 복원된다."""
+    doc, block = self._create_mermaid_block(repo, SPECIAL_CHAR_SRC)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == SPECIAL_CHAR_SRC
+
+  def test_large_diagram_survives_roundtrip(self, repo):
+    """노드 수가 많은 대형 다이어그램 소스가 손실 없이 저장·복원된다."""
+    nodes = "\n".join(f"  N{i} --> N{i + 1}" for i in range(100))
+    large_src = f"graph TD\n{nodes}"
+    doc, block = self._create_mermaid_block(repo, large_src)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == large_src
+
+  def test_empty_diagram_source_survives_roundtrip(self, repo):
+    """빈 소스("")가 저장·조회 후에도 빈 문자열로 반환된다."""
+    doc, block = self._create_mermaid_block(repo, "")
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == ""
+    assert fetched.blocks[0].language == "mermaid"
+
+  def test_update_diagram_source_reflected(self, repo):
+    """다이어그램 소스를 수정하면 변경 내용이 즉시 조회에 반영된다."""
+    doc, block = self._create_mermaid_block(repo, FLOWCHART_SRC)
+    repo.update_block(block["id"], {"code": SEQUENCE_SRC})
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].code == SEQUENCE_SRC
+
+  def test_switch_diagram_type_via_code_update(self, repo):
+    """소스 코드만 변경해 다이어그램 타입을 전환할 수 있다 (language 는 mermaid 유지)."""
+    doc, block = self._create_mermaid_block(repo, FLOWCHART_SRC)
+    repo.update_block(block["id"], {"code": ER_SRC})
+    fetched = repo.get_document(doc["id"])
+    b = fetched.blocks[0]
+    # language 는 그대로 mermaid
+    assert b.language == "mermaid"
+    # code 는 ER 다이어그램으로 교체됨
+    assert b.code == ER_SRC
+
+  def test_multiple_mermaid_blocks_coexist(self, repo):
+    """같은 문서에 여러 mermaid 블록이 각자 다른 소스로 공존할 수 있다."""
+    doc = repo.create_document()
+    b1 = repo.create_block(doc["id"], "code")
+    b2 = repo.create_block(doc["id"], "code")
+    repo.update_block(b1["id"], {"language": "mermaid", "code": FLOWCHART_SRC})
+    repo.update_block(b2["id"], {"language": "mermaid", "code": SEQUENCE_SRC})
+
+    fetched = repo.get_document(doc["id"])
+    codes = {b.code for b in fetched.blocks}
+    assert FLOWCHART_SRC in codes
+    assert SEQUENCE_SRC in codes
+
+  def test_language_field_is_mermaid_after_update(self, repo):
+    """update_block 호출 후 language 필드가 "mermaid" 로 유지된다."""
+    doc, block = self._create_mermaid_block(repo, FLOWCHART_SRC)
+    fetched = repo.get_document(doc["id"])
+    assert fetched.blocks[0].language == "mermaid"
+
+
+# ── 3. API 레이어 ─────────────────────────────────────────────────────────────
+
+class TestMermaidDiagramAPI:
+  """HTTP API 를 통한 Mermaid 다이어그램 데이터의 저장·조회를 검증."""
+
+  def _setup(self, client) -> tuple[dict, dict]:
+    """mermaid 코드 블록이 있는 문서를 생성해 반환하는 헬퍼."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "mermaid"})
+    return doc, block
+
+  def test_get_document_includes_language_field(self, client):
+    """GET /api/documents/{id} 응답 블록에 language 필드가 포함된다."""
+    doc, _ = self._setup(client)
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert "language" in fetched["blocks"][0]
+
+  def test_get_document_includes_code_field(self, client):
+    """GET /api/documents/{id} 응답 블록에 code 필드가 포함된다."""
+    doc, _ = self._setup(client)
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert "code" in fetched["blocks"][0]
+
+  def test_patch_diagram_source_flowchart(self, client):
+    """PATCH /api/blocks/{id} 로 flowchart 소스를 저장하면 200을 반환한다."""
+    doc, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"code": FLOWCHART_SRC})
+    assert resp.status_code == 200
+
+  def test_patch_diagram_source_sequence(self, client):
+    """PATCH /api/blocks/{id} 로 sequenceDiagram 소스를 저장하면 200을 반환한다."""
+    doc, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"code": SEQUENCE_SRC})
+    assert resp.status_code == 200
+
+  def test_patch_diagram_source_er(self, client):
+    """PATCH /api/blocks/{id} 로 erDiagram 소스를 저장하면 200을 반환한다."""
+    doc, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"code": ER_SRC})
+    assert resp.status_code == 200
+
+  def test_diagram_source_reflected_in_get(self, client):
+    """저장된 다이어그램 소스가 GET 응답에서 동일하게 반환된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}", json={"code": FLOWCHART_SRC})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["code"] == FLOWCHART_SRC
+
+  def test_special_characters_survive_api_roundtrip(self, client):
+    """특수 문자가 포함된 소스가 API 왕복 후 손상 없이 반환된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}", json={"code": SPECIAL_CHAR_SRC})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["code"] == SPECIAL_CHAR_SRC
+
+  def test_multiline_diagram_survives_api_roundtrip(self, client):
+    """개행 문자가 포함된 다중 행 소스가 API 왕복 후 동일하게 반환된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}", json={"code": SEQUENCE_SRC})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    # 개행 문자가 보존되었는지 확인
+    assert "\n" in fetched["blocks"][0]["code"]
+    assert fetched["blocks"][0]["code"] == SEQUENCE_SRC
+
+  def test_language_remains_mermaid_after_code_update(self, client):
+    """code 만 업데이트해도 language 가 "mermaid" 로 유지된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}", json={"code": ER_SRC})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["language"] == "mermaid"
+
+  def test_update_diagram_source_sequential(self, client):
+    """소스를 두 번 연속으로 업데이트하면 마지막 값이 반영된다."""
+    doc, block = self._setup(client)
+    client.patch(f"/api/blocks/{block['id']}", json={"code": FLOWCHART_SRC})
+    client.patch(f"/api/blocks/{block['id']}", json={"code": CLASS_SRC})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["code"] == CLASS_SRC
+
+  def test_empty_code_accepted_by_api(self, client):
+    """빈 code 값("")을 PATCH 해도 200을 반환하고 빈 문자열로 저장된다."""
+    doc, block = self._setup(client)
+    resp = client.patch(f"/api/blocks/{block['id']}", json={"code": ""})
+    assert resp.status_code == 200
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    assert fetched["blocks"][0]["code"] == ""
+
+  def test_existing_python_block_unaffected(self, client):
+    """mermaid 기능 추가 후에도 Python 언어 코드 블록이 정상 동작한다."""
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "code"},
+    ).json()
+    client.patch(f"/api/blocks/{block['id']}", json={"language": "python", "code": "print('hello')"})
+    fetched = client.get(f"/api/documents/{doc['id']}").json()
+    b = fetched["blocks"][0]
+    assert b["language"] == "python"
+    assert b["code"] == "print('hello')"


### PR DESCRIPTION
Closes #60

## Summary

- 배경: Mermaid 코드 블록이 소스 텍스트만 표시하고 있어 다이어그램을 즉시 확인하기 어려웠고, 이미지 블록과 달리 크게 보기·다운로드 같은 액션이 제공되지 않았다.
- 목적: Mermaid 프리뷰에 이미지 블록과 동일한 UI 패턴(크게 보기·다운로드·재시도)을 적용해 시각적 일관성을 확보하고 다이어그램 활용성을 높인다.

## Changes

- **`templates/partials/block_templates.html`**
  - `mermaid-preview` 단독 구조 → `mermaid-panel` 래퍼 내 `mermaid-media-wrap` + 액션 overlay 구조로 재설계
  - 프리뷰 우상단에 **크게 보기** / **다운로드** 버튼 추가 (이미지 블록과 동일한 `image-action-btn` 클래스 공유)
  - `mermaid-error` 내부에 오류 메시지 `<span>` 과 **재시도** 버튼 분리
- **`static/css/style.css`**
  - `mermaid-media-wrap` — `position: relative` 기반 액션 overlay 기준점
  - `mermaid-actions` — hover/focus-within 시 `opacity: 1` 노출 (이미지 블록 패턴 동일)
  - `mermaid-error` — `display: flex` 로 오류 메시지와 재시도 버튼 가로 배치
  - `mermaid-retry-btn` — 오류 영역 인라인 재시도 버튼 스타일
  - `mermaid-lightbox-svg` — 라이트박스 내 SVG 컨테이너 (흰 배경·overflow auto)
- **`static/js/blocks/codeBlock.js`**
  - `renderMermaid()` 시그니처를 opts 객체로 변경 — `mediaWrapEl`, `actionsEl`, `errorMsgEl` 포함
  - `openMermaidLightbox(previewEl)` 구현 — 이미지 라이트박스와 동일한 접근성 패턴 (포커스 트랩·ESC·배경 클릭·포커스 복원, WCAG 2.4.3)
  - `downloadMermaidSvg(previewEl, downloadBtn)` 구현 — SVG 직렬화 후 Blob 다운로드, 실패 시 버튼 텍스트로 사용자 피드백
  - 재시도 버튼 핸들러 — `retryBtn.click` 시 `renderMermaid` 재호출
  - `applyMermaidMode()` — `panelEl.hidden` 단일 제어로 통합, 내부 상태 초기화 추가
- **`tests/test_mermaid_diagram_preview.py`** (신규)
  - Model·Repository·API 3계층 단위 테스트 30개 추가

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`/`, `/api/projects`)
- [ ] 브라우저 콘솔 에러 없음
- [x] `tests/test_mermaid_diagram_preview.py` — 30개 통과
- [x] 전체 테스트 스위트 278개 통과, 회귀 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영

## Review Points

- `renderMermaid()` opts 객체 전환으로 기존 모든 호출부(`applyMermaidMode`, `blur` 핸들러)가 변경됨 — 시그니처 일관성 확인 요청
- 이미지 라이트박스 CSS(`.image-lightbox-overlay`, `.image-lightbox-close`)를 Mermaid 라이트박스가 의도적으로 재사용 — 스타일 공유 범위 적절한지 확인 요청