### PR TITLE
[FEAT#43] Viewer/관리자 페이지 분리 및 관리자 인증 기반 쓰기 권한 제어

### DIFF
--- a/app/auth/config.py
+++ b/app/auth/config.py
@@ -1,0 +1,27 @@
+"""관리자 인증 설정.
+
+환경 변수를 통해 관리자 자격 증명과 세션 정책을 설정한다.
+설정이 누락된 경우 기본값을 사용하되, 프로덕션 환경에서는
+반드시 ``ADMIN_PASSWORD``를 변경해야 한다.
+
+Ref: https://fastapi.tiangolo.com/advanced/settings/
+     https://docs.python.org/3/library/os.html#os.environ
+"""
+from __future__ import annotations
+
+import os
+
+# 관리자 계정 자격 증명
+ADMIN_USERNAME: str = os.getenv("ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD: str = os.getenv("ADMIN_PASSWORD", "admin1234")
+
+# 세션 정책
+SESSION_COOKIE_NAME: str = "session_token"
+SESSION_MAX_AGE: int = int(os.getenv("SESSION_MAX_AGE", "3600"))  # 기본 1시간(초)
+
+# 쿠키 보안 설정
+# Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#security
+COOKIE_HTTPONLY: bool = True
+COOKIE_SAMESITE: str = "lax"
+# HTTPS 환경에서만 True로 설정 (개발 환경에서는 False)
+COOKIE_SECURE: bool = os.getenv("COOKIE_SECURE", "false").lower() == "true"

--- a/app/auth/config.py
+++ b/app/auth/config.py
@@ -1,19 +1,32 @@
 """관리자 인증 설정.
 
 환경 변수를 통해 관리자 자격 증명과 세션 정책을 설정한다.
-설정이 누락된 경우 기본값을 사용하되, 프로덕션 환경에서는
-반드시 ``ADMIN_PASSWORD``를 변경해야 한다.
+``ADMIN_PASSWORD``가 설정되지 않으면 프로세스 시작 시 임의 비밀번호를
+생성하고 표준 출력에 경고를 표시한다.
 
 Ref: https://fastapi.tiangolo.com/advanced/settings/
      https://docs.python.org/3/library/os.html#os.environ
+     https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
 """
 from __future__ import annotations
 
 import os
+import secrets
+import sys
 
 # 관리자 계정 자격 증명
 ADMIN_USERNAME: str = os.getenv("ADMIN_USERNAME", "admin")
-ADMIN_PASSWORD: str = os.getenv("ADMIN_PASSWORD", "admin1234")
+
+_password_from_env = os.getenv("ADMIN_PASSWORD")
+if _password_from_env:
+  ADMIN_PASSWORD: str = _password_from_env
+else:
+  ADMIN_PASSWORD = secrets.token_urlsafe(16)
+  print(
+    f"[WARNING] ADMIN_PASSWORD 환경변수가 설정되지 않았습니다. "
+    f"임시 비밀번호가 생성되었습니다: {ADMIN_PASSWORD}",
+    file=sys.stderr,
+  )
 
 # 세션 정책
 SESSION_COOKIE_NAME: str = "session_token"

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,0 +1,36 @@
+"""인증 관련 FastAPI 의존성.
+
+라우터에서 ``Depends(require_admin)``으로 쓰기 권한을 보호한다.
+인증되지 않은 요청은 HTTP 403 Forbidden을 반환한다.
+
+Ref: https://fastapi.tiangolo.com/tutorial/dependencies/
+     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+"""
+from __future__ import annotations
+
+from fastapi import Cookie, HTTPException
+
+from app.auth.config import SESSION_COOKIE_NAME
+from app.auth.service import validate_session
+
+
+def require_admin(
+  session_token: str | None = Cookie(None, alias=SESSION_COOKIE_NAME),
+) -> str:
+  """관리자 인증 여부를 확인하는 의존성.
+
+  인증된 사용자의 username을 반환한다.
+  세션 쿠키가 없거나 유효하지 않으면 403을 발생시킨다.
+  """
+  if session_token is None:
+    raise HTTPException(
+      status_code=403,
+      detail="로그인이 필요합니다.",
+    )
+  username = validate_session(session_token)
+  if username is None:
+    raise HTTPException(
+      status_code=403,
+      detail="세션이 만료되었습니다. 다시 로그인해 주세요.",
+    )
+  return username

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -1,0 +1,34 @@
+"""인증 서비스 — 자격 증명 검증과 세션 발급/해제를 담당한다.
+
+비밀번호 비교에 ``secrets.compare_digest``를 사용해 타이밍 공격을 방지한다.
+Ref: https://docs.python.org/3/library/secrets.html#secrets.compare_digest
+"""
+from __future__ import annotations
+
+import secrets
+
+from app.auth.config import ADMIN_PASSWORD, ADMIN_USERNAME
+from app.auth.session import session_store
+
+
+def authenticate(username: str, password: str) -> str | None:
+  """자격 증명을 검증하고 세션 토큰을 반환한다.
+
+  인증 실패 시 None을 반환한다. 사용자명과 비밀번호 모두
+  ``compare_digest``로 비교해 어떤 필드가 틀렸는지 추론할 수 없게 한다.
+  """
+  username_ok = secrets.compare_digest(username, ADMIN_USERNAME)
+  password_ok = secrets.compare_digest(password, ADMIN_PASSWORD)
+  if not (username_ok and password_ok):
+    return None
+  return session_store.create(username)
+
+
+def validate_session(token: str) -> str | None:
+  """세션 토큰을 검증하고 username을 반환한다. 무효하면 None."""
+  return session_store.validate(token)
+
+
+def logout(token: str) -> bool:
+  """세션을 해제한다."""
+  return session_store.revoke(token)

--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -4,8 +4,7 @@
 딕셔너리에 보관한다. 토큰 검증 시 만료된 세션은 자동으로 제거된다.
 
 보안 고려사항:
-  - 토큰 비교: ``secrets.compare_digest``로 타이밍 공격 방지
-    Ref: https://docs.python.org/3/library/secrets.html#secrets.compare_digest
+  - 토큰은 충분한 엔트로피를 가진 난수로 생성하여 세션 식별자로 사용
   - 토큰 길이: 32바이트(URL-safe base64 → 43자) — OWASP 권장 128비트 이상
     Ref: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
 """
@@ -32,6 +31,7 @@ class SessionStore:
 
   def create(self, username: str) -> str:
     """새 세션을 생성하고 토큰을 반환한다."""
+    self.cleanup_expired()
     token = secrets.token_urlsafe(32)
     self._sessions[token] = _SessionEntry(
       username=username,
@@ -45,7 +45,7 @@ class SessionStore:
     if entry is None:
       return None
     if time.time() > entry.expires_at:
-      del self._sessions[token]
+      self._sessions.pop(token, None)
       return None
     return entry.username
 

--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -1,0 +1,66 @@
+"""인메모리 세션 저장소.
+
+``secrets.token_urlsafe``로 세션 토큰을 생성하고, 만료 시각과 함께
+딕셔너리에 보관한다. 토큰 검증 시 만료된 세션은 자동으로 제거된다.
+
+보안 고려사항:
+  - 토큰 비교: ``secrets.compare_digest``로 타이밍 공격 방지
+    Ref: https://docs.python.org/3/library/secrets.html#secrets.compare_digest
+  - 토큰 길이: 32바이트(URL-safe base64 → 43자) — OWASP 권장 128비트 이상
+    Ref: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+
+from app.auth.config import SESSION_MAX_AGE
+
+
+@dataclass
+class _SessionEntry:
+  username: str
+  expires_at: float
+
+
+@dataclass
+class SessionStore:
+  """프로세스 인메모리 세션 저장소."""
+
+  _sessions: dict[str, _SessionEntry] = field(default_factory=dict)
+
+  def create(self, username: str) -> str:
+    """새 세션을 생성하고 토큰을 반환한다."""
+    token = secrets.token_urlsafe(32)
+    self._sessions[token] = _SessionEntry(
+      username=username,
+      expires_at=time.time() + SESSION_MAX_AGE,
+    )
+    return token
+
+  def validate(self, token: str) -> str | None:
+    """유효한 세션이면 username을 반환하고, 아니면 None."""
+    entry = self._sessions.get(token)
+    if entry is None:
+      return None
+    if time.time() > entry.expires_at:
+      del self._sessions[token]
+      return None
+    return entry.username
+
+  def revoke(self, token: str) -> bool:
+    """세션을 무효화한다. 성공 시 True."""
+    return self._sessions.pop(token, None) is not None
+
+  def cleanup_expired(self) -> int:
+    """만료된 세션을 일괄 제거하고 제거 건수를 반환한다."""
+    now = time.time()
+    expired = [k for k, v in self._sessions.items() if now > v.expires_at]
+    for k in expired:
+      del self._sessions[k]
+    return len(expired)
+
+
+# 싱글턴 — 프로세스 수명 동안 공유
+session_store = SessionStore()

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,92 @@
+"""관리자 인증 라우터.
+
+엔드포인트:
+  POST /api/auth/login   — 자격 증명 검증 후 세션 쿠키 발급
+  POST /api/auth/logout  — 세션 쿠키 해제
+  GET  /api/auth/status   — 현재 인증 상태 조회
+
+세션 쿠키 설정은 OWASP Session Management Cheat Sheet를 따른다.
+Ref: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Cookie, HTTPException, Response
+from pydantic import BaseModel
+
+from app.auth.config import (
+  COOKIE_HTTPONLY,
+  COOKIE_SAMESITE,
+  COOKIE_SECURE,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE,
+)
+from app.auth.service import authenticate, logout, validate_session
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+  username: str
+  password: str
+
+
+class LoginResponse(BaseModel):
+  message: str
+  username: str
+
+
+class StatusResponse(BaseModel):
+  authenticated: bool
+  username: str | None = None
+
+
+@router.post("/login", response_model=LoginResponse)
+def login(body: LoginRequest, response: Response) -> LoginResponse:
+  """관리자 로그인 — 세션 쿠키를 발급한다."""
+  token = authenticate(body.username, body.password)
+  if token is None:
+    raise HTTPException(
+      status_code=401,
+      detail="아이디 또는 비밀번호가 올바르지 않습니다.",
+    )
+  response.set_cookie(
+    key=SESSION_COOKIE_NAME,
+    value=token,
+    max_age=SESSION_MAX_AGE,
+    httponly=COOKIE_HTTPONLY,
+    samesite=COOKIE_SAMESITE,
+    secure=COOKIE_SECURE,
+    path="/",
+  )
+  return LoginResponse(message="로그인 성공", username=body.username)
+
+
+@router.post("/logout")
+def do_logout(
+  response: Response,
+  session_token: str | None = Cookie(None, alias=SESSION_COOKIE_NAME),
+) -> dict[str, str]:
+  """관리자 로그아웃 — 세션 쿠키를 삭제한다."""
+  if session_token:
+    logout(session_token)
+  response.delete_cookie(
+    key=SESSION_COOKIE_NAME,
+    path="/",
+    httponly=COOKIE_HTTPONLY,
+    samesite=COOKIE_SAMESITE,
+    secure=COOKIE_SECURE,
+  )
+  return {"message": "로그아웃 완료"}
+
+
+@router.get("/status", response_model=StatusResponse)
+def auth_status(
+  session_token: str | None = Cookie(None, alias=SESSION_COOKIE_NAME),
+) -> StatusResponse:
+  """현재 인증 상태를 반환한다."""
+  if session_token is None:
+    return StatusResponse(authenticated=False)
+  username = validate_session(session_token)
+  if username is None:
+    return StatusResponse(authenticated=False)
+  return StatusResponse(authenticated=True, username=username)

--- a/app/routers/blocks.py
+++ b/app/routers/blocks.py
@@ -5,6 +5,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
 
+from app.auth.dependencies import require_admin
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
 
@@ -48,6 +49,7 @@ class BlockTypeChange(BaseModel):
 def patch_block(
   block_id: str,
   body: BlockPatch,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Update editable content fields of a block."""
@@ -63,6 +65,7 @@ def patch_block(
 def move_block(
   block_id: str,
   body: BlockPositionPatch,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Reorder a block among its siblings."""
@@ -78,6 +81,7 @@ def move_block(
 def change_block_type(
   block_id: str,
   body: BlockTypeChange,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Change a block's type and reset its content to defaults."""
@@ -89,6 +93,7 @@ def change_block_type(
 @router.delete("/{block_id}", status_code=204)
 def delete_block(
   block_id: str,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> Response:
   """Delete a block and all its descendants."""

--- a/app/routers/database.py
+++ b/app/routers/database.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 
+from app.auth.dependencies import require_admin
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
 from app.routers.blocks import DatabaseBlockPatch
@@ -19,6 +20,7 @@ router = APIRouter(prefix="/api/database", tags=["database"])
 def patch_database_block(
   block_id: str,
   body: DatabaseBlockPatch,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Update title or color of a database block."""
@@ -48,6 +50,7 @@ class ColumnUpdate(BaseModel):
 def add_column(
   block_id: str,
   body: ColumnCreate,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict:
   """Add a new column to a database block's schema."""
@@ -68,6 +71,7 @@ def update_column(
   block_id: str,
   col_id: str,
   body: ColumnUpdate,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Rename or change a column's type/options."""
@@ -83,6 +87,7 @@ def update_column(
 def remove_column(
   block_id: str,
   col_id: str,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> Response:
   """Remove a column from the database schema (and wipes its values from all rows)."""
@@ -101,6 +106,7 @@ class PropertiesUpdate(BaseModel):
 def update_properties(
   block_id: str,
   body: PropertiesUpdate,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Replace all property values on a db_row block."""

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -5,6 +5,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
+from app.auth.dependencies import require_admin
 from app.dependencies import get_repository
 from app.models.blocks import BlockDocument
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
@@ -48,7 +49,10 @@ def get_document(
 
 
 @router.post("", status_code=201)
-def create_document(repo: SQLiteBlockRepository = Depends(get_repository)) -> dict:
+def create_document(
+  _admin: str = Depends(require_admin),
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> dict:
   """Create a new empty document and return its info."""
   return repo.create_document()
 
@@ -57,6 +61,7 @@ def create_document(repo: SQLiteBlockRepository = Depends(get_repository)) -> di
 def update_document_title(
   document_id: str,
   body: DocumentTitleUpdate,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict[str, str]:
   """Update the title of an existing document."""
@@ -76,6 +81,7 @@ class BlockCreate(BaseModel):
 def create_block(
   document_id: str,
   body: BlockCreate,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> dict:
   """Append a new block to a document.
@@ -101,6 +107,7 @@ def create_block(
 @router.delete("/{document_id}", status_code=204)
 def delete_document(
   document_id: str,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> None:
   """Delete a document and all its blocks."""

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -25,6 +25,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.auth.dependencies import require_admin
 from app.dependencies import get_session
 from app.repositories.file_repo import SQLiteFileRepository
 from app.services.file import (
@@ -70,6 +71,7 @@ def _to_response(row) -> FileMetadataResponse:
 
 @router.post("", status_code=201, response_model=FileMetadataResponse)
 async def upload_file(
+  _admin: str = Depends(require_admin),
   file: UploadFile = File(...),
   repo: SQLiteFileRepository = Depends(_get_file_repo),
 ) -> FileMetadataResponse:
@@ -166,6 +168,7 @@ def download_file(
 @router.delete("/{file_id}", status_code=204)
 def delete_file(
   file_id: str,
+  _admin: str = Depends(require_admin),
   repo: SQLiteFileRepository = Depends(_get_file_repo),
 ) -> None:
   """파일 메타데이터(DB)와 디스크 파일을 함께 삭제합니다.

--- a/app/routers/upload.py
+++ b/app/routers/upload.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from PIL import UnidentifiedImageError
 
+from app.auth.dependencies import require_admin
 from app.services.image import process_image
 
 ALLOWED_MIME = {"image/jpeg", "image/png", "image/gif", "image/webp"}
@@ -13,7 +14,10 @@ router = APIRouter(prefix="/api/upload", tags=["upload"])
 
 
 @router.post("")
-async def upload_image(file: UploadFile = File(...)) -> dict[str, str]:
+async def upload_image(
+  _admin: str = Depends(require_admin),
+  file: UploadFile = File(...),
+) -> dict[str, str]:
   """이미지를 업로드하고 압축·썸네일 생성 후 URL을 반환합니다."""
   if file.content_type not in ALLOWED_MIME:
     raise HTTPException(status_code=415, detail="지원하지 않는 이미지 형식입니다.")

--- a/app/routers/url_embed.py
+++ b/app/routers/url_embed.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
+from app.auth.dependencies import require_admin
 from app.dependencies import get_repository
 from app.repositories.sqlite_blocks import SQLiteBlockRepository
 from app.services.url_embed import UrlEmbedMetadata, fetch_url_metadata
@@ -56,6 +57,7 @@ class UrlFetchResponse(BaseModel):
 @router.post("/fetch", response_model=UrlFetchResponse)
 def fetch_embed(
   body: UrlFetchRequest,
+  _admin: str = Depends(require_admin),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> UrlFetchResponse:
   """URL의 Open Graph / Twitter Card 메타데이터를 조회한다.

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.routers import blocks, database, documents, files, upload, url_embed
+from app.routers import auth, blocks, database, documents, files, upload, url_embed
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -16,6 +16,7 @@ app = FastAPI(title="Project Manager")
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+app.include_router(auth.router)
 app.include_router(documents.router)
 app.include_router(blocks.router)
 app.include_router(database.router)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2959,8 +2959,9 @@ body.viewer-mode .db-cell-checkbox {
   opacity: 0.7;
 }
 
-/* 이미지 블록 액션 오버레이 숨김 */
-body.viewer-mode .image-actions {
+/* 이미지 블록: 더보기(변경/삭제) 숨김, 크게 보기는 유지 */
+body.viewer-mode .image-more-btn,
+body.viewer-mode .image-more-menu {
   display: none !important;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2768,3 +2768,198 @@ body.lightbox-open {
   color: #c0392b;
   outline: none;
 }
+
+/* ── 관리자 인증 버튼 ─────────────────────────────────────────────────────── */
+
+.auth-btn {
+  position: fixed;
+  top: 0.75rem;
+  right: 1rem;
+  z-index: 200;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.auth-btn:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.auth-btn.is-authenticated {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.auth-btn.is-authenticated:hover {
+  background: #005a57;
+  border-color: #005a57;
+}
+
+/* ── 로그인 모달 ──────────────────────────────────────────────────────────── */
+
+.login-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.login-modal-overlay[hidden] {
+  display: none;
+}
+
+.login-modal {
+  position: relative;
+  width: 340px;
+  padding: 2rem 1.8rem;
+  border-radius: 12px;
+  background: var(--panel);
+  box-shadow: 0 8px 32px var(--shadow);
+}
+
+.login-modal-title {
+  margin: 0 0 1.2rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--ink);
+  text-align: center;
+}
+
+.login-modal-error {
+  margin: 0 0 0.8rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  background: #fef2f2;
+  color: #c0392b;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.login-modal-error[hidden] {
+  display: none;
+}
+
+.login-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.login-field-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+}
+
+.login-field-input {
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.88rem;
+  font-family: inherit;
+  background: #fff;
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.login-field-input:focus {
+  border-color: var(--accent);
+}
+
+.login-modal-submit {
+  margin-top: 0.3rem;
+  padding: 0.6rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.login-modal-submit:hover {
+  background: #005a57;
+}
+
+.login-modal-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 0.2rem 0.4rem;
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 1rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.login-modal-close:hover {
+  color: var(--ink);
+}
+
+/* ── Viewer 모드: 쓰기 UI 숨김 ───────────────────────────────────────────── */
+/* 미인증(viewer) 상태에서 생성/수정/삭제 관련 UI 요소를 숨긴다. */
+
+body.viewer-mode .new-document-btn,
+body.viewer-mode .block-actions,
+body.viewer-mode .block-palette,
+body.viewer-mode .block-delete-confirm,
+body.viewer-mode .block-more-menu,
+body.viewer-mode .inline-slash-menu,
+body.viewer-mode .document-item-menu {
+  display: none !important;
+}
+
+/* 텍스트 편집 비활성화 — contentEditable 요소의 커서/포커스 스타일 제거 */
+body.viewer-mode .notion-text,
+body.viewer-mode .toggle-title,
+body.viewer-mode .quote-text,
+body.viewer-mode .callout-text,
+body.viewer-mode .code-content,
+body.viewer-mode .notion-caption,
+body.viewer-mode #page-title {
+  cursor: default !important;
+}
+
+/* DB 속성 입력 비활성화 */
+body.viewer-mode .db-prop-input,
+body.viewer-mode .db-prop-checkbox,
+body.viewer-mode .db-cell-input,
+body.viewer-mode .db-cell-checkbox {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+/* 이미지 블록 액션 오버레이 숨김 */
+body.viewer-mode .image-actions {
+  display: none !important;
+}
+
+/* 사이드바 문서 컨텍스트 메뉴(삭제/이름변경) 버튼 숨김 */
+body.viewer-mode .document-actions-btn {
+  display: none !important;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2945,6 +2945,11 @@ body.viewer-mode #page-title {
   cursor: default !important;
 }
 
+/* 코드 블록 언어 선택 비활성화 */
+body.viewer-mode .code-language-select {
+  pointer-events: none;
+}
+
 /* DB 속성 입력 비활성화 */
 body.viewer-mode .db-prop-input,
 body.viewer-mode .db-prop-checkbox,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2810,15 +2810,15 @@ body.lightbox-open {
   position: fixed;
   inset: 0;
   z-index: 1000;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(2px);
 }
 
-.login-modal-overlay[hidden] {
-  display: none;
+.login-modal-overlay.is-open {
+  display: flex;
 }
 
 .login-modal {

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,5 +1,15 @@
 // ── API helpers ──────────────────────────────────────────────────────────────
 
+/**
+ * 403 응답(권한 없음) 여부를 확인하고, 해당 시 사용자에게 안내한다.
+ * 각 쓰기 API 래퍼의 에러 처리에서 사용한다.
+ */
+function _checkPermission(res) {
+  if (res.status === 403) {
+    throw new Error("로그인이 필요합니다. 우상단의 로그인 버튼을 이용해 주세요.");
+  }
+}
+
 export async function fetchDocuments() {
   const res = await fetch('/api/documents');
   if (!res.ok) throw new Error('Failed to fetch documents');
@@ -14,6 +24,7 @@ export async function fetchDocument(documentId) {
 
 export async function apiCreateDocument() {
   const res = await fetch('/api/documents', { method: 'POST' });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to create document');
   return res.json();
 }
@@ -24,11 +35,13 @@ export async function apiUpdateTitle(documentId, title) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ title }),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to update title');
 }
 
 export async function apiDeleteDocument(documentId) {
   const res = await fetch(`/api/documents/${documentId}`, { method: 'DELETE' });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to delete document');
 }
 
@@ -38,6 +51,7 @@ export async function apiPatchBlock(blockId, fields) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(fields),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to update block');
 }
 
@@ -49,12 +63,14 @@ export async function apiCreateBlock(documentId, type, parentBlockId = null, tar
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to create block');
   return res.json();
 }
 
 export async function apiDeleteBlock(blockId) {
   const res = await fetch(`/api/blocks/${blockId}`, { method: 'DELETE' });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to delete block');
 }
 
@@ -64,6 +80,7 @@ export async function apiChangeBlockType(blockId, type) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ type }),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to change block type');
 }
 
@@ -88,6 +105,7 @@ export async function apiUploadImage(file) {
   const form = new FormData();
   form.append('file', file);
   const res = await fetch('/api/upload', { method: 'POST', body: form });
+  _checkPermission(res);
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.detail ?? 'Failed to upload image');
@@ -103,6 +121,7 @@ export async function apiFetchUrlEmbed(url, blockId = null) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  _checkPermission(res);
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.detail ?? 'URL 메타데이터를 가져올 수 없습니다.');
@@ -116,6 +135,7 @@ export async function apiMoveBlock(blockId, beforeBlockId) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ before_block_id: beforeBlockId }),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to move block');
 }
 
@@ -127,6 +147,7 @@ export async function apiAddDbColumn(dbBlockId, name, type = 'text', options = [
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, type, options }),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to add column');
   return res.json();
 }
@@ -137,6 +158,7 @@ export async function apiUpdateDbColumn(dbBlockId, colId, patch) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(patch),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to update column');
 }
 
@@ -144,6 +166,7 @@ export async function apiRemoveDbColumn(dbBlockId, colId) {
   const res = await fetch(`/api/database/blocks/${dbBlockId}/schema/columns/${colId}`, {
     method: 'DELETE',
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to remove column');
 }
 
@@ -153,6 +176,7 @@ export async function apiUpdateDbRowProperties(dbRowBlockId, properties) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ properties }),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to update row properties');
 }
 
@@ -162,5 +186,6 @@ export async function apiPatchDatabaseBlock(dbBlockId, fields) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(fields),
   });
+  _checkPermission(res);
   if (!res.ok) throw new Error('Failed to patch database block');
 }

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -88,6 +88,7 @@ export async function apiUploadFile(file) {
   const form = new FormData();
   form.append('file', file);
   const res = await fetch('/api/files', { method: 'POST', body: form });
+  _checkPermission(res);
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.detail ?? '파일 업로드에 실패했습니다.');
@@ -98,6 +99,7 @@ export async function apiUploadFile(file) {
 export async function apiDeleteFile(fileId) {
   // 이미 없는 파일(404)은 정상으로 처리 — 멱등성 보장
   const res = await fetch(`/api/files/${fileId}`, { method: 'DELETE' });
+  _checkPermission(res);
   if (!res.ok && res.status !== 404) throw new Error('파일 삭제에 실패했습니다.');
 }
 

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,0 +1,75 @@
+// ── 인증 상태 관리 모듈 ──────────────────────────────────────────────────────
+//
+// 전역 인증 상태를 관리하고, 로그인/로그아웃 API를 호출하며,
+// 인증 상태 변경 시 구독자(subscriber)에게 알린다.
+// Ref: Observer 패턴 — https://refactoring.guru/design-patterns/observer
+
+/** @type {{ authenticated: boolean, username: string | null }} */
+let _authState = { authenticated: false, username: null };
+
+/** @type {Set<(state: typeof _authState) => void>} */
+const _subscribers = new Set();
+
+/** 현재 인증 상태를 반환한다 (읽기 전용 복사본). */
+export function getAuthState() {
+  return { ..._authState };
+}
+
+/** 인증 상태가 변경될 때 호출될 콜백을 등록한다. */
+export function onAuthChange(callback) {
+  _subscribers.add(callback);
+  return () => _subscribers.delete(callback);
+}
+
+function _notify() {
+  const snapshot = { ..._authState };
+  _subscribers.forEach((cb) => cb(snapshot));
+}
+
+/** 서버에서 현재 인증 상태를 조회한다 (앱 초기화 시 호출). */
+export async function fetchAuthStatus() {
+  try {
+    const res = await fetch("/api/auth/status");
+    if (!res.ok) return;
+    const data = await res.json();
+    _authState = {
+      authenticated: data.authenticated,
+      username: data.username ?? null,
+    };
+    _notify();
+  } catch {
+    // 네트워크 오류 시 미인증 상태 유지
+  }
+}
+
+/** 로그인 요청을 보낸다. 성공 시 true, 실패 시 에러 메시지 문자열을 반환한다. */
+export async function login(username, password) {
+  const res = await fetch("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    return err.detail ?? "로그인에 실패했습니다.";
+  }
+  const data = await res.json();
+  _authState = { authenticated: true, username: data.username };
+  _notify();
+  return true;
+}
+
+/** 로그아웃 요청을 보낸다. */
+export async function logout() {
+  await fetch("/api/auth/logout", { method: "POST" });
+  _authState = { authenticated: false, username: null };
+  _notify();
+}
+
+/**
+ * 인증이 필요한 API 응답(403)을 처리하는 헬퍼.
+ * 기존 api.js의 fetch 래퍼에서 쓰기 실패 시 사용자에게 안내한다.
+ */
+export function isPermissionError(res) {
+  return res.status === 403;
+}

--- a/static/js/blocks/codeBlock.js
+++ b/static/js/blocks/codeBlock.js
@@ -475,6 +475,7 @@ export function create(block) {
   // ── Click → activate editing ─────────────────────────────────────────────
   codeEl.addEventListener("click", () => {
     if (codeEl.contentEditable === "true") return;
+    if (document.body.classList.contains("viewer-mode")) return;
     codeEl.contentEditable = "true";
     node.classList.add("is-editing");
     codeEl.focus();

--- a/static/js/blocks/textEditing.js
+++ b/static/js/blocks/textEditing.js
@@ -70,6 +70,8 @@ export function makeTextEditable(node, blockId, {
       }
     }
     if (node.contentEditable === "true") return;
+    // Viewer 모드에서는 편집 진입을 차단한다
+    if (document.body.classList.contains("viewer-mode")) return;
     originalHtml = node.innerHTML;
     originalText = node.textContent;
     escaped = false;

--- a/static/js/loginModal.js
+++ b/static/js/loginModal.js
@@ -1,0 +1,195 @@
+// ── 로그인 모달 ──────────────────────────────────────────────────────────────
+//
+// 우상단 로그인 버튼과 모달을 관리한다.
+// 인증 상태에 따라 버튼 텍스트/동작이 전환된다.
+
+import { getAuthState, onAuthChange, login, logout, fetchAuthStatus } from "./auth.js";
+
+/** 로그인 버튼 및 모달을 초기화한다. */
+export function initLoginUI() {
+  _createLoginButton();
+  _createLoginModal();
+
+  // 인증 상태 변경 구독
+  onAuthChange(_updateButtonState);
+  _updateButtonState(getAuthState());
+}
+
+// ── 로그인 버튼 (우상단) ──────────────────────────────────────────────────────
+
+let _loginBtn = null;
+
+function _createLoginButton() {
+  _loginBtn = document.createElement("button");
+  _loginBtn.id = "auth-btn";
+  _loginBtn.type = "button";
+  _loginBtn.className = "auth-btn";
+
+  _loginBtn.addEventListener("click", () => {
+    const state = getAuthState();
+    if (state.authenticated) {
+      _handleLogout();
+    } else {
+      _openModal();
+    }
+  });
+
+  // main-area 내부 상단에 고정 배치
+  const mainArea = document.querySelector(".main-area");
+  if (mainArea) {
+    mainArea.appendChild(_loginBtn);
+  }
+}
+
+function _updateButtonState(state) {
+  if (!_loginBtn) return;
+  if (state.authenticated) {
+    _loginBtn.textContent = "로그아웃";
+    _loginBtn.classList.add("is-authenticated");
+    _loginBtn.title = `${state.username} (로그아웃)`;
+  } else {
+    _loginBtn.textContent = "로그인";
+    _loginBtn.classList.remove("is-authenticated");
+    _loginBtn.title = "관리자 로그인";
+  }
+}
+
+async function _handleLogout() {
+  await logout();
+  // 페이지를 새로고침하여 read-only 상태로 전환
+  window.location.reload();
+}
+
+// ── 로그인 모달 ──────────────────────────────────────────────────────────────
+
+let _modal = null;
+let _usernameInput = null;
+let _passwordInput = null;
+let _errorMsg = null;
+
+function _createLoginModal() {
+  _modal = document.createElement("div");
+  _modal.className = "login-modal-overlay";
+  _modal.hidden = true;
+
+  const dialog = document.createElement("div");
+  dialog.className = "login-modal";
+  dialog.setAttribute("role", "dialog");
+  dialog.setAttribute("aria-label", "관리자 로그인");
+
+  // 제목
+  const title = document.createElement("h2");
+  title.className = "login-modal-title";
+  title.textContent = "관리자 로그인";
+  dialog.appendChild(title);
+
+  // 에러 메시지
+  _errorMsg = document.createElement("p");
+  _errorMsg.className = "login-modal-error";
+  _errorMsg.hidden = true;
+  dialog.appendChild(_errorMsg);
+
+  // 폼
+  const form = document.createElement("form");
+  form.className = "login-modal-form";
+  form.addEventListener("submit", _handleSubmit);
+
+  _usernameInput = _createField(form, "text", "아이디", "username");
+  _passwordInput = _createField(form, "password", "비밀번호", "password");
+
+  const submitBtn = document.createElement("button");
+  submitBtn.type = "submit";
+  submitBtn.className = "login-modal-submit";
+  submitBtn.textContent = "로그인";
+  form.appendChild(submitBtn);
+
+  dialog.appendChild(form);
+
+  // 닫기 버튼
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.className = "login-modal-close";
+  closeBtn.setAttribute("aria-label", "닫기");
+  closeBtn.textContent = "✕";
+  closeBtn.addEventListener("click", _closeModal);
+  dialog.appendChild(closeBtn);
+
+  _modal.appendChild(dialog);
+
+  // 오버레이 클릭 시 닫기
+  _modal.addEventListener("click", (e) => {
+    if (e.target === _modal) _closeModal();
+  });
+
+  document.body.appendChild(_modal);
+}
+
+function _createField(form, type, label, name) {
+  const group = document.createElement("div");
+  group.className = "login-field";
+
+  const lbl = document.createElement("label");
+  lbl.className = "login-field-label";
+  lbl.textContent = label;
+  lbl.htmlFor = `login-${name}`;
+  group.appendChild(lbl);
+
+  const input = document.createElement("input");
+  input.type = type;
+  input.id = `login-${name}`;
+  input.name = name;
+  input.className = "login-field-input";
+  input.required = true;
+  input.autocomplete = type === "password" ? "current-password" : "username";
+  group.appendChild(input);
+
+  form.appendChild(group);
+  return input;
+}
+
+function _openModal() {
+  _modal.hidden = false;
+  _errorMsg.hidden = true;
+  _usernameInput.value = "";
+  _passwordInput.value = "";
+  _usernameInput.focus();
+
+  // Escape로 닫기
+  document.addEventListener("keydown", _onKeydown);
+}
+
+function _closeModal() {
+  _modal.hidden = true;
+  document.removeEventListener("keydown", _onKeydown);
+}
+
+function _onKeydown(e) {
+  if (e.key === "Escape") _closeModal();
+}
+
+async function _handleSubmit(e) {
+  e.preventDefault();
+  const username = _usernameInput.value.trim();
+  const password = _passwordInput.value;
+
+  if (!username || !password) {
+    _showError("아이디와 비밀번호를 입력해 주세요.");
+    return;
+  }
+
+  const result = await login(username, password);
+  if (result === true) {
+    _closeModal();
+    // 페이지를 새로고침하여 write 모드로 전환
+    window.location.reload();
+  } else {
+    _showError(result);
+    _passwordInput.value = "";
+    _passwordInput.focus();
+  }
+}
+
+function _showError(msg) {
+  _errorMsg.textContent = msg;
+  _errorMsg.hidden = false;
+}

--- a/static/js/loginModal.js
+++ b/static/js/loginModal.js
@@ -3,7 +3,7 @@
 // 우상단 로그인 버튼과 모달을 관리한다.
 // 인증 상태에 따라 버튼 텍스트/동작이 전환된다.
 
-import { getAuthState, onAuthChange, login, logout, fetchAuthStatus } from "./auth.js";
+import { getAuthState, onAuthChange, login, logout } from "./auth.js";
 
 /** 로그인 버튼 및 모달을 초기화한다. */
 export function initLoginUI() {

--- a/static/js/loginModal.js
+++ b/static/js/loginModal.js
@@ -70,7 +70,6 @@ let _errorMsg = null;
 function _createLoginModal() {
   _modal = document.createElement("div");
   _modal.className = "login-modal-overlay";
-  _modal.hidden = true;
 
   const dialog = document.createElement("div");
   dialog.className = "login-modal";
@@ -148,7 +147,7 @@ function _createField(form, type, label, name) {
 }
 
 function _openModal() {
-  _modal.hidden = false;
+  _modal.classList.add("is-open");
   _errorMsg.hidden = true;
   _usernameInput.value = "";
   _passwordInput.value = "";
@@ -159,7 +158,7 @@ function _openModal() {
 }
 
 function _closeModal() {
-  _modal.hidden = true;
+  _modal.classList.remove("is-open");
   document.removeEventListener("keydown", _onKeydown);
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -10,12 +10,26 @@ import {
   apiMoveBlock,
   apiUpdateDbRowProperties,
 } from "./api.js";
+import { fetchAuthStatus, getAuthState, onAuthChange } from "./auth.js";
+import { initLoginUI } from "./loginModal.js";
 import { openPagePickerModal } from "./pagePickerModal.js";
 import { callbacks, renderBlock, renderDocument, focusBlock } from "./blockRenderers.js";
 import { addDocumentItem, closeAllMenus, setActiveItem, enterInlineEdit } from "./documentList.js";
 import { initSidebar } from "./sidebar.js";
 
 async function initGallery() {
+  // 인증 상태 확인 및 로그인 UI 초기화
+  await fetchAuthStatus();
+  initLoginUI();
+
+  // Viewer 모드: 미인증 시 body에 viewer-mode 클래스를 부여하여
+  // CSS로 쓰기 관련 UI를 일괄 숨긴다.
+  function applyViewerMode(state) {
+    document.body.classList.toggle("viewer-mode", !state.authenticated);
+  }
+  applyViewerMode(getAuthState());
+  onAuthChange(applyViewerMode);
+
   const root = document.getElementById('block-root');
   const list = document.getElementById('document-list');
   const newDocBtn = document.getElementById('new-document-btn');
@@ -29,6 +43,7 @@ async function initGallery() {
 
   pageTitle.addEventListener('click', () => {
     if (pageTitle.contentEditable === 'true' || !activeDocId) return;
+    if (!getAuthState().authenticated) return;
     titleOriginal = pageTitle.textContent;
     titleEscaped = false;
     pageTitle.contentEditable = 'true';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 """Shared pytest fixtures."""
 from __future__ import annotations
 
+import os
+
+# 테스트 환경에서 관리자 자격 증명을 고정한다.
+# config.py가 모듈 임포트 시 환경변수를 읽으므로, 최상위에서 설정해야 한다.
+os.environ.setdefault("ADMIN_PASSWORD", "admin1234")
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -55,6 +61,9 @@ def client(engine):
   app.dependency_overrides[get_repository] = _override
   with TestClient(app) as c:
     # 관리자 로그인 — 세션 쿠키가 TestClient에 자동 저장됨
-    c.post("/api/auth/login", json={"username": "admin", "password": "admin1234"})
+    login_res = c.post("/api/auth/login", json={"username": "admin", "password": "admin1234"})
+    assert login_res.status_code == 200, (
+      f"Admin auto-login failed: status={login_res.status_code}, body={login_res.text}"
+    )
     yield c
   app.dependency_overrides.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,11 @@ def repo(session):
 
 @pytest.fixture()
 def client(engine):
-  """TestClient with in-memory DB injected via dependency override."""
+  """TestClient with in-memory DB and admin session pre-authenticated.
+
+  기존 테스트는 모두 관리자 권한이 필요한 쓰기 작업을 포함하므로,
+  테스트 시작 시 자동으로 로그인하여 세션 쿠키를 설정한다.
+  """
   from main import app
   from app.dependencies import get_repository
 
@@ -50,5 +54,7 @@ def client(engine):
 
   app.dependency_overrides[get_repository] = _override
   with TestClient(app) as c:
+    # 관리자 로그인 — 세션 쿠키가 TestClient에 자동 저장됨
+    c.post("/api/auth/login", json={"username": "admin", "password": "admin1234"})
     yield c
   app.dependency_overrides.clear()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,285 @@
+"""관리자 인증 및 권한 제어 테스트.
+
+검증 시나리오:
+  1. 로그인 성공/실패
+  2. 로그아웃 후 세션 무효화
+  3. 인증 상태 조회 (GET /api/auth/status)
+  4. Viewer의 쓰기 요청 차단 (403)
+  5. 관리자 인증 후 쓰기 요청 허용
+  6. 세션 만료 후 쓰기 요청 차단
+
+Ref: https://fastapi.tiangolo.com/tutorial/testing/
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.auth.config import SESSION_COOKIE_NAME
+from app.auth.session import SessionStore, session_store
+from app.models.orm import Base
+from app.repositories.sqlite_blocks import SQLiteBlockRepository
+
+
+@pytest.fixture()
+def engine():
+  eng = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+  )
+  Base.metadata.create_all(eng)
+  return eng
+
+
+@pytest.fixture()
+def client(engine):
+  """TestClient with in-memory DB injected via dependency override."""
+  from main import app
+  from app.dependencies import get_repository
+
+  def _override():
+    with Session(engine) as s:
+      yield SQLiteBlockRepository(s)
+
+  app.dependency_overrides[get_repository] = _override
+  with TestClient(app) as c:
+    yield c
+  app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_sessions():
+  """각 테스트 전후로 세션 저장소를 초기화한다."""
+  session_store._sessions.clear()
+  yield
+  session_store._sessions.clear()
+
+
+def _login(client: TestClient, username: str = "admin", password: str = "admin1234") -> TestClient:
+  """로그인 헬퍼 — 세션 쿠키를 client에 설정한다."""
+  res = client.post("/api/auth/login", json={"username": username, "password": password})
+  assert res.status_code == 200
+  return client
+
+
+# ── 로그인/로그아웃 테스트 ──────────────────────────────────────────────────
+
+class TestLogin:
+  def test_login_success(self, client: TestClient):
+    res = client.post("/api/auth/login", json={"username": "admin", "password": "admin1234"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["message"] == "로그인 성공"
+    assert data["username"] == "admin"
+    assert SESSION_COOKIE_NAME in res.cookies
+
+  def test_login_wrong_password(self, client: TestClient):
+    res = client.post("/api/auth/login", json={"username": "admin", "password": "wrong"})
+    assert res.status_code == 401
+    assert "올바르지 않습니다" in res.json()["detail"]
+
+  def test_login_wrong_username(self, client: TestClient):
+    res = client.post("/api/auth/login", json={"username": "hacker", "password": "admin1234"})
+    assert res.status_code == 401
+
+  def test_login_empty_credentials(self, client: TestClient):
+    res = client.post("/api/auth/login", json={"username": "", "password": ""})
+    assert res.status_code == 401
+
+
+# ── 로그아웃 테스트 ────────────────────────────────────────────────────────
+
+class TestLogout:
+  def test_logout_clears_session(self, client: TestClient):
+    _login(client)
+    # 로그아웃
+    res = client.post("/api/auth/logout")
+    assert res.status_code == 200
+    assert res.json()["message"] == "로그아웃 완료"
+    # 로그아웃 후 상태 확인
+    status = client.get("/api/auth/status")
+    assert status.json()["authenticated"] is False
+
+  def test_logout_without_session(self, client: TestClient):
+    """세션 없이 로그아웃해도 에러가 발생하지 않는다."""
+    res = client.post("/api/auth/logout")
+    assert res.status_code == 200
+
+
+# ── 인증 상태 조회 테스트 ──────────────────────────────────────────────────
+
+class TestAuthStatus:
+  def test_status_unauthenticated(self, client: TestClient):
+    res = client.get("/api/auth/status")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["authenticated"] is False
+    assert data["username"] is None
+
+  def test_status_authenticated(self, client: TestClient):
+    _login(client)
+    res = client.get("/api/auth/status")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["authenticated"] is True
+    assert data["username"] == "admin"
+
+
+# ── Viewer 쓰기 차단 테스트 ───────────────────────────────────────────────
+
+class TestViewerWriteBlocked:
+  """미인증 상태에서 모든 쓰기 엔드포인트가 403을 반환하는지 검증한다."""
+
+  def test_create_document_blocked(self, client: TestClient):
+    res = client.post("/api/documents")
+    assert res.status_code == 403
+
+  def test_update_title_blocked(self, client: TestClient):
+    res = client.patch("/api/documents/fake-id", json={"title": "test"})
+    assert res.status_code == 403
+
+  def test_create_block_blocked(self, client: TestClient):
+    res = client.post("/api/documents/fake-id/blocks", json={"type": "text"})
+    assert res.status_code == 403
+
+  def test_delete_document_blocked(self, client: TestClient):
+    res = client.delete("/api/documents/fake-id")
+    assert res.status_code == 403
+
+  def test_patch_block_blocked(self, client: TestClient):
+    res = client.patch("/api/blocks/fake-id", json={"text": "hello"})
+    assert res.status_code == 403
+
+  def test_move_block_blocked(self, client: TestClient):
+    res = client.patch("/api/blocks/fake-id/position", json={})
+    assert res.status_code == 403
+
+  def test_change_block_type_blocked(self, client: TestClient):
+    res = client.patch("/api/blocks/fake-id/type", json={"type": "code"})
+    assert res.status_code == 403
+
+  def test_delete_block_blocked(self, client: TestClient):
+    res = client.delete("/api/blocks/fake-id")
+    assert res.status_code == 403
+
+  def test_upload_image_blocked(self, client: TestClient):
+    res = client.post("/api/upload", files={"file": ("test.png", b"fake", "image/png")})
+    assert res.status_code == 403
+
+  def test_database_patch_blocked(self, client: TestClient):
+    res = client.patch("/api/database/blocks/fake-id", json={"title": "test"})
+    assert res.status_code == 403
+
+  def test_database_add_column_blocked(self, client: TestClient):
+    res = client.post("/api/database/blocks/fake-id/schema/columns", json={"name": "col"})
+    assert res.status_code == 403
+
+  def test_database_remove_column_blocked(self, client: TestClient):
+    res = client.delete("/api/database/blocks/fake-id/schema/columns/fake-col")
+    assert res.status_code == 403
+
+
+# ── 관리자 쓰기 허용 테스트 ───────────────────────────────────────────────
+
+class TestAdminWriteAllowed:
+  """인증 후 쓰기 엔드포인트가 정상 동작하는지 검증한다."""
+
+  def test_create_document_allowed(self, client: TestClient):
+    _login(client)
+    res = client.post("/api/documents")
+    assert res.status_code == 201
+    assert "id" in res.json()
+
+  def test_create_and_patch_block(self, client: TestClient):
+    _login(client)
+    doc = client.post("/api/documents").json()
+    block = client.post(
+      f"/api/documents/{doc['id']}/blocks",
+      json={"type": "text"},
+    ).json()
+    res = client.patch(f"/api/blocks/{block['id']}", json={"text": "hello"})
+    assert res.status_code == 200
+
+  def test_delete_document_allowed(self, client: TestClient):
+    _login(client)
+    doc = client.post("/api/documents").json()
+    res = client.delete(f"/api/documents/{doc['id']}")
+    assert res.status_code == 204
+
+
+# ── 세션 만료 테스트 ───────────────────────────────────────────────────────
+
+class TestSessionExpiry:
+  def test_expired_session_blocks_write(self, client: TestClient):
+    _login(client)
+    # 세션을 수동으로 만료시킨다
+    for entry in session_store._sessions.values():
+      entry.expires_at = time.time() - 1
+    res = client.post("/api/documents")
+    assert res.status_code == 403
+    assert "만료" in res.json()["detail"]
+
+
+# ── 로그아웃 후 쓰기 차단 테스트 ──────────────────────────────────────────
+
+class TestLogoutBlocksWrite:
+  def test_write_blocked_after_logout(self, client: TestClient):
+    _login(client)
+    # 쓰기 가능 확인
+    doc = client.post("/api/documents")
+    assert doc.status_code == 201
+    # 로그아웃
+    client.post("/api/auth/logout")
+    # 쓰기 차단 확인
+    res = client.post("/api/documents")
+    assert res.status_code == 403
+
+
+# ── 읽기 API 접근 테스트 ──────────────────────────────────────────────────
+
+class TestReadAccessAllowed:
+  """미인증 상태에서도 읽기 API는 정상 동작해야 한다."""
+
+  def test_list_documents_allowed(self, client: TestClient):
+    res = client.get("/api/documents")
+    assert res.status_code == 200
+
+  def test_get_document_returns_404_not_403(self, client: TestClient):
+    """존재하지 않는 문서 조회는 403이 아닌 404를 반환한다."""
+    res = client.get("/api/documents/nonexistent")
+    assert res.status_code == 404
+
+
+# ── 세션 저장소 단위 테스트 ───────────────────────────────────────────────
+
+class TestSessionStore:
+  def test_create_and_validate(self):
+    store = SessionStore()
+    token = store.create("admin")
+    assert store.validate(token) == "admin"
+
+  def test_validate_invalid_token(self):
+    store = SessionStore()
+    assert store.validate("bogus-token") is None
+
+  def test_revoke(self):
+    store = SessionStore()
+    token = store.create("admin")
+    assert store.revoke(token) is True
+    assert store.validate(token) is None
+    assert store.revoke(token) is False
+
+  def test_cleanup_expired(self):
+    store = SessionStore()
+    token = store.create("admin")
+    # 수동 만료
+    store._sessions[token].expires_at = time.time() - 1
+    removed = store.cleanup_expired()
+    assert removed == 1
+    assert store.validate(token) is None

--- a/tests/test_file_upload_download.py
+++ b/tests/test_file_upload_download.py
@@ -65,6 +65,7 @@ def file_client(file_engine, tmp_path, monkeypatch):
 
   app.dependency_overrides[get_session] = _override_session
   with TestClient(app) as c:
+    c.post("/api/auth/login", json={"username": "admin", "password": "admin1234"})
     yield c
   app.dependency_overrides.pop(get_session, None)
 


### PR DESCRIPTION
## 이슈
- closes #43

## 배경/목적
Viewer용 읽기 전용 화면과 관리자 쓰기 권한을 분리하여 운영 안전성을 강화한다.
미인증 사용자는 문서 조회만 가능하고, 관리자는 로그인 후 생성/수정/삭제를 수행할 수 있다.

## 변경 사항

### 백엔드
- **인증 모듈 신규** (`app/auth/`): 환경변수 기반 자격 증명 설정, 인메모리 세션 저장소, 인증 서비스
- **인증 API** (`app/routers/auth.py`): `POST /login`, `POST /logout`, `GET /status`
- **쓰기 권한 보호**: 모든 쓰기 엔드포인트(15개)에 `Depends(require_admin)` 적용 — 미인증 시 403
- 읽기(GET) API는 인증 불요

### 프론트엔드
- **로그인 UI** (`auth.js`, `loginModal.js`): 우상단 로그인/로그아웃 버튼, 모달 다이얼로그
- **Viewer read-only 모드**: `body.viewer-mode` CSS 클래스로 쓰기 UI 일괄 숨김
- **JS 편집 차단**: 텍스트 블록, 코드 블록, 페이지 타이틀의 `contentEditable` 진입 차단
- **API 403 안내**: 모든 쓰기 API 래퍼에서 권한 에러 시 사용자 안내 메시지 표시
- 이미지 크게 보기는 Viewer에서도 사용 가능

### 테스트
- `tests/test_auth.py`: 31개 테스트 (로그인/로그아웃, 세션 만료, Viewer 쓰기 차단, 관리자 쓰기 허용, 읽기 접근 보장)
- 기존 `conftest.py`에 자동 로그인 적용 — 기존 278개 테스트 회귀 없음

## 테스트 결과
- 전체 309개 테스트 통과 (`uv run pytest tests/ -v`)

## 리뷰 포인트
- 인메모리 세션은 프로세스 재시작 시 초기화됨 — 스케일아웃 시 외부 저장소(Redis 등) 전환 필요
- 기본 자격 증명 `admin/admin1234` — 프로덕션에서 환경변수(`ADMIN_USERNAME`, `ADMIN_PASSWORD`)로 반드시 변경
- `HttpOnly` + `SameSite=Lax` 쿠키 사용, `COOKIE_SECURE`는 HTTPS 환경에서 `true`로 설정