### PR TITLE
[FEAT#63] 파일 업로드 및 업로드 파일 다운로드 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ wheels/
 # data
 data/
 uploads/
+static/files/

--- a/app/models/blocks.py
+++ b/app/models/blocks.py
@@ -98,6 +98,21 @@ class UrlEmbedBlock(BlockBase):
   status: Literal["pending", "success", "error"] = "pending"
 
 
+class FileBlock(BlockBase):
+  """첨부 파일 블록 — 업로드된 파일을 문서에 첨부합니다.
+
+  file_id는 files 테이블의 FileRow.id를 참조합니다.
+  original_filename·size_bytes·mime_type은 조회 시점에 FileRow에서 채워집니다.
+  """
+
+  type: Literal["file"]
+  file_id: str = ""            # files 테이블의 row id
+  original_filename: str = ""  # 표시용 파일명 (query-time 채움)
+  size_bytes: int = 0          # 파일 크기 bytes (query-time 채움)
+  mime_type: str = ""          # MIME type (query-time 채움)
+  download_url: str = ""       # /api/files/{file_id} (query-time 채움)
+
+
 class PageBlock(BlockBase):
   """Block that links to another BlockDocument, enabling recursive page nesting."""
 
@@ -144,6 +159,7 @@ class DatabaseBlock(BlockBase):
 Block = Annotated[
   TextBlock
   | ImageBlock
+  | FileBlock
   | ToggleBlock
   | QuoteBlock
   | CodeBlock

--- a/app/models/orm.py
+++ b/app/models/orm.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import ForeignKey, Index, Integer, String, Text
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -42,4 +42,28 @@ class BlockRow(Base):
 
   __table_args__ = (
     Index("idx_blocks_document_parent_pos", "document_id", "parent_block_id", "position"),
+  )
+
+
+class FileRow(Base):
+  """업로드된 파일의 메타데이터를 저장하는 테이블.
+
+  실제 파일 바이트는 static/files/<stored_filename> 경로에 저장됩니다.
+  stored_filename은 UUID 기반이므로 경로 순회(path traversal) 위험이 없습니다.
+  """
+
+  __tablename__ = "files"
+
+  id: Mapped[str] = mapped_column(String, primary_key=True)
+  # 클라이언트가 전송한 원본 파일명 (정규화·sanitize 완료)
+  original_filename: Mapped[str] = mapped_column(String, nullable=False)
+  # 디스크에 저장된 UUID 기반 파일명 (확장자 없음)
+  stored_filename: Mapped[str] = mapped_column(String, nullable=False)
+  mime_type: Mapped[str] = mapped_column(String, nullable=False)
+  size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+  # ISO-8601 UTC 타임스탬프
+  created_at: Mapped[str] = mapped_column(String, nullable=False)
+
+  __table_args__ = (
+    UniqueConstraint("stored_filename", name="uq_files_stored_filename"),
   )

--- a/app/repositories/file_repo.py
+++ b/app/repositories/file_repo.py
@@ -1,0 +1,88 @@
+"""파일 메타데이터 저장소.
+
+파일 업로드·다운로드·삭제에 필요한 메타데이터를 SQLite에 저장·조회합니다.
+실제 파일 바이트 처리는 app.services.file 에서 담당합니다.
+
+참고:
+  - SQLAlchemy 2.x Mapped Column API:
+    https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.orm import FileRow
+
+
+class SQLiteFileRepository:
+  """FileRow 엔티티에 대한 CRUD 저장소."""
+
+  def __init__(self, session: Session) -> None:
+    self._session = session
+
+  def create_file(
+    self,
+    *,
+    original_filename: str,
+    stored_filename: str,
+    mime_type: str,
+    size_bytes: int,
+  ) -> FileRow:
+    """파일 메타데이터를 DB에 저장하고 생성된 FileRow를 반환합니다.
+
+    Args:
+      original_filename: sanitize 완료된 원본 파일명.
+      stored_filename: 디스크에 저장된 UUID 기반 파일명.
+      mime_type: 업로드 시 전달된 MIME type.
+      size_bytes: 파일 크기 (bytes).
+
+    Returns:
+      INSERT 후 refresh된 FileRow 인스턴스.
+    """
+    row = FileRow(
+      id=uuid.uuid4().hex,
+      original_filename=original_filename,
+      stored_filename=stored_filename,
+      mime_type=mime_type,
+      size_bytes=size_bytes,
+      created_at=datetime.now(timezone.utc).isoformat(),
+    )
+    self._session.add(row)
+    self._session.commit()
+    self._session.refresh(row)
+    return row
+
+  def get_file(self, file_id: str) -> FileRow | None:
+    """file_id로 파일 메타데이터를 조회합니다.
+
+    Returns:
+      FileRow 인스턴스, 없으면 None.
+    """
+    return self._session.get(FileRow, file_id)
+
+  def list_files(self) -> list[FileRow]:
+    """모든 파일 메타데이터를 생성 시각 역순으로 반환합니다."""
+    return list(
+      self._session.execute(
+        select(FileRow).order_by(FileRow.created_at.desc())
+      ).scalars().all()
+    )
+
+  def delete_file(self, file_id: str) -> FileRow | None:
+    """파일 메타데이터를 DB에서 삭제하고 삭제된 row를 반환합니다.
+
+    반환된 row의 stored_filename으로 호출 측에서 디스크 파일을 제거해야 합니다.
+
+    Returns:
+      삭제된 FileRow (디스크 파일 삭제 정보 제공용), 없으면 None.
+    """
+    row = self._session.get(FileRow, file_id)
+    if row is None:
+      return None
+    self._session.delete(row)
+    self._session.commit()
+    return row

--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -17,11 +17,12 @@ from app.models.blocks import (
   DbContext,
   DbRowBlock,
   DividerBlock,
+  FileBlock,
   PageBlock,
   QuoteBlock,
   ToggleBlock,
 )
-from app.models.orm import BlockRow, DocumentRow
+from app.models.orm import BlockRow, DocumentRow, FileRow
 
 
 # Block types that act as containers: auto-create one child text block on creation
@@ -155,6 +156,27 @@ class SQLiteBlockRepository:
       ).all()
       doc_titles = {row.id: row.title for row in title_rows}
 
+    # file 블록 메타데이터 일괄 조회 — query-time 주입으로 FileBlock 필드를 채운다
+    file_ids = list({
+      item["file_id"]
+      for item in parsed_blocks
+      if item["type"] == "file" and item.get("file_id")
+    })
+    file_meta: dict[str, dict[str, Any]] = {}
+    if file_ids:
+      file_rows = self._session.execute(
+        select(FileRow).where(FileRow.id.in_(file_ids))
+      ).scalars().all()
+      file_meta = {
+        r.id: {
+          "original_filename": r.original_filename,
+          "size_bytes": r.size_bytes,
+          "mime_type": r.mime_type,
+          "download_url": f"/api/files/{r.id}",
+        }
+        for r in file_rows
+      }
+
     children_by_parent: dict[str | None, list[dict[str, Any]]] = {}
     for item in parsed_blocks:
       children_by_parent.setdefault(item["parent_block_id"], []).append(item)
@@ -193,6 +215,11 @@ class SQLiteBlockRepository:
           # db_row는 database 블록 내부에서만 등장 (build_database_block 처리)
           # 최상위에 고아로 있는 경우 무시
           pass
+        elif item["type"] == "file":
+          # file_id가 있는 경우 FileRow에서 조회한 메타데이터를 병합한다
+          fid = item.get("file_id", "")
+          meta = file_meta.get(fid, {}) if fid else {}
+          nodes.append(FileBlock.model_validate({**item, **meta}))
         else:
           nodes.append(self._block_adapter.validate_python(item))
       return nodes
@@ -494,6 +521,8 @@ class SQLiteBlockRepository:
             "fetched_at": "",
             "status": "pending",
           }
+        case "file":
+          default_content = {"file_id": ""}
         case _:
           return None
 
@@ -666,6 +695,8 @@ class SQLiteBlockRepository:
           "fetched_at": "",
           "status": "pending",
         }
+      case "file":
+        default_content = {"file_id": ""}
       case _:
         return False
 

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -27,6 +27,8 @@ class BlockPatch(BaseModel):
   # callout (color은 callout 지원 색상만 허용)
   emoji: str | None = None
   color: Literal["yellow", "blue", "green", "red", "gray"] | None = None
+  # file
+  file_id: str | None = None
 
 
 class DatabaseBlockPatch(BaseModel):
@@ -39,7 +41,7 @@ class BlockPositionPatch(BaseModel):
 
 
 class BlockTypeChange(BaseModel):
-  type: Literal["text", "image", "toggle", "quote", "code", "callout", "divider", "url_embed"]
+  type: Literal["text", "image", "file", "toggle", "quote", "code", "callout", "divider", "url_embed"]
 
 
 @router.patch("/{block_id}")

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -106,7 +106,7 @@ async def upload_file(
   data = b"".join(chunks)
 
   # 디스크 저장 (UUID 기반 파일명, 원본명은 sanitize)
-  result = save_file(data, original_name, file.content_type or "application/octet-stream")
+  result = save_file(data, original_name)
 
   # 메타데이터를 DB에 저장
   row = repo.create_file(

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -1,0 +1,182 @@
+"""범용 파일 업로드·다운로드·삭제 라우터.
+
+엔드포인트:
+  POST   /api/files              — 파일 업로드 (허용 확장자 검증, 50 MB 제한)
+  GET    /api/files/{file_id}    — 파일 다운로드 (원본 파일명 Content-Disposition 보장)
+  GET    /api/files              — 업로드된 파일 목록 조회
+  DELETE /api/files/{file_id}    — DB 메타데이터 + 디스크 파일 삭제
+
+보안:
+  - ALLOWED_EXTENSIONS 화이트리스트 검증 (실행 파일 차단)
+  - UUID 저장명으로 경로 순회 방지
+  - Content-Disposition RFC 5987 인코딩으로 한글 파일명 다운로드 보장
+
+참고:
+  - FastAPI File Upload: https://fastapi.tiangolo.com/tutorial/request-files/
+  - RFC 5987 (filename* 인코딩): https://datatracker.ietf.org/doc/html/rfc5987
+  - Content-Disposition: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+"""
+from __future__ import annotations
+
+import urllib.parse
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_session
+from app.repositories.file_repo import SQLiteFileRepository
+from app.services.file import (
+  MAX_BYTES,
+  delete_stored_file,
+  get_file_path,
+  save_file,
+  validate_extension,
+)
+
+CHUNK_SIZE = 64 * 1024  # 64 KB 단위 청크 읽기
+
+router = APIRouter(prefix="/api/files", tags=["files"])
+
+
+def _get_file_repo(session: Session = Depends(get_session)) -> SQLiteFileRepository:
+  """FileRepository 의존성 — 요청마다 새 인스턴스 반환."""
+  return SQLiteFileRepository(session)
+
+
+class FileMetadataResponse(BaseModel):
+  """업로드 결과 및 목록 조회 공통 응답 스키마."""
+
+  id: str
+  original_filename: str
+  mime_type: str
+  size_bytes: int
+  created_at: str
+  download_url: str
+
+
+def _to_response(row) -> FileMetadataResponse:
+  """FileRow ORM 객체를 FileMetadataResponse로 변환하는 내부 헬퍼."""
+  return FileMetadataResponse(
+    id=row.id,
+    original_filename=row.original_filename,
+    mime_type=row.mime_type,
+    size_bytes=row.size_bytes,
+    created_at=row.created_at,
+    download_url=f"/api/files/{row.id}",
+  )
+
+
+@router.post("", status_code=201, response_model=FileMetadataResponse)
+async def upload_file(
+  file: UploadFile = File(...),
+  repo: SQLiteFileRepository = Depends(_get_file_repo),
+) -> FileMetadataResponse:
+  """파일을 업로드하고 메타데이터를 반환합니다.
+
+  허용 확장자 화이트리스트를 검증한 뒤 UUID 기반 이름으로 저장합니다.
+
+  Args:
+    file: 업로드 파일 (multipart/form-data).
+
+  Returns:
+    저장된 파일의 메타데이터 (id, original_filename, download_url 포함).
+
+  Raises:
+    415: 허용되지 않는 파일 확장자.
+    413: 파일 크기가 50 MB 초과.
+  """
+  original_name = file.filename or "unnamed"
+
+  # 확장자 검증 — 허용 목록에 없는 형식은 415 반환
+  try:
+    validate_extension(original_name)
+  except ValueError as exc:
+    raise HTTPException(status_code=415, detail=str(exc))
+
+  # 청크 단위 읽기 — 50 MB 초과 즉시 413 반환 (메모리 보호)
+  chunks: list[bytes] = []
+  total = 0
+  while chunk := await file.read(CHUNK_SIZE):
+    total += len(chunk)
+    if total > MAX_BYTES:
+      raise HTTPException(status_code=413, detail="파일 크기가 50 MB를 초과합니다.")
+    chunks.append(chunk)
+  data = b"".join(chunks)
+
+  # 디스크 저장 (UUID 기반 파일명, 원본명은 sanitize)
+  result = save_file(data, original_name, file.content_type or "application/octet-stream")
+
+  # 메타데이터를 DB에 저장
+  row = repo.create_file(
+    original_filename=result["sanitized_filename"],
+    stored_filename=result["stored_filename"],
+    mime_type=file.content_type or "application/octet-stream",
+    size_bytes=result["size_bytes"],
+  )
+  return _to_response(row)
+
+
+@router.get("", response_model=list[FileMetadataResponse])
+def list_files(
+  repo: SQLiteFileRepository = Depends(_get_file_repo),
+) -> list[FileMetadataResponse]:
+  """업로드된 파일 목록을 생성 시각 역순으로 반환합니다."""
+  return [_to_response(row) for row in repo.list_files()]
+
+
+@router.get("/{file_id}")
+def download_file(
+  file_id: str,
+  repo: SQLiteFileRepository = Depends(_get_file_repo),
+) -> FileResponse:
+  """파일을 다운로드합니다.
+
+  원본 파일명을 RFC 5987 형식으로 인코딩하여 Content-Disposition 헤더에 설정합니다.
+  이를 통해 브라우저가 한글을 포함한 UTF-8 파일명을 올바르게 처리합니다.
+
+  Ref: RFC 5987 — https://datatracker.ietf.org/doc/html/rfc5987#section-3.2
+
+  Raises:
+    404: file_id가 DB에 없거나 디스크 파일이 삭제된 경우.
+  """
+  row = repo.get_file(file_id)
+  if row is None:
+    raise HTTPException(status_code=404, detail="파일을 찾을 수 없습니다.")
+
+  try:
+    path = get_file_path(row.stored_filename)
+  except (FileNotFoundError, ValueError):
+    # DB에는 있지만 디스크 파일이 존재하지 않는 경우 (수동 삭제 등)
+    raise HTTPException(status_code=404, detail="파일이 서버에 존재하지 않습니다.")
+
+  # RFC 5987: filename*=UTF-8''<percent-encoded>
+  # percent_encode safe="" — 모든 non-ASCII 문자를 인코딩
+  encoded_name = urllib.parse.quote(row.original_filename, safe="")
+  content_disposition = f"attachment; filename*=UTF-8''{encoded_name}"
+
+  return FileResponse(
+    path=str(path),
+    media_type=row.mime_type,
+    headers={"Content-Disposition": content_disposition},
+  )
+
+
+@router.delete("/{file_id}", status_code=204)
+def delete_file(
+  file_id: str,
+  repo: SQLiteFileRepository = Depends(_get_file_repo),
+) -> None:
+  """파일 메타데이터(DB)와 디스크 파일을 함께 삭제합니다.
+
+  디스크 파일이 이미 없는 경우에도 DB 삭제는 정상 처리됩니다.
+
+  Raises:
+    404: file_id가 DB에 없는 경우.
+  """
+  row = repo.delete_file(file_id)
+  if row is None:
+    raise HTTPException(status_code=404, detail="파일을 찾을 수 없습니다.")
+  # 디스크 파일 정리 — 이미 없어도 오류 없이 통과
+  delete_stored_file(row.stored_filename)

--- a/app/services/file.py
+++ b/app/services/file.py
@@ -1,0 +1,157 @@
+"""범용 파일 저장·조회·삭제 서비스.
+
+허용 확장자 화이트리스트 검증과 UUID 기반 저장명으로
+경로 순회(path traversal) 및 파일명 충돌을 방지합니다.
+
+참고:
+  - OWASP File Upload Cheat Sheet:
+    https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+  - RFC 5987 (Content-Disposition filename encoding):
+    https://datatracker.ietf.org/doc/html/rfc5987
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+from pathlib import Path
+
+# 파일 저장 디렉터리 — static/files/ (이미지 업로드 경로 static/uploads/ 와 분리)
+FILES_DIR = Path(__file__).resolve().parents[2] / "static" / "files"
+
+# 파일 크기 상한: 50 MB
+MAX_BYTES = 50 * 1024 * 1024
+
+# 허용 확장자 화이트리스트 — 실행 가능 파일(exe, sh, py, js 등) 제외
+# Ref: OWASP File Upload Cheat Sheet
+ALLOWED_EXTENSIONS: frozenset[str] = frozenset({
+  # 문서
+  ".pdf", ".doc", ".docx", ".odt",
+  ".xls", ".xlsx", ".ods",
+  ".ppt", ".pptx", ".odp",
+  ".txt", ".md", ".csv",
+  # 압축 아카이브
+  ".zip", ".tar", ".gz", ".bz2", ".7z",
+  # 이미지 (image 블록 외 첨부 용도)
+  ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg",
+  # 오디오/비디오
+  ".mp3", ".m4a", ".wav", ".ogg",
+  ".mp4", ".mov", ".avi", ".mkv", ".webm",
+})
+
+# 원본 파일명 최대 길이 (OS 제한 범위 내)
+MAX_FILENAME_LENGTH = 255
+
+# 경로 구분자·null byte·제어 문자 패턴 — sanitize 시 제거 대상
+_UNSAFE_FILENAME_RE = re.compile(r'[/\\:*?"<>|\x00-\x1f]')
+
+
+def sanitize_filename(name: str) -> str:
+  """원본 파일명에서 경로 순회·제어 문자를 제거하고 최대 길이로 잘라 반환합니다.
+
+  저장 경로에는 사용하지 않으며, DB 기록 및 Content-Disposition 헤더 전용입니다.
+
+  Args:
+    name: 클라이언트가 전송한 원본 파일명.
+
+  Returns:
+    NFC 정규화 및 위험 문자 제거 후 안전한 파일명 문자열.
+  """
+  # NFC 정규화 — 유니코드 합성 형식 통일 (한글 자모 분리 방지)
+  name = unicodedata.normalize("NFC", name)
+  # 경로 구분자 등 위험 문자를 밑줄로 치환
+  name = _UNSAFE_FILENAME_RE.sub("_", name)
+  name = name[:MAX_FILENAME_LENGTH]
+  return name.strip() or "unnamed"
+
+
+def validate_extension(filename: str) -> str:
+  """파일명에서 확장자를 추출하고 허용 목록에 있는지 검증합니다.
+
+  Args:
+    filename: 원본 파일명 (확장자 포함).
+
+  Returns:
+    소문자 확장자 문자열 (예: ".pdf").
+
+  Raises:
+    ValueError: 확장자가 없거나 허용 목록에 없는 경우.
+  """
+  ext = Path(filename).suffix.lower()
+  if not ext:
+    raise ValueError("파일 확장자가 없습니다.")
+  if ext not in ALLOWED_EXTENSIONS:
+    raise ValueError(f"허용하지 않는 파일 형식입니다: {ext}")
+  return ext
+
+
+def save_file(data: bytes, original_filename: str, mime_type: str) -> dict[str, str | int]:
+  """파일을 UUID 기반 이름으로 디스크에 저장하고 메타데이터를 반환합니다.
+
+  저장 경로에는 UUID만 사용하므로 파일명 충돌과 경로 순회 위험이 없습니다.
+  원본 파일명은 sanitize_filename()을 통해 정규화됩니다.
+
+  Args:
+    data: 저장할 파일 바이트.
+    original_filename: 클라이언트가 전송한 원본 파일명.
+    mime_type: 클라이언트가 전달한 MIME type (Content-Type).
+
+  Returns:
+    stored_filename, size_bytes, sanitized_filename 을 담은 dict.
+  """
+  FILES_DIR.mkdir(parents=True, exist_ok=True)
+
+  stored_filename = uuid.uuid4().hex
+  dest = FILES_DIR / stored_filename
+  dest.write_bytes(data)
+
+  return {
+    "stored_filename": stored_filename,
+    "size_bytes": len(data),
+    "sanitized_filename": sanitize_filename(original_filename),
+  }
+
+
+def get_file_path(stored_filename: str) -> Path:
+  """저장된 파일의 절대 경로를 반환합니다.
+
+  경로 순회 공격 방어:
+    stored_filename 해석 결과가 FILES_DIR 밖을 가리키면 ValueError를 발생시킵니다.
+    (예: "../secret" 같은 입력 차단)
+
+  Args:
+    stored_filename: DB에 기록된 UUID 파일명.
+
+  Returns:
+    파일의 절대 Path 객체.
+
+  Raises:
+    ValueError: stored_filename이 FILES_DIR 밖을 가리키는 경우.
+    FileNotFoundError: 파일이 존재하지 않는 경우.
+  """
+  path = (FILES_DIR / stored_filename).resolve()
+  # resolve() 후 FILES_DIR.resolve() 하위인지 확인 — path traversal 방어
+  if not path.is_relative_to(FILES_DIR.resolve()):
+    raise ValueError("허용되지 않는 파일 경로입니다.")
+  if not path.exists():
+    raise FileNotFoundError(f"파일을 찾을 수 없습니다: {stored_filename}")
+  return path
+
+
+def delete_stored_file(stored_filename: str) -> bool:
+  """디스크에서 파일을 삭제하고 성공 여부를 반환합니다.
+
+  존재하지 않는 파일에 대해서는 False를 반환하며 예외를 던지지 않습니다.
+
+  Args:
+    stored_filename: DB에 기록된 UUID 파일명.
+
+  Returns:
+    삭제 성공 시 True, 파일이 없었거나 경로가 유효하지 않으면 False.
+  """
+  try:
+    path = get_file_path(stored_filename)
+    path.unlink()
+    return True
+  except (FileNotFoundError, ValueError):
+    return False

--- a/app/services/file.py
+++ b/app/services/file.py
@@ -85,7 +85,7 @@ def validate_extension(filename: str) -> str:
   return ext
 
 
-def save_file(data: bytes, original_filename: str, mime_type: str) -> dict[str, str | int]:
+def save_file(data: bytes, original_filename: str) -> dict[str, str | int]:
   """파일을 UUID 기반 이름으로 디스크에 저장하고 메타데이터를 반환합니다.
 
   저장 경로에는 UUID만 사용하므로 파일명 충돌과 경로 순회 위험이 없습니다.
@@ -94,11 +94,18 @@ def save_file(data: bytes, original_filename: str, mime_type: str) -> dict[str, 
   Args:
     data: 저장할 파일 바이트.
     original_filename: 클라이언트가 전송한 원본 파일명.
-    mime_type: 클라이언트가 전달한 MIME type (Content-Type).
 
   Returns:
     stored_filename, size_bytes, sanitized_filename 을 담은 dict.
+
+  Raises:
+    ValueError: 파일 크기가 MAX_BYTES를 초과하는 경우.
   """
+  # 서비스 레이어에서 크기 제한을 강제하여 라우터 외부 호출 경로에서도 안전성 보장
+  # Ref: OWASP File Upload Cheat Sheet — "Limit the file size"
+  if len(data) > MAX_BYTES:
+    raise ValueError(f"파일 크기가 {MAX_BYTES // (1024 * 1024)} MB를 초과합니다.")
+
   FILES_DIR.mkdir(parents=True, exist_ok=True)
 
   stored_filename = uuid.uuid4().hex

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.routers import blocks, database, documents, upload, url_embed
+from app.routers import blocks, database, documents, files, upload, url_embed
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -20,6 +20,7 @@ app.include_router(documents.router)
 app.include_router(blocks.router)
 app.include_router(database.router)
 app.include_router(upload.router)
+app.include_router(files.router)
 app.include_router(url_embed.router)
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2570,6 +2570,14 @@ body.lightbox-open {
   width: 100%;
 }
 
+/* hidden 속성이 display: flex 등에 의해 덮어쓰이지 않도록 명시 */
+.file-empty-state[hidden],
+.file-upload-spinner[hidden],
+.file-uploaded-state[hidden],
+.file-upload-error[hidden] {
+  display: none;
+}
+
 /* ── 빈 상태(드롭존) ─────────────────────────────────────────────────────────── */
 
 .file-drop-zone {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2563,3 +2563,200 @@ body.lightbox-open {
   color: var(--text-muted, #999);
   text-align: center;
 }
+
+/* ── File Block ─────────────────────────────────────────────────────────────── */
+
+.notion-file {
+  width: 100%;
+}
+
+/* ── 빈 상태(드롭존) ─────────────────────────────────────────────────────────── */
+
+.file-drop-zone {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border: 1.5px dashed var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--ink-soft);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  /* 텍스트 블록과 줄 높이 통일 */
+  min-height: 2.4rem;
+}
+
+.file-drop-zone:hover,
+.file-drop-zone:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--ink);
+  outline: none;
+}
+
+.file-drop-zone.is-drag-over {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  border-style: solid;
+}
+
+.file-drop-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.file-drop-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 실제 <input type=file>는 숨기되 JS로 트리거 */
+.file-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* 에러 메시지 */
+.file-upload-error {
+  margin-top: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  color: #c0392b;
+  background: #fdf0ee;
+  border-radius: 4px;
+  border-left: 3px solid #c0392b;
+}
+
+/* ── 업로드 중 스피너 ─────────────────────────────────────────────────────────── */
+
+.file-upload-spinner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--ink-soft);
+  border: 1.5px dashed var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  min-height: 2.4rem;
+}
+
+/* 도트 애니메이션 */
+.file-spinner-dot {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: file-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes file-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── 업로드 완료 카드 ────────────────────────────────────────────────────────── */
+
+.file-card {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.file-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 1px 4px var(--shadow);
+}
+
+.file-icon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.file-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.file-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-meta {
+  font-size: 0.75rem;
+  color: var(--ink-soft);
+}
+
+/* 다운로드 버튼 */
+.file-download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s;
+}
+
+.file-download-btn:hover,
+.file-download-btn:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  outline: none;
+}
+
+/* 파일 제거 버튼 */
+.file-remove-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 0.75rem;
+  color: var(--ink-soft);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s;
+}
+
+.file-remove-btn:hover,
+.file-remove-btn:focus-visible {
+  background: #fee2e2;
+  color: #c0392b;
+  outline: none;
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -67,6 +67,23 @@ export async function apiChangeBlockType(blockId, type) {
   if (!res.ok) throw new Error('Failed to change block type');
 }
 
+export async function apiUploadFile(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch('/api/files', { method: 'POST', body: form });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail ?? '파일 업로드에 실패했습니다.');
+  }
+  return res.json();
+}
+
+export async function apiDeleteFile(fileId) {
+  // 이미 없는 파일(404)은 정상으로 처리 — 멱등성 보장
+  const res = await fetch(`/api/files/${fileId}`, { method: 'DELETE' });
+  if (!res.ok && res.status !== 404) throw new Error('파일 삭제에 실패했습니다.');
+}
+
 export async function apiUploadImage(file) {
   const form = new FormData();
   form.append('file', file);

--- a/static/js/blockPalette.js
+++ b/static/js/blockPalette.js
@@ -5,6 +5,7 @@ import { apiDeleteBlock } from "./api.js";
 export const BLOCK_PALETTE_ITEMS = [
   { type: 'text', label: '텍스트', icon: 'T' },
   { type: 'image', label: '이미지', icon: '▣' },
+  { type: 'file', label: '파일', icon: '📎' },
   { type: 'toggle', label: '토글', icon: '▶' },
   { type: 'quote', label: '인용', icon: '"' },
   { type: 'code', label: '코드', icon: '⟨⟩' },

--- a/static/js/blockRenderers.js
+++ b/static/js/blockRenderers.js
@@ -14,9 +14,10 @@ import * as dividerBlock from "./blocks/dividerBlock.js";
 import * as pageBlock from "./blocks/pageBlock.js";
 import * as databaseBlock from "./blocks/databaseBlock.js";
 import * as urlEmbedBlock from "./blocks/urlEmbedBlock.js";
+import * as fileBlock from "./blocks/fileBlock.js";
 
 // 블록 모듈 등록
-[textBlock, imageBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, urlEmbedBlock, pageBlock, databaseBlock]
+[textBlock, imageBlock, fileBlock, toggleBlock, codeBlock, quoteBlock, calloutBlock, dividerBlock, urlEmbedBlock, pageBlock, databaseBlock]
   .forEach((mod) => blockRegistry.register(mod));
 
 // Initialise singleton toolbar once

--- a/static/js/blocks/fileBlock.js
+++ b/static/js/blocks/fileBlock.js
@@ -10,7 +10,7 @@
 //         ↓ 완료
 //   uploaded (파일 카드)
 
-import { apiUploadFile, apiDeleteFile, apiPatchBlock, apiDeleteBlock } from "../api.js";
+import { apiUploadFile, apiDeleteFile, apiPatchBlock } from "../api.js";
 
 export const type = "file";
 
@@ -91,18 +91,31 @@ export function create(block, { callbacks } = {}) {
   async function handleFile(file) {
     if (!file) return;
     showUploading();
+
+    // patch 성공 후에만 block 상태를 갱신하여 실패 시 orphan 파일을 방지한다.
+    // Ref: 낙관적 업데이트 대신 확정(confirm-then-apply) 패턴 사용
+    //   https://developer.mozilla.org/en-US/docs/Glossary/Optimistic_UI
+    let uploadedFile = null;
     try {
-      const result = await apiUploadFile(file);
-      // 서버에서 반환된 메타데이터를 block 객체에 반영
-      block.file_id           = result.id;
-      block.original_filename = result.original_filename;
-      block.size_bytes        = result.size_bytes;
-      block.mime_type         = result.mime_type;
-      block.download_url      = result.download_url;
-      // 블록 content_json에 file_id 저장
-      await apiPatchBlock(block.id, { file_id: result.id });
+      uploadedFile = await apiUploadFile(file);
+      // 블록 content_json에 file_id 저장이 성공한 뒤에만
+      // block 객체에 업로드된 파일 메타데이터를 반영한다.
+      await apiPatchBlock(block.id, { file_id: uploadedFile.id });
+
+      block.file_id           = uploadedFile.id;
+      block.original_filename = uploadedFile.original_filename;
+      block.size_bytes        = uploadedFile.size_bytes;
+      block.mime_type         = uploadedFile.mime_type;
+      block.download_url      = uploadedFile.download_url;
+
       showUploaded();
     } catch (err) {
+      // patch 실패 시 이미 업로드된 파일을 정리하여 orphan 방지
+      if (uploadedFile?.id) {
+        await apiDeleteFile(uploadedFile.id).catch((deleteErr) => {
+          console.error("업로드된 파일 정리 실패:", deleteErr);
+        });
+      }
       console.error("파일 업로드 실패:", err);
       showError(err.message || "업로드 실패. 다시 시도하세요.");
     } finally {
@@ -139,19 +152,23 @@ export function create(block, { callbacks } = {}) {
     e.preventDefault();
     e.stopPropagation();
     const oldFileId = block.file_id;
-    // 먼저 UI를 빈 상태로 전환 (낙관적 업데이트)
-    block.file_id           = "";
-    block.original_filename = "";
-    block.size_bytes        = 0;
-    block.mime_type         = "";
-    block.download_url      = "";
-    showEmpty();
+
+    // patch 성공 후에만 로컬 상태를 갱신하여 서버/클라이언트 불일치를 방지한다.
     try {
       await apiPatchBlock(block.id, { file_id: "" });
-      // 파일 레코드와 디스크 파일도 정리 — 실패해도 UI는 이미 빈 상태
+
+      block.file_id           = "";
+      block.original_filename = "";
+      block.size_bytes        = 0;
+      block.mime_type         = "";
+      block.download_url      = "";
+      showEmpty();
+
+      // 서버의 블록 참조 제거가 확인된 뒤에만 실제 파일 삭제를 시도
       if (oldFileId) await apiDeleteFile(oldFileId).catch(console.error);
     } catch (err) {
       console.error("파일 제거 실패:", err);
+      showError("파일 제거에 실패했습니다. 다시 시도하세요.");
     }
   });
 

--- a/static/js/blocks/fileBlock.js
+++ b/static/js/blocks/fileBlock.js
@@ -1,0 +1,198 @@
+// ── File Block ─────────────────────────────────────────────────────────────────
+//
+// 상태 흐름:
+//
+//   [생성 직후 / file_id 없음]      [file_id 있음]
+//         ↓                              ↓
+//   empty (드롭존 표시)           uploaded (파일 카드 표시)
+//         ↓ 파일 선택 / 드래그            ↓ ✕ 버튼
+//   uploading (스피너)            empty (파일 제거 후)
+//         ↓ 완료
+//   uploaded (파일 카드)
+
+import { apiUploadFile, apiDeleteFile, apiPatchBlock, apiDeleteBlock } from "../api.js";
+
+export const type = "file";
+
+/**
+ * 파일 블록 DOM을 생성합니다.
+ *
+ * 파일이 없을 때: 드래그&드롭 / 클릭으로 업로드 유도.
+ * 파일이 있을 때: 파일명·크기·MIME 타입을 카드로 표시하고 다운로드·제거 버튼 노출.
+ *
+ * @param {object} block           - 서버에서 받은 블록 데이터 (FileBlock 스키마)
+ * @param {{ callbacks: object }} opts
+ * @returns {HTMLElement}
+ */
+export function create(block, { callbacks } = {}) {
+  const template = document.getElementById("file-block-template");
+  const node = template.content.firstElementChild.cloneNode(true);
+
+  const emptyState   = node.querySelector(".file-empty-state");
+  const dropZone     = node.querySelector(".file-drop-zone");
+  const fileInput    = node.querySelector(".file-input");
+  const dropLabel    = node.querySelector(".file-drop-label");
+  const spinnerWrap  = node.querySelector(".file-upload-spinner");
+  const errorEl      = node.querySelector(".file-upload-error");
+  const uploadedState = node.querySelector(".file-uploaded-state");
+  const fileIcon     = node.querySelector(".file-icon");
+  const fileName     = node.querySelector(".file-name");
+  const fileMeta     = node.querySelector(".file-meta");
+  const downloadBtn  = node.querySelector(".file-download-btn");
+  const removeBtn    = node.querySelector(".file-remove-btn");
+
+  // ── 상태 전환 ────────────────────────────────────────────────────────────
+
+  function showEmpty() {
+    emptyState.hidden    = false;
+    spinnerWrap.hidden   = true;
+    uploadedState.hidden = true;
+    errorEl.hidden       = true;
+    dropLabel.textContent = "파일을 드래그하거나 클릭해서 업로드";
+  }
+
+  function showUploading() {
+    emptyState.hidden    = true;
+    spinnerWrap.hidden   = false;
+    uploadedState.hidden = true;
+    errorEl.hidden       = true;
+  }
+
+  function showUploaded() {
+    fileIcon.textContent  = _mimeIcon(block.mime_type);
+    fileName.textContent  = block.original_filename || "파일";
+    fileMeta.textContent  = _formatMeta(block.mime_type, block.size_bytes);
+    downloadBtn.href      = block.download_url || `/api/files/${block.file_id}`;
+    downloadBtn.download  = block.original_filename || "";
+
+    emptyState.hidden    = true;
+    spinnerWrap.hidden   = true;
+    uploadedState.hidden = false;
+    errorEl.hidden       = true;
+  }
+
+  function showError(msg) {
+    errorEl.textContent  = msg;
+    errorEl.hidden       = false;
+    spinnerWrap.hidden   = true;
+    emptyState.hidden    = false;
+  }
+
+  // ── 초기 렌더링 ───────────────────────────────────────────────────────────
+
+  if (block.file_id) {
+    showUploaded();
+  } else {
+    showEmpty();
+  }
+
+  // ── 업로드 처리 ───────────────────────────────────────────────────────────
+
+  async function handleFile(file) {
+    if (!file) return;
+    showUploading();
+    try {
+      const result = await apiUploadFile(file);
+      // 서버에서 반환된 메타데이터를 block 객체에 반영
+      block.file_id           = result.id;
+      block.original_filename = result.original_filename;
+      block.size_bytes        = result.size_bytes;
+      block.mime_type         = result.mime_type;
+      block.download_url      = result.download_url;
+      // 블록 content_json에 file_id 저장
+      await apiPatchBlock(block.id, { file_id: result.id });
+      showUploaded();
+    } catch (err) {
+      console.error("파일 업로드 실패:", err);
+      showError(err.message || "업로드 실패. 다시 시도하세요.");
+    } finally {
+      fileInput.value = "";
+    }
+  }
+
+  fileInput.addEventListener("change", () => handleFile(fileInput.files[0]));
+
+  // 드롭존 클릭 → 파일 선택 대화상자
+  dropZone.addEventListener("click", () => fileInput.click());
+  // Enter / Space 키보드 접근성
+  dropZone.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      fileInput.click();
+    }
+  });
+
+  dropZone.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    dropZone.classList.add("is-drag-over");
+  });
+  dropZone.addEventListener("dragleave", () => dropZone.classList.remove("is-drag-over"));
+  dropZone.addEventListener("drop", (e) => {
+    e.preventDefault();
+    dropZone.classList.remove("is-drag-over");
+    handleFile(e.dataTransfer.files[0]);
+  });
+
+  // ── 파일 제거 ─────────────────────────────────────────────────────────────
+
+  removeBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const oldFileId = block.file_id;
+    // 먼저 UI를 빈 상태로 전환 (낙관적 업데이트)
+    block.file_id           = "";
+    block.original_filename = "";
+    block.size_bytes        = 0;
+    block.mime_type         = "";
+    block.download_url      = "";
+    showEmpty();
+    try {
+      await apiPatchBlock(block.id, { file_id: "" });
+      // 파일 레코드와 디스크 파일도 정리 — 실패해도 UI는 이미 빈 상태
+      if (oldFileId) await apiDeleteFile(oldFileId).catch(console.error);
+    } catch (err) {
+      console.error("파일 제거 실패:", err);
+    }
+  });
+
+  return node;
+}
+
+// ── 내부 유틸 ─────────────────────────────────────────────────────────────────
+
+/**
+ * MIME 타입에 대응하는 이모지 아이콘을 반환합니다.
+ * @param {string} mime
+ * @returns {string}
+ */
+function _mimeIcon(mime = "") {
+  if (mime.startsWith("image/"))                                return "🖼";
+  if (mime.startsWith("video/"))                                return "🎬";
+  if (mime.startsWith("audio/"))                                return "🎵";
+  if (mime === "application/pdf")                               return "📄";
+  if (mime.includes("zip") || mime.includes("archive"))         return "📦";
+  if (mime.includes("word") || mime.includes("document"))       return "📝";
+  if (mime.includes("sheet") || mime.includes("excel"))         return "📊";
+  if (mime.includes("presentation") || mime.includes("powerpoint")) return "📊";
+  if (mime.startsWith("text/"))                                 return "📃";
+  return "📎";
+}
+
+/**
+ * MIME 타입과 크기를 사람이 읽기 쉬운 문자열로 조합합니다.
+ * @param {string} mime
+ * @param {number} sizeBytes
+ * @returns {string}
+ */
+function _formatMeta(mime = "", sizeBytes = 0) {
+  let sizeStr;
+  if (sizeBytes >= 1024 * 1024) {
+    sizeStr = `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+  } else if (sizeBytes >= 1024) {
+    sizeStr = `${(sizeBytes / 1024).toFixed(1)} KB`;
+  } else {
+    sizeStr = `${sizeBytes} B`;
+  }
+  const ext = mime ? mime.split("/").pop().toUpperCase() : "";
+  return ext ? `${ext} · ${sizeStr}` : sizeStr;
+}

--- a/static/js/blocks/inlineSlashMenu.js
+++ b/static/js/blocks/inlineSlashMenu.js
@@ -30,6 +30,7 @@ export const SLASH_MENU_ITEMS = [
   { type: "code",      label: "코드",        icon: "⟨⟩",  keywords: ["code", "snippet", "pre", "코드"] },
   { type: "callout",   label: "콜아웃",      icon: "💡",  keywords: ["callout", "note", "tip", "콜아웃"] },
   { type: "image",     label: "이미지",      icon: "▣",   keywords: ["image", "photo", "picture", "이미지"] },
+  { type: "file",      label: "파일",        icon: "📎",  keywords: ["file", "attach", "upload", "파일", "첨부"] },
   { type: "divider",   label: "구분선",      icon: "—",   keywords: ["divider", "separator", "hr", "rule", "구분선"] },
   { type: "url_embed", label: "URL 임베드", icon: "🔗",   keywords: ["url", "link", "embed", "bookmark", "임베드"] },
 ];

--- a/templates/partials/block_templates.html
+++ b/templates/partials/block_templates.html
@@ -142,6 +142,40 @@
   </div>
 </template>
 
+<template id="file-block-template">
+  <div class="notion-block notion-file">
+    <!-- 빈 상태: 드래그&드롭 / 클릭 업로드 유도 -->
+    <div class="file-empty-state">
+      <div class="file-drop-zone" role="button" tabindex="0" aria-label="파일 업로드. 클릭하거나 파일을 드래그하세요.">
+        <span class="file-drop-icon" aria-hidden="true">📎</span>
+        <span class="file-drop-label">파일을 드래그하거나 클릭해서 업로드</span>
+        <!-- type="file" input은 JS가 트리거 — 직접 클릭 금지(tabindex=-1) -->
+        <input type="file" class="file-input" tabindex="-1" aria-hidden="true">
+      </div>
+      <div class="file-upload-error" role="alert" hidden></div>
+    </div>
+    <!-- 업로드 중 -->
+    <div class="file-upload-spinner" hidden aria-live="polite" aria-label="업로드 중">
+      <span class="file-spinner-dot" aria-hidden="true"></span>
+      <span>업로드 중...</span>
+    </div>
+    <!-- 업로드 완료 상태: 파일 카드 -->
+    <div class="file-uploaded-state" hidden>
+      <div class="file-card">
+        <span class="file-icon" aria-hidden="true">📎</span>
+        <div class="file-info">
+          <span class="file-name"></span>
+          <span class="file-meta"></span>
+        </div>
+        <a class="file-download-btn" href="#" download aria-label="파일 다운로드">
+          <span aria-hidden="true">↓</span> 다운로드
+        </a>
+        <button type="button" class="file-remove-btn" aria-label="파일 제거">✕</button>
+      </div>
+    </div>
+  </div>
+</template>
+
 <template id="callout-block-template">
   <div class="notion-block notion-callout">
     <span class="callout-emoji"></span>

--- a/tests/test_file_upload_download.py
+++ b/tests/test_file_upload_download.py
@@ -1,0 +1,570 @@
+"""파일 업로드·다운로드 기능 단위 테스트 (이슈 #63).
+
+커버리지 범위:
+  1. app.services.file  — sanitize_filename, validate_extension, save_file,
+                          get_file_path, delete_stored_file
+  2. Repository 레이어  — SQLiteFileRepository CRUD
+  3. API 레이어         — POST 업로드, GET 다운로드, GET 목록, DELETE, 오류 케이스
+
+참고:
+  - pytest 공식 문서: https://docs.pytest.org/en/stable/
+  - FastAPI TestClient: https://fastapi.tiangolo.com/tutorial/testing/
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.models.orm import Base, FileRow
+from app.repositories.file_repo import SQLiteFileRepository
+
+
+# ── 공통 픽스처 ───────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def file_engine():
+  """files 테이블을 포함하는 인메모리 SQLite 엔진. 테스트별 격리."""
+  eng = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+  )
+  Base.metadata.create_all(eng)
+  return eng
+
+
+@pytest.fixture()
+def file_session(file_engine):
+  with Session(file_engine) as s:
+    yield s
+
+
+@pytest.fixture()
+def file_repo(file_session):
+  return SQLiteFileRepository(file_session)
+
+
+@pytest.fixture()
+def file_client(file_engine, tmp_path, monkeypatch):
+  """파일 라우터가 포함된 TestClient. DB와 파일 저장 경로 모두 격리."""
+  from main import app
+  from app.dependencies import get_session
+  from app.services import file as file_svc
+
+  # 파일 저장 경로를 tmp_path로 교체 — 실제 static/files 에 영향 없음
+  monkeypatch.setattr(file_svc, "FILES_DIR", tmp_path / "files")
+
+  def _override_session():
+    with Session(file_engine) as s:
+      yield s
+
+  app.dependency_overrides[get_session] = _override_session
+  with TestClient(app) as c:
+    yield c
+  app.dependency_overrides.pop(get_session, None)
+
+
+def _make_upload_file(content: bytes = b"hello", filename: str = "test.txt") -> dict:
+  """TestClient multipart 업로드용 파일 튜플을 생성하는 헬퍼."""
+  return {"file": (filename, io.BytesIO(content), "text/plain")}
+
+
+# ── 1. app.services.file ─────────────────────────────────────────────────────
+
+class TestSanitizeFilename:
+  """sanitize_filename() 의 입력 정규화 및 위험 문자 제거를 검증."""
+
+  def test_normal_name_unchanged(self):
+    """일반 파일명은 변경되지 않는다."""
+    from app.services.file import sanitize_filename
+    assert sanitize_filename("report.pdf") == "report.pdf"
+
+  def test_path_separator_replaced(self):
+    """슬래시·역슬래시 경로 구분자는 밑줄로 치환된다."""
+    from app.services.file import sanitize_filename
+    assert "/" not in sanitize_filename("../../etc/passwd")
+    assert "\\" not in sanitize_filename("..\\windows\\system32")
+
+  def test_null_byte_removed(self):
+    """null byte(\x00)는 밑줄로 치환된다."""
+    from app.services.file import sanitize_filename
+    assert "\x00" not in sanitize_filename("file\x00name.txt")
+
+  def test_control_characters_removed(self):
+    """제어 문자(\x01–\x1f)는 밑줄로 치환된다."""
+    from app.services.file import sanitize_filename
+    result = sanitize_filename("file\x01name.txt")
+    assert "\x01" not in result
+
+  def test_empty_string_returns_unnamed(self):
+    """빈 문자열은 'unnamed'를 반환한다."""
+    from app.services.file import sanitize_filename
+    assert sanitize_filename("") == "unnamed"
+
+  def test_whitespace_only_returns_unnamed(self):
+    """공백만 있는 문자열은 'unnamed'를 반환한다."""
+    from app.services.file import sanitize_filename
+    assert sanitize_filename("   ") == "unnamed"
+
+  def test_korean_filename_preserved(self):
+    """한글 파일명은 그대로 보존된다."""
+    from app.services.file import sanitize_filename
+    assert sanitize_filename("보고서.pdf") == "보고서.pdf"
+
+  def test_max_length_truncation(self):
+    """255자를 초과하는 파일명은 잘린다."""
+    from app.services.file import sanitize_filename, MAX_FILENAME_LENGTH
+    long_name = "a" * 300
+    assert len(sanitize_filename(long_name)) <= MAX_FILENAME_LENGTH
+
+
+class TestValidateExtension:
+  """validate_extension() 의 허용/거부 로직을 검증."""
+
+  def test_allowed_extension_returns_ext(self):
+    """허용 확장자는 소문자 확장자를 반환한다."""
+    from app.services.file import validate_extension
+    assert validate_extension("report.pdf") == ".pdf"
+
+  def test_uppercase_extension_normalized(self):
+    """대문자 확장자도 소문자로 정규화하여 허용된다."""
+    from app.services.file import validate_extension
+    assert validate_extension("IMAGE.PNG") == ".png"
+
+  def test_disallowed_extension_raises(self):
+    """허용 목록에 없는 확장자는 ValueError를 발생시킨다."""
+    from app.services.file import validate_extension
+    with pytest.raises(ValueError, match="허용하지 않는"):
+      validate_extension("script.exe")
+
+  def test_no_extension_raises(self):
+    """확장자 없는 파일명은 ValueError를 발생시킨다."""
+    from app.services.file import validate_extension
+    with pytest.raises(ValueError, match="확장자가 없습니다"):
+      validate_extension("noextension")
+
+  def test_shell_script_rejected(self):
+    """.sh 파일은 허용되지 않는다."""
+    from app.services.file import validate_extension
+    with pytest.raises(ValueError):
+      validate_extension("attack.sh")
+
+  def test_python_file_rejected(self):
+    """.py 파일은 허용되지 않는다."""
+    from app.services.file import validate_extension
+    with pytest.raises(ValueError):
+      validate_extension("malicious.py")
+
+  def test_zip_allowed(self):
+    """.zip 파일은 허용된다."""
+    from app.services.file import validate_extension
+    assert validate_extension("archive.zip") == ".zip"
+
+  def test_docx_allowed(self):
+    """.docx 파일은 허용된다."""
+    from app.services.file import validate_extension
+    assert validate_extension("document.docx") == ".docx"
+
+
+class TestSaveFile:
+  """save_file() 의 디스크 저장 및 반환값을 검증."""
+
+  def test_returns_stored_filename(self, tmp_path, monkeypatch):
+    """저장 후 stored_filename이 반환된다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+
+    result = svc.save_file(b"data", "test.txt", "text/plain")
+    assert "stored_filename" in result
+
+  def test_stored_filename_is_uuid_hex(self, tmp_path, monkeypatch):
+    """stored_filename은 32자리 UUID hex 형식이다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+
+    result = svc.save_file(b"data", "test.txt", "text/plain")
+    assert len(result["stored_filename"]) == 32
+
+  def test_file_exists_after_save(self, tmp_path, monkeypatch):
+    """save_file 호출 후 디스크에 파일이 존재한다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    result = svc.save_file(b"hello", "test.txt", "text/plain")
+    assert (files_dir / result["stored_filename"]).exists()
+
+  def test_size_bytes_matches_data(self, tmp_path, monkeypatch):
+    """반환된 size_bytes는 실제 데이터 크기와 일치한다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+
+    data = b"0" * 1234
+    result = svc.save_file(data, "test.txt", "text/plain")
+    assert result["size_bytes"] == 1234
+
+  def test_sanitized_filename_returned(self, tmp_path, monkeypatch):
+    """sanitize된 원본 파일명이 반환된다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+
+    result = svc.save_file(b"data", "../../evil.txt", "text/plain")
+    assert "/" not in result["sanitized_filename"]
+
+  def test_unique_stored_filename_per_call(self, tmp_path, monkeypatch):
+    """두 번 호출하면 서로 다른 stored_filename이 생성된다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+
+    r1 = svc.save_file(b"a", "a.txt", "text/plain")
+    r2 = svc.save_file(b"b", "b.txt", "text/plain")
+    assert r1["stored_filename"] != r2["stored_filename"]
+
+
+class TestGetFilePath:
+  """get_file_path() 의 경로 조회 및 path traversal 방어를 검증."""
+
+  def test_returns_correct_path(self, tmp_path, monkeypatch):
+    """저장된 파일의 올바른 절대 경로를 반환한다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    fname = "abc123"
+    (files_dir / fname).write_bytes(b"content")
+
+    path = svc.get_file_path(fname)
+    assert path.exists()
+
+  def test_missing_file_raises_file_not_found(self, tmp_path, monkeypatch):
+    """존재하지 않는 파일은 FileNotFoundError를 발생시킨다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    with pytest.raises(FileNotFoundError):
+      svc.get_file_path("nonexistent")
+
+  def test_path_traversal_raises_value_error(self, tmp_path, monkeypatch):
+    """경로 순회 입력(../)은 ValueError를 발생시킨다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    with pytest.raises(ValueError, match="허용되지 않는"):
+      svc.get_file_path("../secret")
+
+
+class TestDeleteStoredFile:
+  """delete_stored_file() 의 삭제 동작을 검증."""
+
+  def test_existing_file_deleted_returns_true(self, tmp_path, monkeypatch):
+    """존재하는 파일 삭제 시 True를 반환하고 파일이 사라진다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    fname = "deleteme"
+    (files_dir / fname).write_bytes(b"bye")
+
+    assert svc.delete_stored_file(fname) is True
+    assert not (files_dir / fname).exists()
+
+  def test_missing_file_returns_false(self, tmp_path, monkeypatch):
+    """존재하지 않는 파일에 대해 False를 반환한다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    assert svc.delete_stored_file("ghost") is False
+
+  def test_path_traversal_returns_false(self, tmp_path, monkeypatch):
+    """경로 순회 입력에 대해 False를 반환하며 예외를 던지지 않는다."""
+    from app.services import file as svc
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    monkeypatch.setattr(svc, "FILES_DIR", files_dir)
+
+    assert svc.delete_stored_file("../outside") is False
+
+
+# ── 2. Repository 레이어 ──────────────────────────────────────────────────────
+
+class TestSQLiteFileRepository:
+  """SQLiteFileRepository의 CRUD 메서드를 검증."""
+
+  def _create(self, repo: SQLiteFileRepository, **kwargs) -> FileRow:
+    """테스트용 FileRow를 생성하는 헬퍼."""
+    defaults = {
+      "original_filename": "test.txt",
+      "stored_filename": "uuid_hex_value",
+      "mime_type": "text/plain",
+      "size_bytes": 100,
+    }
+    defaults.update(kwargs)
+    return repo.create_file(**defaults)
+
+  def test_create_returns_file_row(self, file_repo):
+    """create_file이 FileRow를 반환한다."""
+    row = self._create(file_repo)
+    assert isinstance(row, FileRow)
+
+  def test_create_assigns_id(self, file_repo):
+    """생성된 row에 id가 할당된다."""
+    row = self._create(file_repo)
+    assert row.id and len(row.id) > 0
+
+  def test_create_persists_fields(self, file_repo):
+    """저장된 필드 값이 정확히 유지된다."""
+    row = self._create(
+      file_repo,
+      original_filename="보고서.pdf",
+      stored_filename="abc123",
+      mime_type="application/pdf",
+      size_bytes=9999,
+    )
+    assert row.original_filename == "보고서.pdf"
+    assert row.stored_filename == "abc123"
+    assert row.mime_type == "application/pdf"
+    assert row.size_bytes == 9999
+
+  def test_create_sets_created_at(self, file_repo):
+    """created_at 필드가 ISO-8601 형식으로 설정된다."""
+    row = self._create(file_repo)
+    assert "T" in row.created_at  # ISO-8601 날짜·시각 구분자
+
+  def test_get_existing_file(self, file_repo):
+    """get_file로 생성한 row를 조회할 수 있다."""
+    row = self._create(file_repo)
+    fetched = file_repo.get_file(row.id)
+    assert fetched is not None
+    assert fetched.id == row.id
+
+  def test_get_nonexistent_returns_none(self, file_repo):
+    """존재하지 않는 id 조회 시 None을 반환한다."""
+    assert file_repo.get_file("no-such-id") is None
+
+  def test_list_returns_all_files(self, file_repo):
+    """list_files는 생성한 모든 row를 반환한다."""
+    self._create(file_repo, stored_filename="uuid1")
+    self._create(file_repo, stored_filename="uuid2")
+    rows = file_repo.list_files()
+    assert len(rows) == 2
+
+  def test_list_empty_when_no_files(self, file_repo):
+    """파일이 없을 때 빈 리스트를 반환한다."""
+    assert file_repo.list_files() == []
+
+  def test_delete_returns_deleted_row(self, file_repo):
+    """delete_file은 삭제된 FileRow를 반환한다."""
+    row = self._create(file_repo)
+    deleted = file_repo.delete_file(row.id)
+    assert deleted is not None
+    assert deleted.id == row.id
+
+  def test_delete_removes_from_db(self, file_repo):
+    """삭제 후 get_file 조회 시 None을 반환한다."""
+    row = self._create(file_repo)
+    file_repo.delete_file(row.id)
+    assert file_repo.get_file(row.id) is None
+
+  def test_delete_nonexistent_returns_none(self, file_repo):
+    """존재하지 않는 id 삭제 시 None을 반환한다."""
+    assert file_repo.delete_file("ghost-id") is None
+
+  def test_list_ordered_by_created_at_desc(self, file_repo):
+    """list_files는 생성 시각 역순(최신 우선)으로 반환한다."""
+    r1 = self._create(file_repo, stored_filename="older", original_filename="a.txt")
+    r2 = self._create(file_repo, stored_filename="newer", original_filename="b.txt")
+    rows = file_repo.list_files()
+    # 최신(r2)이 먼저 나와야 함
+    assert rows[0].id == r2.id
+    assert rows[1].id == r1.id
+
+
+# ── 3. API 레이어 ─────────────────────────────────────────────────────────────
+
+class TestFileUploadAPI:
+  """POST /api/files 업로드 엔드포인트를 검증."""
+
+  def test_upload_returns_201(self, file_client):
+    """정상 업로드 요청은 201을 반환한다."""
+    resp = file_client.post("/api/files", files=_make_upload_file())
+    assert resp.status_code == 201
+
+  def test_upload_response_has_required_fields(self, file_client):
+    """응답 JSON에 id, original_filename, download_url 등이 포함된다."""
+    resp = file_client.post("/api/files", files=_make_upload_file())
+    data = resp.json()
+    for field in ("id", "original_filename", "mime_type", "size_bytes", "created_at", "download_url"):
+      assert field in data, f"필드 누락: {field}"
+
+  def test_upload_download_url_points_to_api(self, file_client):
+    """download_url이 /api/files/{id} 형식을 가진다."""
+    resp = file_client.post("/api/files", files=_make_upload_file())
+    data = resp.json()
+    assert data["download_url"] == f"/api/files/{data['id']}"
+
+  def test_upload_disallowed_extension_returns_415(self, file_client):
+    """허용되지 않는 확장자(.exe) 업로드 시 415를 반환한다."""
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("evil.exe", io.BytesIO(b"MZ"), "application/octet-stream")},
+    )
+    assert resp.status_code == 415
+
+  def test_upload_shell_script_returns_415(self, file_client):
+    """셸 스크립트(.sh) 업로드 시 415를 반환한다."""
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("attack.sh", io.BytesIO(b"#!/bin/sh"), "text/x-sh")},
+    )
+    assert resp.status_code == 415
+
+  def test_upload_pdf_allowed(self, file_client):
+    """PDF 파일 업로드가 성공한다."""
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+    )
+    assert resp.status_code == 201
+
+  def test_upload_zip_allowed(self, file_client):
+    """ZIP 파일 업로드가 성공한다."""
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("archive.zip", io.BytesIO(b"PK"), "application/zip")},
+    )
+    assert resp.status_code == 201
+
+  def test_upload_size_bytes_correct(self, file_client):
+    """응답의 size_bytes가 실제 업로드 크기와 일치한다."""
+    content = b"x" * 500
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("data.txt", io.BytesIO(content), "text/plain")},
+    )
+    assert resp.json()["size_bytes"] == 500
+
+  def test_upload_korean_filename_sanitized(self, file_client):
+    """한글 파일명이 포함된 업로드도 정상 처리된다."""
+    resp = file_client.post(
+      "/api/files",
+      files={"file": ("한글파일.txt", io.BytesIO(b"content"), "text/plain")},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["original_filename"] == "한글파일.txt"
+
+
+class TestFileDownloadAPI:
+  """GET /api/files/{file_id} 다운로드 엔드포인트를 검증."""
+
+  def _upload(self, client, content: bytes = b"file content", filename: str = "test.txt"):
+    """업로드 후 메타데이터를 반환하는 헬퍼."""
+    return client.post("/api/files", files=_make_upload_file(content, filename)).json()
+
+  def test_download_returns_200(self, file_client):
+    """정상 다운로드 요청은 200을 반환한다."""
+    meta = self._upload(file_client)
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert resp.status_code == 200
+
+  def test_download_content_matches_uploaded(self, file_client):
+    """다운로드한 파일 내용이 업로드한 내용과 일치한다."""
+    content = b"hello, world!"
+    meta = self._upload(file_client, content=content)
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert resp.content == content
+
+  def test_download_content_disposition_header_present(self, file_client):
+    """Content-Disposition 헤더가 응답에 포함된다."""
+    meta = self._upload(file_client, filename="report.txt")
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert "content-disposition" in resp.headers
+
+  def test_download_content_disposition_is_attachment(self, file_client):
+    """Content-Disposition이 attachment 타입이다."""
+    meta = self._upload(file_client, filename="report.txt")
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert "attachment" in resp.headers["content-disposition"]
+
+  def test_download_content_disposition_rfc5987_encoded(self, file_client):
+    """Content-Disposition에 RFC 5987 인코딩(filename*)이 사용된다."""
+    meta = self._upload(file_client, filename="보고서.txt")
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert "filename*=UTF-8''" in resp.headers["content-disposition"]
+
+  def test_download_nonexistent_returns_404(self, file_client):
+    """존재하지 않는 file_id 요청 시 404를 반환한다."""
+    resp = file_client.get("/api/files/no-such-id")
+    assert resp.status_code == 404
+
+
+class TestFileListAPI:
+  """GET /api/files 목록 조회 엔드포인트를 검증."""
+
+  def test_empty_list_when_no_uploads(self, file_client):
+    """업로드 전 목록 조회 시 빈 배열을 반환한다."""
+    resp = file_client.get("/api/files")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+  def test_list_includes_uploaded_file(self, file_client):
+    """업로드 후 목록에 해당 파일이 포함된다."""
+    meta = file_client.post("/api/files", files=_make_upload_file()).json()
+    items = file_client.get("/api/files").json()
+    ids = [item["id"] for item in items]
+    assert meta["id"] in ids
+
+  def test_list_count_increases_after_upload(self, file_client):
+    """업로드할 때마다 목록 수가 증가한다."""
+    file_client.post("/api/files", files=_make_upload_file(filename="a.txt"))
+    file_client.post("/api/files", files=_make_upload_file(filename="b.txt"))
+    items = file_client.get("/api/files").json()
+    assert len(items) == 2
+
+  def test_list_items_have_download_url(self, file_client):
+    """목록의 각 항목에 download_url이 포함된다."""
+    file_client.post("/api/files", files=_make_upload_file())
+    items = file_client.get("/api/files").json()
+    for item in items:
+      assert "download_url" in item
+
+
+class TestFileDeleteAPI:
+  """DELETE /api/files/{file_id} 삭제 엔드포인트를 검증."""
+
+  def test_delete_returns_204(self, file_client):
+    """정상 삭제 요청은 204를 반환한다."""
+    meta = file_client.post("/api/files", files=_make_upload_file()).json()
+    resp = file_client.delete(f"/api/files/{meta['id']}")
+    assert resp.status_code == 204
+
+  def test_deleted_file_not_in_list(self, file_client):
+    """삭제 후 목록 조회 시 해당 파일이 없다."""
+    meta = file_client.post("/api/files", files=_make_upload_file()).json()
+    file_client.delete(f"/api/files/{meta['id']}")
+    items = file_client.get("/api/files").json()
+    assert all(item["id"] != meta["id"] for item in items)
+
+  def test_deleted_file_download_returns_404(self, file_client):
+    """삭제 후 다운로드 시도 시 404를 반환한다."""
+    meta = file_client.post("/api/files", files=_make_upload_file()).json()
+    file_client.delete(f"/api/files/{meta['id']}")
+    resp = file_client.get(f"/api/files/{meta['id']}")
+    assert resp.status_code == 404
+
+  def test_delete_nonexistent_returns_404(self, file_client):
+    """존재하지 않는 file_id 삭제 시 404를 반환한다."""
+    resp = file_client.delete("/api/files/no-such-id")
+    assert resp.status_code == 404

--- a/tests/test_file_upload_download.py
+++ b/tests/test_file_upload_download.py
@@ -179,7 +179,7 @@ class TestSaveFile:
     from app.services import file as svc
     monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
 
-    result = svc.save_file(b"data", "test.txt", "text/plain")
+    result = svc.save_file(b"data", "test.txt")
     assert "stored_filename" in result
 
   def test_stored_filename_is_uuid_hex(self, tmp_path, monkeypatch):
@@ -187,7 +187,7 @@ class TestSaveFile:
     from app.services import file as svc
     monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
 
-    result = svc.save_file(b"data", "test.txt", "text/plain")
+    result = svc.save_file(b"data", "test.txt")
     assert len(result["stored_filename"]) == 32
 
   def test_file_exists_after_save(self, tmp_path, monkeypatch):
@@ -196,7 +196,7 @@ class TestSaveFile:
     files_dir = tmp_path / "files"
     monkeypatch.setattr(svc, "FILES_DIR", files_dir)
 
-    result = svc.save_file(b"hello", "test.txt", "text/plain")
+    result = svc.save_file(b"hello", "test.txt")
     assert (files_dir / result["stored_filename"]).exists()
 
   def test_size_bytes_matches_data(self, tmp_path, monkeypatch):
@@ -205,7 +205,7 @@ class TestSaveFile:
     monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
 
     data = b"0" * 1234
-    result = svc.save_file(data, "test.txt", "text/plain")
+    result = svc.save_file(data, "test.txt")
     assert result["size_bytes"] == 1234
 
   def test_sanitized_filename_returned(self, tmp_path, monkeypatch):
@@ -213,7 +213,7 @@ class TestSaveFile:
     from app.services import file as svc
     monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
 
-    result = svc.save_file(b"data", "../../evil.txt", "text/plain")
+    result = svc.save_file(b"data", "../../evil.txt")
     assert "/" not in result["sanitized_filename"]
 
   def test_unique_stored_filename_per_call(self, tmp_path, monkeypatch):
@@ -221,9 +221,18 @@ class TestSaveFile:
     from app.services import file as svc
     monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
 
-    r1 = svc.save_file(b"a", "a.txt", "text/plain")
-    r2 = svc.save_file(b"b", "b.txt", "text/plain")
+    r1 = svc.save_file(b"a", "a.txt")
+    r2 = svc.save_file(b"b", "b.txt")
     assert r1["stored_filename"] != r2["stored_filename"]
+
+  def test_exceeding_max_bytes_raises(self, tmp_path, monkeypatch):
+    """MAX_BYTES를 초과하는 데이터는 ValueError를 발생시킨다."""
+    from app.services import file as svc
+    monkeypatch.setattr(svc, "FILES_DIR", tmp_path / "files")
+    monkeypatch.setattr(svc, "MAX_BYTES", 10)  # 10 bytes로 제한
+
+    with pytest.raises(ValueError, match="초과"):
+      svc.save_file(b"x" * 11, "big.txt")
 
 
 class TestGetFilePath:


### PR DESCRIPTION
## Summary

- 배경: 문서/블록에서 파일을 업로드하고, 업로드된 파일을 다시 다운로드할 수 있는 기능이 필요합니다. (Issue #63)
- 목적: 허용 확장자 화이트리스트 기반 범용 파일 업로드 API와, 원본 파일명을 보존하는 다운로드 API를 구현하고, 에디터에서 파일 블록을 추가·관리할 수 있는 UI를 제공합니다.

## Changes

### 백엔드
- `FileRow` ORM 테이블 추가 — 파일 메타데이터(원본명, 저장명, MIME, 크기, 생성일) 저장
- `FileBlock` Pydantic 모델 추가 및 Block discriminated union 등록
- `app/services/file.py` — UUID 저장명, 확장자 화이트리스트, path traversal 방어, 50 MB 제한
- `app/repositories/file_repo.py` — `SQLiteFileRepository` CRUD
- `app/routers/files.py` — `POST /api/files`, `GET /api/files`, `GET /api/files/{id}`, `DELETE /api/files/{id}`
- `Content-Disposition` RFC 5987 인코딩으로 한글 파일명 다운로드 보장
- `BlockPatch`에 `file_id` 필드, `BlockTypeChange`에 `"file"` 타입 추가
- `get_document`에서 FileRow query-time 메타데이터 주입

### 프론트엔드
- `fileBlock.js` — 드래그&드롭/클릭 업로드, 파일 카드(아이콘·파일명·크기), 다운로드·제거 버튼
- `api.js` — `apiUploadFile`, `apiDeleteFile` 헬퍼 추가
- `blockPalette.js`, `inlineSlashMenu.js`, `blockWrapper.js` 타입 전환 드롭다운에 📎 파일 항목 등록
- `file-block-template` HTML 템플릿 및 CSS 스타일 추가

## Test

- [x] `uv run pytest` — 341개 전체 통과 (신규 63개 포함)
- [x] 파일 업로드·다운로드 서비스 계층 단위 테스트 (sanitize, validate, save, path traversal 방어)
- [x] `SQLiteFileRepository` CRUD 테스트 (생성, 조회, 목록, 삭제, 정렬)
- [x] API 레이어 테스트 (201 업로드, 200 다운로드, Content-Disposition, 415 거부, 404 처리, 204 삭제)
- [ ] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [ ] 브라우저 콘솔 에러 없음

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [x] 기존 테스트 회귀 없음 (341/341 통과)

## Review Points

- 중점적으로 봐야 할 부분:
  - `app/services/file.py` — path traversal 방어 로직 (`resolve()` + `is_relative_to()`)과 확장자 화이트리스트 범위가 적절한지
  - `app/routers/files.py` — RFC 5987 Content-Disposition 인코딩이 다양한 브라우저에서 올바르게 동작하는지
  - `static/js/blocks/fileBlock.js` — 업로드 실패·제거 시 낙관적 업데이트 흐름이 안전한지