### PR TITLE
[FEAT#35] Notion Export(HTML/Markdown) → Project 페이지 변환 Import

### DIFF
--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from pathlib import PurePosixPath
 from typing import Any
 
 from pydantic import TypeAdapter
@@ -327,6 +328,201 @@ class SQLiteBlockRepository:
     data = self._build_child_document_row(parent_id)
     self._session.commit()
     return data
+
+  # ── Notion Import 영속화 ────────────────────────────────────────────────────
+
+  def import_pages(
+    self,
+    pages: list[dict[str, Any]],
+    image_url_resolver: "callable[[dict[str, Any]], None] | None" = None,
+  ) -> dict[str, Any]:
+    """파싱된 Notion 페이지 리스트를 문서/블록 트리로 영속화합니다.
+
+    트리 구성:
+      - 첫 번째 페이지 → 루트 문서
+      - 나머지 페이지 → 경로 기반으로 부모 문서를 결정하고 부모 문서에
+        PageBlock으로 연결
+
+    성능/안정성 보장:
+      - 블록 저장은 명시적 스택을 사용한 반복문으로 처리 (재귀 깊이 제한 회피)
+      - 부모 문서별 position 카운터를 메모리에 캐싱 (max() 쿼리 N+1 방지)
+      - 페이지·블록 추가는 단일 트랜잭션에서 수행
+
+    Args:
+      pages: 파싱된 페이지 dict 리스트.
+        각 항목: {"path": str, "title": str, "blocks": list, "sub_page_links": list}
+      image_url_resolver: 블록 트리의 이미지 URL을 실제 저장 경로로 갱신하는
+        선택적 콜백. import 호출자가 이미지 처리(저장/리사이즈) 정책을 주입하기
+        위해 사용한다.
+
+    Returns:
+      {"id": root_doc_id, "title": root_title}
+    """
+    if not pages:
+      raise ValueError("import할 페이지가 없습니다.")
+
+    # path → document_id 매핑 (부모 추정용)
+    path_to_doc_id: dict[str, str] = {}
+    # (document_id, parent_block_id|None) → 다음 position 카운터
+    position_cursor: dict[tuple[str, str | None], int] = {}
+
+    first_page = pages[0]
+    root_id = self._add_imported_document(
+      first_page["title"], parent_id=None,
+    )
+    path_to_doc_id[first_page["path"]] = root_id
+
+    self._persist_imported_blocks(
+      root_id, first_page["blocks"], position_cursor, image_url_resolver,
+    )
+
+    for page in pages[1:]:
+      parent_doc_id = self._resolve_import_parent(
+        page["path"], path_to_doc_id, root_id,
+      )
+      child_doc_id = self._add_imported_document(
+        page["title"], parent_id=parent_doc_id,
+      )
+      path_to_doc_id[page["path"]] = child_doc_id
+
+      self._add_imported_page_block(
+        parent_doc_id, child_doc_id, position_cursor,
+      )
+      self._persist_imported_blocks(
+        child_doc_id, page["blocks"], position_cursor, image_url_resolver,
+      )
+
+    self._session.commit()
+    return {"id": root_id, "title": first_page["title"]}
+
+  def _add_imported_document(self, title: str, parent_id: str | None) -> str:
+    """Import 전용 — DocumentRow를 세션에 추가하고 id를 반환한다 (commit 안 함)."""
+    doc_id = str(uuid.uuid4())
+    self._session.add(DocumentRow(
+      id=doc_id,
+      title=title or "Untitled",
+      subtitle="",
+      parent_id=parent_id,
+    ))
+    self._session.flush()
+    return doc_id
+
+  def _add_imported_page_block(
+    self,
+    parent_doc_id: str,
+    child_doc_id: str,
+    position_cursor: dict[tuple[str, str | None], int],
+  ) -> None:
+    """부모 문서에 하위 페이지를 가리키는 PageBlock을 추가한다.
+
+    position은 카운터 캐시에서 가져오며, 캐시 미스 시에만 DB에서 조회한다.
+    """
+    cursor_key = (parent_doc_id, None)
+    next_pos = self._next_position(cursor_key, position_cursor)
+
+    block_id = str(uuid.uuid4())
+    content = json.dumps(
+      {"document_id": child_doc_id, "is_reference": False},
+      ensure_ascii=False,
+    )
+    self._session.add(BlockRow(
+      id=block_id,
+      document_id=parent_doc_id,
+      parent_block_id=None,
+      type="page",
+      position=next_pos,
+      content_json=content,
+    ))
+
+  def _persist_imported_blocks(
+    self,
+    document_id: str,
+    blocks: list[dict[str, Any]],
+    position_cursor: dict[tuple[str, str | None], int],
+    image_url_resolver: "callable[[dict[str, Any]], None] | None",
+  ) -> None:
+    """블록 트리를 명시적 스택 기반 반복으로 영속화한다.
+
+    재귀 호출을 사용하지 않기 때문에 매우 깊은 Notion 페이지(중첩 토글 등)도
+    파이썬 재귀 깊이 제한에 영향받지 않는다.
+    """
+    # 스택에 (document_id, parent_block_id, blocks_list)를 푸시
+    stack: list[tuple[str, str | None, list[dict[str, Any]]]] = [
+      (document_id, None, blocks),
+    ]
+
+    while stack:
+      doc_id, parent_block_id, current_blocks = stack.pop()
+      cursor_key = (doc_id, parent_block_id)
+
+      for block in current_blocks:
+        if image_url_resolver and block.get("type") == "image":
+          image_url_resolver(block)
+
+        block_id = block.get("id") or str(uuid.uuid4())
+        block_type = block["type"]
+        children = block.pop("children", None)
+
+        # content_json — id/type 컬럼은 제외
+        content = {k: v for k, v in block.items() if k not in ("id", "type")}
+        next_pos = self._next_position(cursor_key, position_cursor)
+
+        self._session.add(BlockRow(
+          id=block_id,
+          document_id=doc_id,
+          parent_block_id=parent_block_id,
+          type=block_type,
+          position=next_pos,
+          content_json=json.dumps(content, ensure_ascii=False),
+        ))
+
+        if children:
+          stack.append((doc_id, block_id, children))
+
+  def _next_position(
+    self,
+    cursor_key: tuple[str, str | None],
+    position_cursor: dict[tuple[str, str | None], int],
+  ) -> int:
+    """캐시된 position 카운터를 1 증가시켜 반환한다.
+
+    캐시에 키가 없으면 빈 컨테이너로 간주(=0)하고 1부터 시작한다.
+    Notion import는 항상 빈 문서에 새 블록을 추가하므로 DB 조회가 불필요하다.
+    """
+    next_pos = position_cursor.get(cursor_key, 0) + 1
+    position_cursor[cursor_key] = next_pos
+    return next_pos
+
+  def _resolve_import_parent(
+    self,
+    page_path: str,
+    path_to_doc_id: dict[str, str],
+    root_id: str,
+  ) -> str:
+    """페이지 경로 기반으로 부모 문서 id를 결정한다.
+
+    Notion export 디렉터리 구조:
+      Root.html / Root.md
+      Root/
+        Child.html / Child.md
+        Child/
+          GrandChild.html / GrandChild.md
+
+    부모 페이지의 stem(확장자 제외 파일명)은 자식 디렉터리 이름과 일치한다.
+    """
+    parts = PurePosixPath(page_path).parts
+    if len(parts) < 2:
+      return root_id
+
+    parent_dir_name = parts[-2]
+    for registered_path, doc_id in path_to_doc_id.items():
+      reg_stem = PurePosixPath(registered_path).stem
+      if reg_stem == parent_dir_name:
+        return doc_id
+      if str(PurePosixPath(*parts[:-1])).endswith(reg_stem):
+        return doc_id
+
+    return root_id
 
   def _build_child_document_row(self, parent_id: str, source_block_id: str | None = None) -> dict:
     """Add a child DocumentRow to the session without committing.

--- a/app/routers/notion_import.py
+++ b/app/routers/notion_import.py
@@ -1,20 +1,20 @@
-"""Notion Export HTML Import API 라우터.
+"""Notion Export Import API 라우터.
 
-Notion에서 export한 HTML 파일(단일 .html 또는 .zip 아카이브)을 업로드하면
+Notion에서 export한 파일(단일 .html / .md 또는 .zip 아카이브)을 업로드하면
 프로젝트 페이지 구조로 자동 변환합니다.
 
 엔드포인트:
-  POST /api/import/notion — Notion HTML/ZIP 파일 업로드 및 변환
+  POST /api/import/notion — Notion HTML/Markdown/ZIP 파일 업로드 및 변환
 
 Ref:
   - Notion Export 포맷: https://www.notion.so/help/export-your-content
   - FastAPI File Upload: https://fastapi.tiangolo.com/tutorial/request-files/
+  - OWASP File Upload Cheat Sheet:
+      https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
 """
 from __future__ import annotations
 
-import json
 import logging
-import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
@@ -38,8 +38,13 @@ router = APIRouter(prefix="/api/import", tags=["import"])
 # 업로드 크기 제한: 500 MB (Notion export ZIP은 대용량일 수 있음)
 MAX_IMPORT_BYTES = 500 * 1024 * 1024
 
-# 청크 단위 읽기 크기
+# 청크 단위 읽기 크기 (스트리밍 임시 파일에 기록)
 CHUNK_SIZE = 64 * 1024
+
+# Spool 임계치 — 이 크기까지는 메모리, 초과 시 자동으로 디스크 임시 파일에 보관
+# Ref: Python tempfile.SpooledTemporaryFile —
+#   https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile
+SPOOL_MAX_MEMORY = 5 * 1024 * 1024  # 5 MB
 
 
 # ── 응답 모델 ────────────────────────────────────────────────────────────────────
@@ -54,6 +59,9 @@ class ImportResponse(BaseModel):
 
 
 # ── Import 엔드포인트 ────────────────────────────────────────────────────────────
+
+_ALLOWED_EXTS: tuple[str, ...] = (".html", ".htm", ".md", ".zip")
+
 
 @router.post("/notion", status_code=201, response_model=ImportResponse)
 async def import_notion(
@@ -74,38 +82,24 @@ async def import_notion(
   Raises:
     HTTPException 415: 지원하지 않는 파일 형식
     HTTPException 413: 파일 크기 초과
-    HTTPException 422: 파싱 실패
+    HTTPException 422: 파싱 실패 / 빈 파일 / 변환할 페이지 없음
+    HTTPException 500: 저장 실패
   """
   filename = file.filename or ""
   lower_name = filename.lower()
 
-  _ALLOWED_EXTS = (".html", ".htm", ".md", ".zip")
   if not any(lower_name.endswith(ext) for ext in _ALLOWED_EXTS):
     raise HTTPException(
       status_code=415,
       detail="지원하지 않는 파일 형식입니다. .html, .md 또는 .zip 파일을 업로드해주세요.",
     )
 
-  # 청크 단위로 읽어 메모리 제한 방어
-  chunks: list[bytes] = []
-  total_size = 0
-  while True:
-    chunk = await file.read(CHUNK_SIZE)
-    if not chunk:
-      break
-    total_size += len(chunk)
-    if total_size > MAX_IMPORT_BYTES:
-      raise HTTPException(
-        status_code=413,
-        detail=f"파일 크기가 {MAX_IMPORT_BYTES // (1024 * 1024)} MB를 초과합니다.",
-      )
-    chunks.append(chunk)
-
-  data = b"".join(chunks)
+  data = await _read_upload_to_bytes(file)
   if not data:
     raise HTTPException(status_code=422, detail="빈 파일입니다.")
 
-  # 파싱
+  # 파싱 단계 — ValueError는 사용자 제어 입력 검증 결과이므로 메시지 노출 OK,
+  # 그 외 예외는 내부 정보 누출 방지를 위해 로그만 남기고 일반 메시지로 응답.
   try:
     if lower_name.endswith(".zip"):
       result = extract_and_parse_zip(data)
@@ -115,19 +109,26 @@ async def import_notion(
       result = parse_single_html(data)
   except ValueError as exc:
     raise HTTPException(status_code=422, detail=str(exc))
-  except Exception as exc:
-    logger.error("Notion import 파싱 실패: %s", exc)
-    raise HTTPException(status_code=422, detail=f"파싱 중 오류가 발생했습니다: {exc}")
+  except Exception:
+    logger.exception("Notion import 파싱 실패")
+    raise HTTPException(
+      status_code=422,
+      detail="파일을 파싱하는 중 오류가 발생했습니다.",
+    )
 
   if not result.pages:
     raise HTTPException(status_code=422, detail="변환할 페이지가 없습니다.")
 
-  # DB에 문서/블록 생성
+  # DB 영속화 — 내부 예외는 클라이언트에 노출하지 않음
   try:
-    root_doc = _persist_import(result, repo)
-  except Exception as exc:
-    logger.error("Notion import 저장 실패: %s", exc)
-    raise HTTPException(status_code=500, detail=f"저장 중 오류가 발생했습니다: {exc}")
+    image_resolver = _make_image_resolver(result.image_mappings)
+    root_doc = repo.import_pages(result.pages, image_url_resolver=image_resolver)
+  except Exception:
+    logger.exception("Notion import 저장 실패")
+    raise HTTPException(
+      status_code=500,
+      detail="가져온 데이터를 저장하는 중 오류가 발생했습니다.",
+    )
 
   return ImportResponse(
     document_id=root_doc["id"],
@@ -137,226 +138,59 @@ async def import_notion(
   )
 
 
-# ── 영속화 로직 ─────────────────────────────────────────────────────────────────
+# ── 업로드 스트리밍 ─────────────────────────────────────────────────────────────
 
-def _persist_import(
-  result: ImportResult,
-  repo: SQLiteBlockRepository,
-) -> dict[str, Any]:
-  """파싱된 Import 결과를 DB에 문서/블록으로 저장합니다.
+async def _read_upload_to_bytes(file: UploadFile) -> bytes:
+  """업로드 파일을 청크 단위로 읽어 메모리 중복 없이 단일 bytes로 반환합니다.
 
-  페이지 계층 구조:
-    - 최상위 페이지 → 루트 문서
-    - 하위 페이지 → 루트 문서의 하위 PageBlock으로 연결
+  메모리 안전성:
+    - SpooledTemporaryFile에 청크를 누적 기록 → 임계치(SPOOL_MAX_MEMORY)
+      초과 시 자동으로 디스크로 spill되어 RSS 사용량 상한을 보장한다.
+    - 최종적으로 bytes 한 카피만 만들어 반환하므로 list+join() 방식 대비
+      피크 메모리가 절반 수준으로 낮아진다.
 
-  이미지 처리:
-    - ZIP 내 이미지 파일은 process_image()를 통해 저장
-    - 블록의 url 필드를 실제 저장 경로로 갱신
+  Ref: tempfile.SpooledTemporaryFile —
+    https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile
   """
-  from app.models.orm import BlockRow, DocumentRow
+  import tempfile
 
-  session = repo._session
-
-  # 페이지 경로 → 생성된 document_id 매핑
-  path_to_doc_id: dict[str, str] = {}
-
-  # 1단계: 루트 문서 결정 — 첫 번째 페이지 또는 단일 페이지
-  first_page = result.pages[0]
-
-  # 단일 페이지인 경우 바로 루트 문서로 생성
-  if len(result.pages) == 1:
-    root_id = str(uuid.uuid4())
-    session.add(DocumentRow(
-      id=root_id,
-      title=first_page["title"],
-      subtitle="",
-      parent_id=None,
-    ))
-    session.flush()
-    path_to_doc_id[first_page["path"]] = root_id
-
-    # 이미지 URL 치환 후 블록 저장
-    _upload_images_in_blocks(first_page["blocks"], result.image_mappings)
-    _persist_blocks(session, root_id, first_page["blocks"])
-    session.commit()
-
-    return {"id": root_id, "title": first_page["title"]}
-
-  # 다중 페이지: 첫 번째 페이지를 루트 문서로, 나머지를 하위로 연결
-  root_id = str(uuid.uuid4())
-  session.add(DocumentRow(
-    id=root_id,
-    title=first_page["title"],
-    subtitle="",
-    parent_id=None,
-  ))
-  session.flush()
-  path_to_doc_id[first_page["path"]] = root_id
-
-  _upload_images_in_blocks(first_page["blocks"], result.image_mappings)
-  _persist_blocks(session, root_id, first_page["blocks"])
-
-  # 2단계: 하위 페이지 생성 및 PageBlock으로 연결
-  for page in result.pages[1:]:
-    child_doc_id = str(uuid.uuid4())
-    # 부모 문서 결정: 경로 기반 계층 탐색
-    parent_doc_id = _find_parent_doc_id(page["path"], path_to_doc_id, root_id)
-
-    session.add(DocumentRow(
-      id=child_doc_id,
-      title=page["title"],
-      subtitle="",
-      parent_id=parent_doc_id,
-    ))
-    session.flush()
-    path_to_doc_id[page["path"]] = child_doc_id
-
-    # 부모 문서에 PageBlock 추가
-    _add_page_block(session, parent_doc_id, child_doc_id, page["title"])
-
-    # 이미지 URL 치환 후 블록 저장
-    _upload_images_in_blocks(page["blocks"], result.image_mappings)
-    _persist_blocks(session, child_doc_id, page["blocks"])
-
-  session.commit()
-  return {"id": root_id, "title": first_page["title"]}
+  total = 0
+  with tempfile.SpooledTemporaryFile(max_size=SPOOL_MAX_MEMORY) as buf:
+    while True:
+      chunk = await file.read(CHUNK_SIZE)
+      if not chunk:
+        break
+      total += len(chunk)
+      if total > MAX_IMPORT_BYTES:
+        raise HTTPException(
+          status_code=413,
+          detail=f"파일 크기가 {MAX_IMPORT_BYTES // (1024 * 1024)} MB를 초과합니다.",
+        )
+      buf.write(chunk)
+    buf.seek(0)
+    return buf.read()
 
 
-def _find_parent_doc_id(
-  page_path: str,
-  path_to_doc_id: dict[str, str],
-  root_id: str,
-) -> str:
-  """페이지 경로를 기반으로 부모 문서 ID를 결정합니다.
+# ── 이미지 처리 콜백 ────────────────────────────────────────────────────────────
 
-  Notion export 디렉터리 구조에서 부모 페이지의 HTML 파일은
-  자식 페이지의 디렉터리와 같은 레벨에 위치합니다.
-
-  예시:
-    Root UUID.html          ← 루트
-    Root UUID/
-      Child UUID.html       ← Root의 자식
-      Child UUID/
-        GrandChild UUID.html  ← Child의 자식
-  """
-  from pathlib import PurePosixPath
-
-  parts = PurePosixPath(page_path).parts
-
-  # 부모 디렉터리의 HTML 파일을 역순으로 탐색
-  if len(parts) >= 2:
-    # 부모 디렉터리 이름으로 부모 HTML 파일을 매칭
-    parent_dir = str(PurePosixPath(*parts[:-1]))
-    # parent_dir + ".html" 패턴으로 부모 문서 검색
-    for registered_path, doc_id in path_to_doc_id.items():
-      reg_stem = PurePosixPath(registered_path).stem
-      if parent_dir.endswith(reg_stem):
-        return doc_id
-      # 부분 경로 매칭 — 디렉터리명이 HTML 파일명(확장자 제외)과 동일
-      reg_parts = PurePosixPath(registered_path).parts
-      if len(reg_parts) >= 1:
-        parent_dir_name = parts[-2] if len(parts) >= 2 else ""
-        if reg_parts[-1].replace(".html", "") == parent_dir_name:
-          return doc_id
-
-  return root_id
-
-
-def _add_page_block(
-  session: Any,
-  parent_doc_id: str,
-  child_doc_id: str,
-  title: str,
-) -> None:
-  """부모 문서에 하위 페이지를 가리키는 PageBlock을 추가합니다."""
-  from sqlalchemy import func, select
-
-  from app.models.orm import BlockRow
-
-  # 현재 최대 position 조회
-  max_pos = session.execute(
-    select(func.coalesce(func.max(BlockRow.position), 0))
-    .where(
-      BlockRow.document_id == parent_doc_id,
-      BlockRow.parent_block_id.is_(None),
-    )
-  ).scalar_one()
-
-  block_id = str(uuid.uuid4())
-  content = json.dumps({
-    "document_id": child_doc_id,
-    "is_reference": False,
-  }, ensure_ascii=False)
-
-  session.add(BlockRow(
-    id=block_id,
-    document_id=parent_doc_id,
-    parent_block_id=None,
-    type="page",
-    position=max_pos + 1,
-    content_json=content,
-  ))
-
-
-def _persist_blocks(
-  session: Any,
-  document_id: str,
-  blocks: list[dict[str, Any]],
-  parent_block_id: str | None = None,
-) -> None:
-  """블록 리스트를 DB에 저장합니다.
-
-  컨테이너 블록(toggle, quote, callout)의 children은 재귀적으로 처리됩니다.
-  """
-  from app.models.orm import BlockRow
-
-  for position, block in enumerate(blocks, start=1):
-    block_id = block.get("id", str(uuid.uuid4()))
-    block_type = block["type"]
-
-    # children은 content_json에서 제외 (별도 BlockRow로 저장)
-    children = block.pop("children", None)
-
-    # content_json 구성: id, type은 BlockRow 컬럼이므로 제외
-    content = {k: v for k, v in block.items() if k not in ("id", "type")}
-    content_json = json.dumps(content, ensure_ascii=False)
-
-    session.add(BlockRow(
-      id=block_id,
-      document_id=document_id,
-      parent_block_id=parent_block_id,
-      type=block_type,
-      position=position,
-      content_json=content_json,
-    ))
-
-    # 컨테이너 블록의 자식 재귀 저장
-    if children:
-      _persist_blocks(session, document_id, children, parent_block_id=block_id)
-
-
-def _upload_images_in_blocks(
-  blocks: list[dict[str, Any]],
+def _make_image_resolver(
   image_mappings: dict[str, bytes],
-) -> None:
-  """블록 내 이미지 URL을 실제 업로드된 경로로 치환합니다.
+) -> "callable[[dict[str, Any]], None]":
+  """블록 트리 순회 중 호출되어 이미지 블록의 URL을 실제 저장 경로로 갱신한다.
 
-  ZIP 내부 상대 경로로 참조된 이미지를 process_image()를 통해
-  서버에 저장하고, 블록의 url 필드를 갱신합니다.
+  ZIP 내부 상대 경로(image_mappings 키)로 참조된 이미지는 process_image()를
+  통해 서버에 저장하고, 블록의 url 필드를 갱신한다. 매핑에 없는 외부 URL은
+  그대로 둔다.
   """
-  for block in blocks:
-    if block.get("type") == "image":
-      url = block.get("url", "")
-      if url in image_mappings:
-        try:
-          img_data = image_mappings[url]
-          result = process_image(img_data)
-          block["url"] = result["url"]
-        except Exception as exc:
-          logger.warning("이미지 업로드 실패: %s — %s", url, exc)
-          block["url"] = ""
+  def resolver(block: dict[str, Any]) -> None:
+    url = block.get("url", "")
+    if not url or url not in image_mappings:
+      return
+    try:
+      processed = process_image(image_mappings[url])
+      block["url"] = processed["url"]
+    except Exception:
+      logger.warning("이미지 업로드 실패: %s", url, exc_info=True)
+      block["url"] = ""
 
-    # 재귀: 컨테이너 블록의 children
-    children = block.get("children")
-    if children:
-      _upload_images_in_blocks(children, image_mappings)
+  return resolver

--- a/app/routers/notion_import.py
+++ b/app/routers/notion_import.py
@@ -28,6 +28,7 @@ from app.services.notion_import import (
   ImportResult,
   extract_and_parse_zip,
   parse_single_html,
+  parse_single_markdown,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,11 +61,12 @@ async def import_notion(
   file: UploadFile = File(...),
   repo: SQLiteBlockRepository = Depends(get_repository),
 ) -> ImportResponse:
-  """Notion export HTML/ZIP 파일을 프로젝트 페이지로 변환 import합니다.
+  """Notion export 파일을 프로젝트 페이지로 변환 import합니다.
 
   지원 파일 형식:
-    - .html — 단일 Notion 페이지
-    - .zip  — Notion export 아카이브 (다중 페이지/이미지 포함)
+    - .html — 단일 Notion HTML 페이지
+    - .md   — 단일 Notion Markdown 페이지
+    - .zip  — Notion export 아카이브 (HTML/Markdown + 이미지/CSV 포함)
 
   Returns:
     생성된 루트 문서 ID, 제목, 페이지 수, 변환 리포트.
@@ -77,10 +79,11 @@ async def import_notion(
   filename = file.filename or ""
   lower_name = filename.lower()
 
-  if not (lower_name.endswith(".html") or lower_name.endswith(".htm") or lower_name.endswith(".zip")):
+  _ALLOWED_EXTS = (".html", ".htm", ".md", ".zip")
+  if not any(lower_name.endswith(ext) for ext in _ALLOWED_EXTS):
     raise HTTPException(
       status_code=415,
-      detail="지원하지 않는 파일 형식입니다. .html 또는 .zip 파일을 업로드해주세요.",
+      detail="지원하지 않는 파일 형식입니다. .html, .md 또는 .zip 파일을 업로드해주세요.",
     )
 
   # 청크 단위로 읽어 메모리 제한 방어
@@ -106,6 +109,8 @@ async def import_notion(
   try:
     if lower_name.endswith(".zip"):
       result = extract_and_parse_zip(data)
+    elif lower_name.endswith(".md"):
+      result = parse_single_markdown(data)
     else:
       result = parse_single_html(data)
   except ValueError as exc:

--- a/app/routers/notion_import.py
+++ b/app/routers/notion_import.py
@@ -1,0 +1,357 @@
+"""Notion Export HTML Import API 라우터.
+
+Notion에서 export한 HTML 파일(단일 .html 또는 .zip 아카이브)을 업로드하면
+프로젝트 페이지 구조로 자동 변환합니다.
+
+엔드포인트:
+  POST /api/import/notion — Notion HTML/ZIP 파일 업로드 및 변환
+
+Ref:
+  - Notion Export 포맷: https://www.notion.so/help/export-your-content
+  - FastAPI File Upload: https://fastapi.tiangolo.com/tutorial/request-files/
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from app.auth.dependencies import require_admin
+from app.dependencies import get_repository
+from app.repositories.sqlite_blocks import SQLiteBlockRepository
+from app.services.image import process_image
+from app.services.notion_import import (
+  ImportResult,
+  extract_and_parse_zip,
+  parse_single_html,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/import", tags=["import"])
+
+# 업로드 크기 제한: 500 MB (Notion export ZIP은 대용량일 수 있음)
+MAX_IMPORT_BYTES = 500 * 1024 * 1024
+
+# 청크 단위 읽기 크기
+CHUNK_SIZE = 64 * 1024
+
+
+# ── 응답 모델 ────────────────────────────────────────────────────────────────────
+
+class ImportResponse(BaseModel):
+  """Import 완료 응답 스키마."""
+
+  document_id: str
+  title: str
+  total_pages: int
+  report: dict[str, Any]
+
+
+# ── Import 엔드포인트 ────────────────────────────────────────────────────────────
+
+@router.post("/notion", status_code=201, response_model=ImportResponse)
+async def import_notion(
+  _admin: str = Depends(require_admin),
+  file: UploadFile = File(...),
+  repo: SQLiteBlockRepository = Depends(get_repository),
+) -> ImportResponse:
+  """Notion export HTML/ZIP 파일을 프로젝트 페이지로 변환 import합니다.
+
+  지원 파일 형식:
+    - .html — 단일 Notion 페이지
+    - .zip  — Notion export 아카이브 (다중 페이지/이미지 포함)
+
+  Returns:
+    생성된 루트 문서 ID, 제목, 페이지 수, 변환 리포트.
+
+  Raises:
+    HTTPException 415: 지원하지 않는 파일 형식
+    HTTPException 413: 파일 크기 초과
+    HTTPException 422: 파싱 실패
+  """
+  filename = file.filename or ""
+  lower_name = filename.lower()
+
+  if not (lower_name.endswith(".html") or lower_name.endswith(".htm") or lower_name.endswith(".zip")):
+    raise HTTPException(
+      status_code=415,
+      detail="지원하지 않는 파일 형식입니다. .html 또는 .zip 파일을 업로드해주세요.",
+    )
+
+  # 청크 단위로 읽어 메모리 제한 방어
+  chunks: list[bytes] = []
+  total_size = 0
+  while True:
+    chunk = await file.read(CHUNK_SIZE)
+    if not chunk:
+      break
+    total_size += len(chunk)
+    if total_size > MAX_IMPORT_BYTES:
+      raise HTTPException(
+        status_code=413,
+        detail=f"파일 크기가 {MAX_IMPORT_BYTES // (1024 * 1024)} MB를 초과합니다.",
+      )
+    chunks.append(chunk)
+
+  data = b"".join(chunks)
+  if not data:
+    raise HTTPException(status_code=422, detail="빈 파일입니다.")
+
+  # 파싱
+  try:
+    if lower_name.endswith(".zip"):
+      result = extract_and_parse_zip(data)
+    else:
+      result = parse_single_html(data)
+  except ValueError as exc:
+    raise HTTPException(status_code=422, detail=str(exc))
+  except Exception as exc:
+    logger.error("Notion import 파싱 실패: %s", exc)
+    raise HTTPException(status_code=422, detail=f"파싱 중 오류가 발생했습니다: {exc}")
+
+  if not result.pages:
+    raise HTTPException(status_code=422, detail="변환할 페이지가 없습니다.")
+
+  # DB에 문서/블록 생성
+  try:
+    root_doc = _persist_import(result, repo)
+  except Exception as exc:
+    logger.error("Notion import 저장 실패: %s", exc)
+    raise HTTPException(status_code=500, detail=f"저장 중 오류가 발생했습니다: {exc}")
+
+  return ImportResponse(
+    document_id=root_doc["id"],
+    title=root_doc["title"],
+    total_pages=len(result.pages),
+    report=result.report.to_dict(),
+  )
+
+
+# ── 영속화 로직 ─────────────────────────────────────────────────────────────────
+
+def _persist_import(
+  result: ImportResult,
+  repo: SQLiteBlockRepository,
+) -> dict[str, Any]:
+  """파싱된 Import 결과를 DB에 문서/블록으로 저장합니다.
+
+  페이지 계층 구조:
+    - 최상위 페이지 → 루트 문서
+    - 하위 페이지 → 루트 문서의 하위 PageBlock으로 연결
+
+  이미지 처리:
+    - ZIP 내 이미지 파일은 process_image()를 통해 저장
+    - 블록의 url 필드를 실제 저장 경로로 갱신
+  """
+  from app.models.orm import BlockRow, DocumentRow
+
+  session = repo._session
+
+  # 페이지 경로 → 생성된 document_id 매핑
+  path_to_doc_id: dict[str, str] = {}
+
+  # 1단계: 루트 문서 결정 — 첫 번째 페이지 또는 단일 페이지
+  first_page = result.pages[0]
+
+  # 단일 페이지인 경우 바로 루트 문서로 생성
+  if len(result.pages) == 1:
+    root_id = str(uuid.uuid4())
+    session.add(DocumentRow(
+      id=root_id,
+      title=first_page["title"],
+      subtitle="",
+      parent_id=None,
+    ))
+    session.flush()
+    path_to_doc_id[first_page["path"]] = root_id
+
+    # 이미지 URL 치환 후 블록 저장
+    _upload_images_in_blocks(first_page["blocks"], result.image_mappings)
+    _persist_blocks(session, root_id, first_page["blocks"])
+    session.commit()
+
+    return {"id": root_id, "title": first_page["title"]}
+
+  # 다중 페이지: 첫 번째 페이지를 루트 문서로, 나머지를 하위로 연결
+  root_id = str(uuid.uuid4())
+  session.add(DocumentRow(
+    id=root_id,
+    title=first_page["title"],
+    subtitle="",
+    parent_id=None,
+  ))
+  session.flush()
+  path_to_doc_id[first_page["path"]] = root_id
+
+  _upload_images_in_blocks(first_page["blocks"], result.image_mappings)
+  _persist_blocks(session, root_id, first_page["blocks"])
+
+  # 2단계: 하위 페이지 생성 및 PageBlock으로 연결
+  for page in result.pages[1:]:
+    child_doc_id = str(uuid.uuid4())
+    # 부모 문서 결정: 경로 기반 계층 탐색
+    parent_doc_id = _find_parent_doc_id(page["path"], path_to_doc_id, root_id)
+
+    session.add(DocumentRow(
+      id=child_doc_id,
+      title=page["title"],
+      subtitle="",
+      parent_id=parent_doc_id,
+    ))
+    session.flush()
+    path_to_doc_id[page["path"]] = child_doc_id
+
+    # 부모 문서에 PageBlock 추가
+    _add_page_block(session, parent_doc_id, child_doc_id, page["title"])
+
+    # 이미지 URL 치환 후 블록 저장
+    _upload_images_in_blocks(page["blocks"], result.image_mappings)
+    _persist_blocks(session, child_doc_id, page["blocks"])
+
+  session.commit()
+  return {"id": root_id, "title": first_page["title"]}
+
+
+def _find_parent_doc_id(
+  page_path: str,
+  path_to_doc_id: dict[str, str],
+  root_id: str,
+) -> str:
+  """페이지 경로를 기반으로 부모 문서 ID를 결정합니다.
+
+  Notion export 디렉터리 구조에서 부모 페이지의 HTML 파일은
+  자식 페이지의 디렉터리와 같은 레벨에 위치합니다.
+
+  예시:
+    Root UUID.html          ← 루트
+    Root UUID/
+      Child UUID.html       ← Root의 자식
+      Child UUID/
+        GrandChild UUID.html  ← Child의 자식
+  """
+  from pathlib import PurePosixPath
+
+  parts = PurePosixPath(page_path).parts
+
+  # 부모 디렉터리의 HTML 파일을 역순으로 탐색
+  if len(parts) >= 2:
+    # 부모 디렉터리 이름으로 부모 HTML 파일을 매칭
+    parent_dir = str(PurePosixPath(*parts[:-1]))
+    # parent_dir + ".html" 패턴으로 부모 문서 검색
+    for registered_path, doc_id in path_to_doc_id.items():
+      reg_stem = PurePosixPath(registered_path).stem
+      if parent_dir.endswith(reg_stem):
+        return doc_id
+      # 부분 경로 매칭 — 디렉터리명이 HTML 파일명(확장자 제외)과 동일
+      reg_parts = PurePosixPath(registered_path).parts
+      if len(reg_parts) >= 1:
+        parent_dir_name = parts[-2] if len(parts) >= 2 else ""
+        if reg_parts[-1].replace(".html", "") == parent_dir_name:
+          return doc_id
+
+  return root_id
+
+
+def _add_page_block(
+  session: Any,
+  parent_doc_id: str,
+  child_doc_id: str,
+  title: str,
+) -> None:
+  """부모 문서에 하위 페이지를 가리키는 PageBlock을 추가합니다."""
+  from sqlalchemy import func, select
+
+  from app.models.orm import BlockRow
+
+  # 현재 최대 position 조회
+  max_pos = session.execute(
+    select(func.coalesce(func.max(BlockRow.position), 0))
+    .where(
+      BlockRow.document_id == parent_doc_id,
+      BlockRow.parent_block_id.is_(None),
+    )
+  ).scalar_one()
+
+  block_id = str(uuid.uuid4())
+  content = json.dumps({
+    "document_id": child_doc_id,
+    "is_reference": False,
+  }, ensure_ascii=False)
+
+  session.add(BlockRow(
+    id=block_id,
+    document_id=parent_doc_id,
+    parent_block_id=None,
+    type="page",
+    position=max_pos + 1,
+    content_json=content,
+  ))
+
+
+def _persist_blocks(
+  session: Any,
+  document_id: str,
+  blocks: list[dict[str, Any]],
+  parent_block_id: str | None = None,
+) -> None:
+  """블록 리스트를 DB에 저장합니다.
+
+  컨테이너 블록(toggle, quote, callout)의 children은 재귀적으로 처리됩니다.
+  """
+  from app.models.orm import BlockRow
+
+  for position, block in enumerate(blocks, start=1):
+    block_id = block.get("id", str(uuid.uuid4()))
+    block_type = block["type"]
+
+    # children은 content_json에서 제외 (별도 BlockRow로 저장)
+    children = block.pop("children", None)
+
+    # content_json 구성: id, type은 BlockRow 컬럼이므로 제외
+    content = {k: v for k, v in block.items() if k not in ("id", "type")}
+    content_json = json.dumps(content, ensure_ascii=False)
+
+    session.add(BlockRow(
+      id=block_id,
+      document_id=document_id,
+      parent_block_id=parent_block_id,
+      type=block_type,
+      position=position,
+      content_json=content_json,
+    ))
+
+    # 컨테이너 블록의 자식 재귀 저장
+    if children:
+      _persist_blocks(session, document_id, children, parent_block_id=block_id)
+
+
+def _upload_images_in_blocks(
+  blocks: list[dict[str, Any]],
+  image_mappings: dict[str, bytes],
+) -> None:
+  """블록 내 이미지 URL을 실제 업로드된 경로로 치환합니다.
+
+  ZIP 내부 상대 경로로 참조된 이미지를 process_image()를 통해
+  서버에 저장하고, 블록의 url 필드를 갱신합니다.
+  """
+  for block in blocks:
+    if block.get("type") == "image":
+      url = block.get("url", "")
+      if url in image_mappings:
+        try:
+          img_data = image_mappings[url]
+          result = process_image(img_data)
+          block["url"] = result["url"]
+        except Exception as exc:
+          logger.warning("이미지 업로드 실패: %s — %s", url, exc)
+          block["url"] = ""
+
+    # 재귀: 컨테이너 블록의 children
+    children = block.get("children")
+    if children:
+      _upload_images_in_blocks(children, image_mappings)

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1088,7 +1088,9 @@ def parse_notion_markdown(md_content: str) -> ParsedPage:
   sub_page_links: list[str] = []
   title = "Untitled"
 
-  lines = md_content.split("\n")
+  # splitlines() 는 \n / \r\n / \r 을 모두 줄 구분자로 처리하므로
+  # OS별 줄바꿈 차이에 견고하다. (CPython str.splitlines docs 참조)
+  lines = md_content.splitlines()
   i = 0
 
   while i < len(lines):

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -181,34 +181,33 @@ def _parse_list(tag: Tag, report: ConversionReport) -> list[dict[str, Any]]:
   for idx, li in enumerate(tag.find_all("li", recursive=False), start=1):
     report.total_elements += 1
 
+    # 중첩 <ul>/<ol> 은 별도 블록으로 처리하므로 본 li의 텍스트 추출 시 제외한다.
+    # _extract_inline_text() 가 자식을 재귀 탐색하기 때문에 사전에 분리하지 않으면
+    # 부모 li 텍스트에 중첩 항목이 중복으로 포함되는 버그가 발생한다.
+    nested_lists = li.find_all(["ul", "ol"], recursive=False)
+    detached_nested = [n.extract() for n in nested_lists]
+
     if is_todo:
       checkbox_div = li.find("div", class_=re.compile(r"checkbox"))
       checked = checkbox_div and "checkbox-on" in (checkbox_div.get("class") or [])
-      # 체크박스 div 다음 텍스트가 실제 내용
       plain, formatted = _extract_inline_text(li)
       prefix = "☑ " if checked else "☐ "
-      block = _make_block("text", text=prefix + plain)
-      if formatted != plain:
-        block["formatted_text"] = prefix + formatted
     elif is_numbered:
       plain, formatted = _extract_inline_text(li)
       prefix = f"{idx}. "
-      block = _make_block("text", text=prefix + plain)
-      if formatted != plain:
-        block["formatted_text"] = prefix + formatted
     else:
       plain, formatted = _extract_inline_text(li)
       prefix = "• "
-      block = _make_block("text", text=prefix + plain)
-      if formatted != plain:
-        block["formatted_text"] = prefix + formatted
+
+    block = _make_block("text", text=prefix + plain)
+    if formatted != plain:
+      block["formatted_text"] = prefix + formatted
 
     blocks.append(block)
     report.converted += 1
 
-    # 중첩 리스트 처리
-    nested = li.find(["ul", "ol"], recursive=False)
-    if nested:
+    # 중첩 리스트는 분리된 상태로 재귀 처리
+    for nested in detached_nested:
       blocks.extend(_parse_list(nested, report))
 
   return blocks
@@ -831,13 +830,12 @@ def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
       csv_text = raw.decode("utf-8-sig", errors="replace")
       csv_blocks = _parse_csv_to_blocks(csv_text)
       if csv_blocks:
-        csv_dir = str(PurePosixPath(csv_path).parent)
         csv_stem = PurePosixPath(csv_path).stem
         # UUID 해시 제거 — Notion export는 "제목 UUID해시.csv" 패턴
         csv_title = re.sub(r"\s+[0-9a-f]{32}$", "", csv_stem).strip() or csv_stem
 
-        # 동일 디렉터리의 부모 페이지를 찾아 블록 추가
-        parent_page = _find_parent_page_for_csv(csv_dir, csv_title, pages)
+        # 부모 페이지 매칭: sub_page_links 우선 → 디렉터리 fallback
+        parent_page = _find_parent_page_for_csv(csv_path, pages)
         if parent_page:
           parent_page["blocks"].extend(csv_blocks)
         else:
@@ -1266,26 +1264,45 @@ def _parse_csv_to_blocks(csv_text: str) -> list[dict[str, Any]]:
 
 
 def _find_parent_page_for_csv(
-  csv_dir: str,
-  csv_title: str,
+  csv_path: str,
   pages: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-  """CSV 파일의 부모 페이지를 찾습니다.
+  """CSV 파일의 부모 페이지를 정확히 찾습니다.
 
-  Notion export에서 CSV 파일은 이를 참조하는 .md 파일과
-  같은 디렉터리 또는 상위 디렉터리에 위치합니다.
+  매칭 우선순위:
+    1. 페이지의 sub_page_links가 csv 경로(또는 파일명)를 참조 — 가장 신뢰 가능
+    2. 같은 폴더에 정확히 하나의 페이지만 존재 — 모호성 없는 케이스
+    3. 매칭 실패 시 None (호출부에서 독립 페이지로 처리)
+
+  Notion export에서 CSV는 부모 .md/.html 페이지의 본문에서 링크되거나,
+  같은 폴더(또는 상위 폴더)에 배치됩니다. 단순히 같은 디렉터리의 첫 페이지를
+  부모로 가정하면 한 폴더에 여러 페이지가 있을 때 잘못된 페이지에 부착됩니다.
   """
-  # 같은 디렉터리의 페이지 중 이름이 유사한 것을 찾음
-  for page in pages:
-    page_dir = str(PurePosixPath(page["path"]).parent)
-    if page_dir == csv_dir:
-      return page
+  csv_filename = PurePosixPath(csv_path).name
+  csv_dir = str(PurePosixPath(csv_path).parent)
 
-  # 상위 디렉터리의 페이지에서 탐색
-  parent_dir = str(PurePosixPath(csv_dir).parent)
+  # 1. sub_page_links 기반 정확 매칭 (URL-decoded 비교)
   for page in pages:
-    page_dir = str(PurePosixPath(page["path"]).parent)
-    if page_dir == parent_dir:
-      return page
+    for link in page.get("sub_page_links", []):
+      link_name = PurePosixPath(unquote(link)).name
+      if link_name == csv_filename:
+        return page
+
+  # 2. 같은 디렉터리에 페이지가 정확히 하나일 때만 부착
+  same_dir_pages = [
+    p for p in pages
+    if str(PurePosixPath(p["path"]).parent) == csv_dir
+  ]
+  if len(same_dir_pages) == 1:
+    return same_dir_pages[0]
+
+  # 3. 상위 디렉터리에 페이지가 정확히 하나일 때만 부착
+  parent_dir = str(PurePosixPath(csv_dir).parent)
+  parent_dir_pages = [
+    p for p in pages
+    if str(PurePosixPath(p["path"]).parent) == parent_dir
+  ]
+  if len(parent_dir_pages) == 1:
+    return parent_dir_pages[0]
 
   return None

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -685,31 +685,85 @@ def _read_zip_entry(zf: zipfile.ZipFile, name: str) -> bytes:
     return b"".join(chunks)
 
 
-def _flatten_zip(zip_data: bytes) -> dict[str, bytes]:
+# ── ZIP Bomb 방어 임계치 ────────────────────────────────────────────────────────
+#
+# OWASP Cheat Sheet — Decompression Bomb 대응 권장사항에 따라 다음 항목을 제한:
+#   - 추출 파일 총 개수
+#   - 추출된 데이터 누적 바이트 수
+#   - 단일 엔트리의 비압축 크기
+#   - 압축비 (compressed/uncompressed) — 비정상적으로 높은 압축비 차단
+#   - 중첩 ZIP 재귀 깊이
+#
+# Ref:
+#   - https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+#   - https://owasp.org/www-community/Application_Threat_Modeling
+
+MAX_ZIP_ENTRIES = 100_000
+MAX_TOTAL_UNCOMPRESSED = 2 * 1024 * 1024 * 1024   # 2 GB
+MAX_SINGLE_UNCOMPRESSED = 500 * 1024 * 1024        # 500 MB / 엔트리
+MAX_COMPRESSION_RATIO = 200                        # 비정상 압축비 차단
+MAX_NESTED_ZIP_DEPTH = 4                           # 중첩 ZIP 깊이 제한
+
+
+def _flatten_zip(
+  zip_data: bytes,
+  *,
+  _depth: int = 0,
+  _quota: dict[str, int] | None = None,
+) -> dict[str, bytes]:
   """ZIP 파일 내 모든 파일을 추출합니다. 내부 ZIP도 재귀적으로 해제합니다.
 
   Notion export ZIP은 대용량 export 시 내부에 Part-N.zip 파일을
   포함할 수 있습니다. 이 함수는 모든 중첩 ZIP을 자동으로 해제하여
   최종 콘텐츠 파일만 반환합니다.
 
+  ZIP Bomb 방어:
+    - 엔트리 개수, 총 비압축 크기, 단일 엔트리 크기, 압축비, 중첩 깊이를 제한
+    - 한도 초과 시 ValueError를 발생시켜 import 자체를 중단
+
   Args:
     zip_data: ZIP 파일의 바이트 데이터.
+    _depth: 내부 호출 — 현재 재귀 깊이.
+    _quota: 내부 호출 — 누적 카운터 ({"entries": int, "bytes": int}).
 
   Returns:
     {파일경로: 바이트데이터} dict. 디렉터리 엔트리와 __MACOSX는 제외됨.
 
   Raises:
-    ValueError: 유효하지 않은 ZIP 파일인 경우.
+    ValueError: 유효하지 않은 ZIP이거나 안전 임계치 초과인 경우.
   """
+  if _depth > MAX_NESTED_ZIP_DEPTH:
+    raise ValueError(f"ZIP 중첩 깊이가 {MAX_NESTED_ZIP_DEPTH}를 초과합니다.")
+
   if not zipfile.is_zipfile(BytesIO(zip_data)):
     raise ValueError("유효하지 않은 ZIP 파일입니다.")
+
+  if _quota is None:
+    _quota = {"entries": 0, "bytes": 0}
 
   result: dict[str, bytes] = {}
 
   with zipfile.ZipFile(BytesIO(zip_data), "r") as zf:
-    for name in zf.namelist():
+    for info in zf.infolist():
+      name = info.filename
       if name.endswith("/") or "__MACOSX" in name:
         continue
+
+      # 사전 메타데이터 검증 — 데이터 읽기 전에 차단
+      if info.file_size > MAX_SINGLE_UNCOMPRESSED:
+        raise ValueError(
+          f"단일 엔트리 크기({info.file_size} bytes)가 허용치를 초과합니다: {name}"
+        )
+      if info.compress_size > 0:
+        ratio = info.file_size / info.compress_size
+        if ratio > MAX_COMPRESSION_RATIO:
+          raise ValueError(
+            f"비정상적인 압축비({ratio:.0f}:1)가 감지되었습니다: {name}"
+          )
+
+      _quota["entries"] += 1
+      if _quota["entries"] > MAX_ZIP_ENTRIES:
+        raise ValueError(f"ZIP 엔트리 개수가 {MAX_ZIP_ENTRIES}를 초과합니다.")
 
       try:
         data = _read_zip_entry(zf, name)
@@ -717,11 +771,20 @@ def _flatten_zip(zip_data: bytes) -> dict[str, bytes]:
         logger.error("ZIP 엔트리 읽기 실패: %s — %s", name, exc)
         continue
 
-      # 내부 ZIP 파일 감지 → 재귀 추출
+      _quota["bytes"] += len(data)
+      if _quota["bytes"] > MAX_TOTAL_UNCOMPRESSED:
+        raise ValueError(
+          f"ZIP 비압축 누적 크기가 {MAX_TOTAL_UNCOMPRESSED // (1024 * 1024)} MB를 초과합니다."
+        )
+
+      # 내부 ZIP 파일 감지 → 재귀 추출 (동일 quota 공유)
       if name.lower().endswith(".zip") and zipfile.is_zipfile(BytesIO(data)):
         try:
-          inner = _flatten_zip(data)
+          inner = _flatten_zip(data, _depth=_depth + 1, _quota=_quota)
           result.update(inner)
+        except ValueError:
+          # ZIP Bomb 임계치 초과는 상위로 전파
+          raise
         except Exception as exc:
           logger.error("내부 ZIP 추출 실패: %s — %s", name, exc)
       else:

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -657,6 +657,35 @@ class ImportResult:
   image_mappings: dict[str, bytes]  # 상대경로 → 이미지 바이트 데이터
 
 
+def _read_zip_entry(zf: zipfile.ZipFile, name: str) -> bytes:
+  """ZIP 엔트리를 읽습니다. CRC 검증 실패 시 검증을 건너뛰고 재시도합니다.
+
+  Notion export ZIP은 일부 환경에서 CRC-32 헤더 값과 실제 데이터가 불일치하는
+  경우가 있어 (`unzip -t`는 OK이지만 Python zipfile은 거부) 표준 read가
+  BadZipFile을 던질 수 있습니다. 이런 경우 안전하게 CRC 검증 없이 데이터를
+  추출합니다.
+
+  Ref: Python issue tracker — zipfile strict CRC validation
+  """
+  try:
+    return zf.read(name)
+  except zipfile.BadZipFile as exc:
+    if "CRC-32" not in str(exc):
+      raise
+    logger.warning("CRC 검증 실패, 검증 우회 후 재시도: %s", name)
+
+  # CRC 검증을 건너뛰는 대체 경로 — ZipExtFile 내부 _expected_crc를 None으로 설정
+  with zf.open(name) as src:
+    src._expected_crc = None  # type: ignore[attr-defined]
+    chunks: list[bytes] = []
+    while True:
+      chunk = src.read(1024 * 1024)
+      if not chunk:
+        break
+      chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _flatten_zip(zip_data: bytes) -> dict[str, bytes]:
   """ZIP 파일 내 모든 파일을 추출합니다. 내부 ZIP도 재귀적으로 해제합니다.
 
@@ -683,12 +712,19 @@ def _flatten_zip(zip_data: bytes) -> dict[str, bytes]:
       if name.endswith("/") or "__MACOSX" in name:
         continue
 
-      data = zf.read(name)
+      try:
+        data = _read_zip_entry(zf, name)
+      except Exception as exc:
+        logger.error("ZIP 엔트리 읽기 실패: %s — %s", name, exc)
+        continue
 
       # 내부 ZIP 파일 감지 → 재귀 추출
       if name.lower().endswith(".zip") and zipfile.is_zipfile(BytesIO(data)):
-        inner = _flatten_zip(data)
-        result.update(inner)
+        try:
+          inner = _flatten_zip(data)
+          result.update(inner)
+        except Exception as exc:
+          logger.error("내부 ZIP 추출 실패: %s — %s", name, exc)
       else:
         result[name] = data
 

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1,0 +1,799 @@
+"""Notion Export HTML을 프로젝트 블록 구조로 변환하는 파서 서비스.
+
+Notion HTML Export 포맷:
+  - 각 페이지는 독립 HTML 파일로 export됨
+  - 페이지 제목은 <header><h1 class="page-title"> 에 위치
+  - 본문은 <div class="page-body"> 내부의 HTML 요소들로 구성
+  - 하위 페이지는 같은 폴더 내 별도 HTML 파일로 <a href="..."> 링크됨
+  - 이미지/첨부 파일은 페이지 이름과 동일한 폴더 안에 저장됨
+
+지원 블록 매핑:
+  완전 지원 — heading(h1-h3), paragraph, bulleted/numbered list, to-do,
+              toggle, quote, code, callout, divider, image, bookmark
+  부분 지원 — table(텍스트 기반 렌더링), column layout(순차 렌더링)
+  미지원   — embed, synced block, equation (fallback 텍스트 처리)
+
+참고:
+  - Notion Help: https://www.notion.so/help/export-your-content
+  - BeautifulSoup 4 docs: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import unquote
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+logger = logging.getLogger(__name__)
+
+
+# ── 변환 리포트 ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class ConversionReport:
+  """Import 변환 결과 리포트.
+
+  변환 성공·fallback·누락 항목을 추적하여
+  사용자에게 투명한 결과 안내를 제공합니다.
+  """
+
+  total_elements: int = 0
+  converted: int = 0
+  fallback: int = 0
+  skipped: int = 0
+  warnings: list[str] = field(default_factory=list)
+
+  def to_dict(self) -> dict[str, Any]:
+    return {
+      "total_elements": self.total_elements,
+      "converted": self.converted,
+      "fallback": self.fallback,
+      "skipped": self.skipped,
+      "warnings": self.warnings,
+    }
+
+
+# ── 인라인 서식 변환 ────────────────────────────────────────────────────────────
+
+# Notion HTML에서 사용되는 인라인 서식 태그와 프로젝트 formatted_text 마크업 매핑
+# Ref: Notion export는 <strong>, <em>, <del>, <code> 등 표준 HTML 태그를 사용
+_INLINE_TAG_MAP: dict[str, tuple[str, str]] = {
+  "b":      ("<b>", "</b>"),
+  "strong": ("<b>", "</b>"),
+  "i":      ("<i>", "</i>"),
+  "em":     ("<i>", "</i>"),
+  "u":      ("<u>", "</u>"),
+  "s":      ("<s>", "</s>"),
+  "del":    ("<s>", "</s>"),
+  "strike": ("<s>", "</s>"),
+  "code":   ("<code>", "</code>"),
+  "mark":   ("<mark>", "</mark>"),
+}
+
+
+def _extract_inline_text(element: Tag | NavigableString) -> tuple[str, str]:
+  """HTML 요소에서 plain text와 formatted_text를 재귀적으로 추출합니다.
+
+  Args:
+    element: BeautifulSoup 파싱된 HTML 요소.
+
+  Returns:
+    (plain_text, formatted_text) 튜플.
+    formatted_text는 인라인 서식(<b>, <i>, <u> 등)이 보존된 문자열.
+  """
+  if isinstance(element, NavigableString):
+    text = str(element)
+    return text, text
+
+  plain_parts: list[str] = []
+  formatted_parts: list[str] = []
+
+  for child in element.children:
+    if isinstance(child, NavigableString):
+      text = str(child)
+      plain_parts.append(text)
+      formatted_parts.append(text)
+    elif isinstance(child, Tag):
+      child_plain, child_fmt = _extract_inline_text(child)
+      plain_parts.append(child_plain)
+
+      tag_name = child.name.lower()
+      if tag_name == "a":
+        href = child.get("href", "")
+        formatted_parts.append(f'<a href="{href}">{child_fmt}</a>')
+      elif tag_name == "br":
+        plain_parts.append("\n")
+        formatted_parts.append("\n")
+      elif tag_name in _INLINE_TAG_MAP:
+        open_tag, close_tag = _INLINE_TAG_MAP[tag_name]
+        formatted_parts.append(f"{open_tag}{child_fmt}{close_tag}")
+      else:
+        # span 등 서식 없는 래퍼 — 내용만 전달
+        formatted_parts.append(child_fmt)
+
+  plain = "".join(plain_parts)
+  formatted = "".join(formatted_parts)
+  return plain, formatted
+
+
+# ── 블록 변환 함수들 ────────────────────────────────────────────────────────────
+
+def _make_block(block_type: str, **content: Any) -> dict[str, Any]:
+  """블록 dict를 생성합니다. id는 UUID v4로 자동 할당됩니다."""
+  return {"id": str(uuid.uuid4()), "type": block_type, **content}
+
+
+def _parse_heading(tag: Tag) -> dict[str, Any]:
+  """<h1>-<h3> 태그를 TextBlock(level=1-3)으로 변환합니다."""
+  level_map = {"h1": 1, "h2": 2, "h3": 3}
+  level = level_map.get(tag.name.lower(), 1)
+  plain, formatted = _extract_inline_text(tag)
+  block = _make_block("text", text=plain, level=level)
+  if formatted != plain:
+    block["formatted_text"] = formatted
+  return block
+
+
+def _parse_paragraph(tag: Tag) -> dict[str, Any] | None:
+  """<p> 태그를 TextBlock으로 변환합니다. 빈 단락은 None을 반환합니다."""
+  plain, formatted = _extract_inline_text(tag)
+  if not plain.strip():
+    return None
+  block = _make_block("text", text=plain)
+  if formatted != plain:
+    block["formatted_text"] = formatted
+  return block
+
+
+def _parse_list(tag: Tag, report: ConversionReport) -> list[dict[str, Any]]:
+  """<ul>/<ol> 태그의 각 <li>를 개별 TextBlock으로 변환합니다.
+
+  Notion HTML 리스트 구조:
+    <ul class="bulleted-list"> / <ol class="numbered-list">
+      <li> ... </li>
+
+  To-do 리스트 (<ul class="to-do-list">):
+    <li><div class="checkbox checkbox-on/off">
+  """
+  blocks: list[dict[str, Any]] = []
+  is_todo = "to-do-list" in (tag.get("class") or [])
+  is_numbered = tag.name.lower() == "ol"
+
+  for idx, li in enumerate(tag.find_all("li", recursive=False), start=1):
+    report.total_elements += 1
+
+    if is_todo:
+      checkbox_div = li.find("div", class_=re.compile(r"checkbox"))
+      checked = checkbox_div and "checkbox-on" in (checkbox_div.get("class") or [])
+      # 체크박스 div 다음 텍스트가 실제 내용
+      plain, formatted = _extract_inline_text(li)
+      prefix = "☑ " if checked else "☐ "
+      block = _make_block("text", text=prefix + plain)
+      if formatted != plain:
+        block["formatted_text"] = prefix + formatted
+    elif is_numbered:
+      plain, formatted = _extract_inline_text(li)
+      prefix = f"{idx}. "
+      block = _make_block("text", text=prefix + plain)
+      if formatted != plain:
+        block["formatted_text"] = prefix + formatted
+    else:
+      plain, formatted = _extract_inline_text(li)
+      prefix = "• "
+      block = _make_block("text", text=prefix + plain)
+      if formatted != plain:
+        block["formatted_text"] = prefix + formatted
+
+    blocks.append(block)
+    report.converted += 1
+
+    # 중첩 리스트 처리
+    nested = li.find(["ul", "ol"], recursive=False)
+    if nested:
+      blocks.extend(_parse_list(nested, report))
+
+  return blocks
+
+
+def _parse_toggle(tag: Tag, report: ConversionReport) -> dict[str, Any]:
+  """<details> 태그를 ToggleBlock으로 변환합니다.
+
+  Notion toggle 구조:
+    <details>
+      <summary>Toggle title</summary>
+      <p>내부 콘텐츠...</p>
+    </details>
+  """
+  summary = tag.find("summary")
+  if summary:
+    plain, formatted = _extract_inline_text(summary)
+  else:
+    plain, formatted = "", ""
+
+  children = []
+  for child in tag.children:
+    if isinstance(child, Tag) and child.name != "summary":
+      child_blocks = _parse_element(child, report)
+      children.extend(child_blocks)
+
+  # 자식이 없으면 빈 텍스트 블록 하나 추가 (기존 create_block 패턴과 일관성)
+  if not children:
+    children.append(_make_block("text", text=""))
+
+  block = _make_block("toggle", text=plain, is_open=False, children=children)
+  if formatted != plain:
+    block["formatted_text"] = formatted
+  return block
+
+
+def _parse_quote(tag: Tag, report: ConversionReport) -> dict[str, Any]:
+  """<blockquote> 태그를 QuoteBlock으로 변환합니다."""
+  children = []
+  first_text = ""
+  for child in tag.children:
+    if isinstance(child, NavigableString):
+      text = str(child).strip()
+      if text and not first_text:
+        first_text = text
+    elif isinstance(child, Tag):
+      child_blocks = _parse_element(child, report)
+      children.extend(child_blocks)
+
+  if not children:
+    children.append(_make_block("text", text=""))
+
+  # 첫 번째 텍스트를 quote의 text 필드로 사용
+  if not first_text and children:
+    first_child = children[0]
+    if first_child.get("type") == "text":
+      first_text = first_child.get("text", "")
+
+  return _make_block("quote", text=first_text, children=children)
+
+
+def _parse_code(tag: Tag) -> dict[str, Any]:
+  """<pre> 또는 <code> 블록을 CodeBlock으로 변환합니다.
+
+  Notion 코드 블록 HTML 구조:
+    <pre id="..." class="code"><code class="language-python">코드...</code></pre>
+  """
+  code_tag = tag.find("code") if tag.name == "pre" else tag
+  code_text = code_tag.get_text() if code_tag else tag.get_text()
+
+  # 언어 감지: class="language-python" 패턴
+  language = "plain"
+  if code_tag and isinstance(code_tag, Tag):
+    classes = code_tag.get("class") or []
+    for cls in classes:
+      if isinstance(cls, str) and cls.startswith("language-"):
+        language = cls.replace("language-", "")
+        break
+
+  return _make_block("code", code=code_text, language=language)
+
+
+def _parse_callout(tag: Tag, report: ConversionReport) -> dict[str, Any]:
+  """Notion callout (<figure class="callout">) 을 CalloutBlock으로 변환합니다.
+
+  Notion callout HTML 구조:
+    <figure class="callout" style="...">
+      <span class="icon">💡</span>
+      <div class="callout-body">
+        <p>내용</p>
+      </div>
+    </figure>
+  """
+  # 아이콘 추출
+  icon_span = tag.find("span", class_="icon")
+  emoji = icon_span.get_text().strip() if icon_span else "💡"
+  if not emoji:
+    emoji = "💡"
+
+  # 배경색 → color 매핑
+  color = _extract_callout_color(tag)
+
+  # 본문 콘텐츠 파싱
+  children = []
+  first_text = ""
+  body_div = tag.find("div", class_="callout-body")
+  content_source = body_div if body_div else tag
+
+  for child in content_source.children:
+    if isinstance(child, Tag) and child.name not in ("span",):
+      if "icon" in (child.get("class") or []):
+        continue
+      child_blocks = _parse_element(child, report)
+      children.extend(child_blocks)
+
+  if not children:
+    children.append(_make_block("text", text=""))
+
+  if children and children[0].get("type") == "text":
+    first_text = children[0].get("text", "")
+
+  return _make_block(
+    "callout",
+    text=first_text,
+    emoji=emoji,
+    color=color,
+    children=children,
+  )
+
+
+def _extract_callout_color(tag: Tag) -> str:
+  """callout 태그의 background-color 스타일에서 color 값을 추출합니다."""
+  style = tag.get("style", "")
+  if not style:
+    return "yellow"
+
+  # Notion callout 배경색 → 프로젝트 color 매핑
+  color_map = {
+    "rgba(241,241,239": "gray",
+    "rgba(244,238,225": "yellow",
+    "rgba(251,236,221": "yellow",
+    "rgba(232,222,238": "blue",
+    "rgba(225,232,246": "blue",
+    "rgba(221,237,226": "green",
+    "rgba(253,235,236": "red",
+    "rgba(244,223,235": "red",
+  }
+  for prefix, color in color_map.items():
+    if prefix in style:
+      return color
+  return "yellow"
+
+
+def _parse_image(tag: Tag) -> dict[str, Any] | None:
+  """<figure>/<img> 태그를 ImageBlock으로 변환합니다.
+
+  이미지 URL은 export 내 상대 경로 형태로 저장되며,
+  import 과정에서 실제 파일이 업로드된 후 URL이 갱신됩니다.
+  """
+  img = tag.find("img") if tag.name != "img" else tag
+  if img is None:
+    return None
+
+  src = img.get("src", "")
+  if not src:
+    return None
+
+  # 캡션 추출 (figure > figcaption)
+  caption = ""
+  figcaption = tag.find("figcaption") if tag.name == "figure" else None
+  if figcaption:
+    caption = figcaption.get_text().strip()
+
+  return _make_block("image", url=src, caption=caption)
+
+
+def _parse_table(tag: Tag, report: ConversionReport) -> list[dict[str, Any]]:
+  """<table> 태그를 텍스트 기반 블록으로 변환합니다.
+
+  프로젝트의 DatabaseBlock 구조에 정확히 매핑하기 어려운 경우가 많으므로
+  각 행을 텍스트 블록으로 변환하는 fallback 전략을 사용합니다.
+
+  향후 DatabaseBlock 매핑 확장 시 이 함수를 교체할 수 있습니다.
+  """
+  blocks: list[dict[str, Any]] = []
+
+  # 헤더 행 처리
+  thead = tag.find("thead")
+  if thead:
+    header_row = thead.find("tr")
+    if header_row:
+      cells = [th.get_text().strip() for th in header_row.find_all(["th", "td"])]
+      if any(cells):
+        blocks.append(_make_block("text", text=" | ".join(cells), level=3))
+        blocks.append(_make_block("divider"))
+        report.converted += 1
+
+  # 본문 행 처리
+  tbody = tag.find("tbody") or tag
+  for tr in tbody.find_all("tr", recursive=False):
+    # thead 내부 tr은 이미 처리했으므로 건너뜀
+    if tr.parent and tr.parent.name == "thead":
+      continue
+    cells = [td.get_text().strip() for td in tr.find_all(["td", "th"])]
+    if any(cells):
+      blocks.append(_make_block("text", text=" | ".join(cells)))
+      report.converted += 1
+
+  if blocks:
+    report.fallback += 1
+    report.warnings.append("테이블이 텍스트 기반으로 변환되었습니다 (부분 지원)")
+
+  return blocks
+
+
+def _parse_bookmark(tag: Tag) -> dict[str, Any] | None:
+  """Notion bookmark (<figure class="bookmark">) 을 UrlEmbedBlock으로 변환합니다.
+
+  Notion bookmark HTML 구조:
+    <figure class="bookmark source">
+      <a href="https://example.com">
+        <div class="bookmark-info">
+          <div class="bookmark-title">Title</div>
+          <div class="bookmark-description">Description</div>
+        </div>
+      </a>
+    </figure>
+  """
+  link = tag.find("a")
+  if not link:
+    return None
+
+  url = link.get("href", "")
+  if not url:
+    return None
+
+  title_div = tag.find("div", class_="bookmark-title")
+  desc_div = tag.find("div", class_="bookmark-description")
+  title = title_div.get_text().strip() if title_div else ""
+  description = desc_div.get_text().strip() if desc_div else ""
+
+  return _make_block(
+    "url_embed",
+    url=url,
+    title=title,
+    description=description,
+    logo="",
+    provider="",
+    fetched_at="",
+    status="pending",
+  )
+
+
+# ── 요소 디스패처 ───────────────────────────────────────────────────────────────
+
+def _parse_element(element: Tag, report: ConversionReport) -> list[dict[str, Any]]:
+  """단일 HTML 요소를 파싱하여 블록 리스트로 변환합니다.
+
+  하나의 HTML 요소가 여러 블록을 생성할 수 있습니다 (예: 리스트).
+  """
+  tag_name = element.name.lower() if element.name else ""
+  classes = element.get("class") or []
+
+  report.total_elements += 1
+
+  # heading
+  if tag_name in ("h1", "h2", "h3"):
+    report.converted += 1
+    return [_parse_heading(element)]
+
+  # paragraph
+  if tag_name == "p":
+    block = _parse_paragraph(element)
+    if block:
+      report.converted += 1
+      return [block]
+    report.skipped += 1
+    return []
+
+  # list
+  if tag_name in ("ul", "ol"):
+    return _parse_list(element, report)
+
+  # toggle
+  if tag_name == "details":
+    report.converted += 1
+    return [_parse_toggle(element, report)]
+
+  # blockquote
+  if tag_name == "blockquote":
+    report.converted += 1
+    return [_parse_quote(element, report)]
+
+  # code block
+  if tag_name == "pre":
+    report.converted += 1
+    return [_parse_code(element)]
+
+  # divider
+  if tag_name == "hr":
+    report.converted += 1
+    return [_make_block("divider")]
+
+  # figure — callout / image / bookmark 분기
+  if tag_name == "figure":
+    if "callout" in classes:
+      report.converted += 1
+      return [_parse_callout(element, report)]
+    if "bookmark" in classes:
+      block = _parse_bookmark(element)
+      if block:
+        report.converted += 1
+        return [block]
+    # image figure
+    if element.find("img"):
+      block = _parse_image(element)
+      if block:
+        report.converted += 1
+        return [block]
+    report.skipped += 1
+    return []
+
+  # standalone image
+  if tag_name == "img":
+    block = _parse_image(element)
+    if block:
+      report.converted += 1
+      return [block]
+    report.skipped += 1
+    return []
+
+  # table
+  if tag_name == "table":
+    return _parse_table(element, report)
+
+  # div — 재귀적으로 내부 요소 파싱
+  if tag_name == "div":
+    blocks: list[dict[str, Any]] = []
+    for child in element.children:
+      if isinstance(child, Tag):
+        blocks.extend(_parse_element(child, report))
+    # div 자체는 요소 카운트에서 제외
+    report.total_elements -= 1
+    return blocks
+
+  # 미지원 요소 — fallback 텍스트 처리
+  text = element.get_text().strip()
+  if text:
+    report.fallback += 1
+    report.warnings.append(f"미지원 요소 <{tag_name}>를 텍스트로 변환했습니다")
+    return [_make_block("text", text=text)]
+
+  report.skipped += 1
+  return []
+
+
+# ── 페이지 파서 ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class ParsedPage:
+  """파싱된 Notion 페이지 한 장의 결과."""
+
+  title: str
+  blocks: list[dict[str, Any]]
+  sub_page_links: list[str]  # 하위 페이지 HTML 파일 상대 경로
+  report: ConversionReport
+
+
+def parse_notion_html(html_content: str) -> ParsedPage:
+  """단일 Notion HTML 파일을 파싱하여 블록 구조로 변환합니다.
+
+  Args:
+    html_content: Notion에서 export한 HTML 문자열.
+
+  Returns:
+    ParsedPage 객체 (제목, 블록 리스트, 하위 페이지 링크, 변환 리포트).
+  """
+  soup = BeautifulSoup(html_content, "html.parser")
+  report = ConversionReport()
+
+  # 제목 추출: <header> > <h1 class="page-title">
+  title = ""
+  header = soup.find("header")
+  if header:
+    h1 = header.find("h1", class_="page-title")
+    if h1:
+      title = h1.get_text().strip()
+
+  # title 태그 fallback
+  if not title:
+    title_tag = soup.find("title")
+    if title_tag:
+      title = title_tag.get_text().strip()
+
+  if not title:
+    title = "Untitled"
+
+  # 본문 파싱: <div class="page-body">
+  page_body = soup.find("div", class_="page-body")
+  blocks: list[dict[str, Any]] = []
+
+  if page_body:
+    for child in page_body.children:
+      if isinstance(child, Tag):
+        child_blocks = _parse_element(child, report)
+        blocks.extend(child_blocks)
+
+  # 하위 페이지 링크 수집
+  sub_page_links = _collect_subpage_links(soup)
+
+  return ParsedPage(
+    title=title,
+    blocks=blocks,
+    sub_page_links=sub_page_links,
+    report=report,
+  )
+
+
+def _collect_subpage_links(soup: BeautifulSoup) -> list[str]:
+  """페이지 내 하위 페이지 링크(.html)를 수집합니다.
+
+  Notion export에서 하위 페이지는 같은 폴더 내 별도 HTML 파일로 저장되며,
+  부모 페이지에서 <a href="SubPage%20UUID.html"> 형태로 참조됩니다.
+  """
+  links: list[str] = []
+  for a in soup.find_all("a", href=True):
+    href = a["href"]
+    # 외부 URL 및 앵커 링크 제외
+    if href.startswith(("http://", "https://", "#", "mailto:")):
+      continue
+    # .html 파일 링크만 수집
+    decoded = unquote(href)
+    if decoded.endswith(".html"):
+      links.append(decoded)
+  return links
+
+
+# ── ZIP 아카이브 처리 ───────────────────────────────────────────────────────────
+
+@dataclass
+class ImportResult:
+  """전체 import 작업 결과."""
+
+  pages: list[dict[str, Any]]  # 생성된 페이지 정보 리스트
+  report: ConversionReport
+  image_mappings: dict[str, bytes]  # 상대경로 → 이미지 바이트 데이터
+
+
+def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
+  """Notion export ZIP 파일을 추출하고 HTML 파일들을 파싱합니다.
+
+  ZIP 구조 (Notion HTML export):
+    Export-UUID/
+      PageTitle UUID.html
+      PageTitle UUID/
+        SubPage UUID.html
+        image1.png
+        SubPage UUID/
+          ...
+
+  Args:
+    zip_data: ZIP 파일의 바이트 데이터.
+
+  Returns:
+    ImportResult 객체.
+
+  Raises:
+    ValueError: ZIP 파일이 유효하지 않거나 HTML 파일이 없는 경우.
+  """
+  if not zipfile.is_zipfile(BytesIO(zip_data)):
+    raise ValueError("유효하지 않은 ZIP 파일입니다.")
+
+  overall_report = ConversionReport()
+  pages: list[dict[str, Any]] = []
+  image_mappings: dict[str, bytes] = {}
+
+  with zipfile.ZipFile(BytesIO(zip_data), "r") as zf:
+    # ZIP 내부 파일 목록 분류
+    html_files: list[str] = []
+    asset_files: list[str] = []
+
+    for name in zf.namelist():
+      # 디렉터리 엔트리 및 __MACOSX 제외
+      if name.endswith("/") or "__MACOSX" in name:
+        continue
+      if name.lower().endswith(".html"):
+        html_files.append(name)
+      elif _is_image_file(name):
+        asset_files.append(name)
+
+    if not html_files:
+      raise ValueError("ZIP 파일에 HTML 파일이 없습니다.")
+
+    # 이미지 파일 읽기
+    for asset_path in asset_files:
+      try:
+        image_mappings[asset_path] = zf.read(asset_path)
+      except Exception as exc:
+        logger.warning("이미지 읽기 실패: %s — %s", asset_path, exc)
+        overall_report.warnings.append(f"이미지 읽기 실패: {asset_path}")
+
+    # 페이지 계층 구조 결정: 경로 깊이 기준으로 정렬
+    html_files.sort(key=lambda p: p.count("/"))
+
+    # 각 HTML 파일 파싱
+    for html_path in html_files:
+      try:
+        raw = zf.read(html_path)
+        content = raw.decode("utf-8", errors="replace")
+        parsed = parse_notion_html(content)
+
+        # 이미지 URL을 ZIP 내 절대 경로로 정규화
+        html_dir = str(PurePosixPath(html_path).parent)
+        _resolve_image_urls(parsed.blocks, html_dir, image_mappings)
+
+        pages.append({
+          "path": html_path,
+          "title": parsed.title,
+          "blocks": parsed.blocks,
+          "sub_page_links": parsed.sub_page_links,
+        })
+
+        # 리포트 집계
+        overall_report.total_elements += parsed.report.total_elements
+        overall_report.converted += parsed.report.converted
+        overall_report.fallback += parsed.report.fallback
+        overall_report.skipped += parsed.report.skipped
+        overall_report.warnings.extend(parsed.report.warnings)
+
+      except Exception as exc:
+        logger.error("HTML 파싱 실패: %s — %s", html_path, exc)
+        overall_report.warnings.append(f"HTML 파싱 실패: {html_path}")
+
+  return ImportResult(pages=pages, report=overall_report, image_mappings=image_mappings)
+
+
+def parse_single_html(html_data: bytes) -> ImportResult:
+  """단일 HTML 파일을 파싱합니다 (ZIP이 아닌 경우).
+
+  Args:
+    html_data: HTML 파일의 바이트 데이터.
+
+  Returns:
+    ImportResult 객체 (이미지 매핑 없음).
+  """
+  content = html_data.decode("utf-8", errors="replace")
+  parsed = parse_notion_html(content)
+
+  pages = [{
+    "path": "",
+    "title": parsed.title,
+    "blocks": parsed.blocks,
+    "sub_page_links": parsed.sub_page_links,
+  }]
+
+  return ImportResult(
+    pages=pages,
+    report=parsed.report,
+    image_mappings={},
+  )
+
+
+def _resolve_image_urls(
+  blocks: list[dict[str, Any]],
+  html_dir: str,
+  image_mappings: dict[str, bytes],
+) -> None:
+  """블록 내 이미지 URL을 ZIP 내 절대 경로로 정규화합니다.
+
+  Notion export HTML에서 이미지 src는 상대 경로로 작성됩니다.
+  이를 ZIP 내부의 전체 경로로 변환하여 나중에 업로드 시 매칭할 수 있게 합니다.
+  """
+  for block in blocks:
+    if block.get("type") == "image":
+      url = block.get("url", "")
+      if url and not url.startswith(("http://", "https://", "/")):
+        decoded_url = unquote(url)
+        resolved = str(PurePosixPath(html_dir) / decoded_url)
+        # ZIP 내 실제 경로와 매칭 시도
+        if resolved in image_mappings:
+          block["url"] = resolved
+        else:
+          # 부분 매칭 시도 (파일명 기반)
+          filename = PurePosixPath(decoded_url).name
+          for key in image_mappings:
+            if PurePosixPath(key).name == filename:
+              block["url"] = key
+              break
+
+    # 재귀: 컨테이너 블록의 children 처리
+    children = block.get("children")
+    if children:
+      _resolve_image_urls(children, html_dir, image_mappings)
+
+
+def _is_image_file(filename: str) -> bool:
+  """파일명이 이미지 확장자인지 판별합니다."""
+  ext = PurePosixPath(filename).suffix.lower()
+  return ext in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"}

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1,16 +1,25 @@
-"""Notion Export HTML을 프로젝트 블록 구조로 변환하는 파서 서비스.
+"""Notion Export를 프로젝트 블록 구조로 변환하는 파서 서비스.
 
-Notion HTML Export 포맷:
-  - 각 페이지는 독립 HTML 파일로 export됨
-  - 페이지 제목은 <header><h1 class="page-title"> 에 위치
-  - 본문은 <div class="page-body"> 내부의 HTML 요소들로 구성
-  - 하위 페이지는 같은 폴더 내 별도 HTML 파일로 <a href="..."> 링크됨
-  - 이미지/첨부 파일은 페이지 이름과 동일한 폴더 안에 저장됨
+Notion Export 포맷 (HTML / Markdown+CSV 양쪽 지원):
+  HTML Export:
+    - 각 페이지는 독립 HTML 파일로 export됨
+    - 페이지 제목은 <header><h1 class="page-title"> 에 위치
+    - 본문은 <div class="page-body"> 내부의 HTML 요소들로 구성
+
+  Markdown Export:
+    - 각 페이지는 독립 .md 파일로 export됨
+    - 데이터베이스는 .csv 파일로 export됨
+    - 이미지는 페이지 이름과 동일한 하위 폴더에 저장됨
+    - 하위 페이지는 같은 폴더 내 별도 .md 파일로 [text](path) 링크됨
+
+  ZIP 구조:
+    - Notion export ZIP은 내부에 Part-N.zip을 포함할 수 있음 (이중 ZIP)
+    - 자동으로 내부 ZIP을 해제하여 콘텐츠를 추출함
 
 지원 블록 매핑:
   완전 지원 — heading(h1-h3), paragraph, bulleted/numbered list, to-do,
               toggle, quote, code, callout, divider, image, bookmark
-  부분 지원 — table(텍스트 기반 렌더링), column layout(순차 렌더링)
+  부분 지원 — table/CSV(텍스트 기반 렌더링), column layout(순차 렌더링)
   미지원   — embed, synced block, equation (fallback 텍스트 처리)
 
 참고:
@@ -19,6 +28,8 @@ Notion HTML Export 포맷:
 """
 from __future__ import annotations
 
+import csv
+import io
 import json
 import logging
 import re
@@ -646,17 +657,60 @@ class ImportResult:
   image_mappings: dict[str, bytes]  # 상대경로 → 이미지 바이트 데이터
 
 
-def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
-  """Notion export ZIP 파일을 추출하고 HTML 파일들을 파싱합니다.
+def _flatten_zip(zip_data: bytes) -> dict[str, bytes]:
+  """ZIP 파일 내 모든 파일을 추출합니다. 내부 ZIP도 재귀적으로 해제합니다.
 
-  ZIP 구조 (Notion HTML export):
-    Export-UUID/
-      PageTitle UUID.html
-      PageTitle UUID/
-        SubPage UUID.html
-        image1.png
-        SubPage UUID/
-          ...
+  Notion export ZIP은 대용량 export 시 내부에 Part-N.zip 파일을
+  포함할 수 있습니다. 이 함수는 모든 중첩 ZIP을 자동으로 해제하여
+  최종 콘텐츠 파일만 반환합니다.
+
+  Args:
+    zip_data: ZIP 파일의 바이트 데이터.
+
+  Returns:
+    {파일경로: 바이트데이터} dict. 디렉터리 엔트리와 __MACOSX는 제외됨.
+
+  Raises:
+    ValueError: 유효하지 않은 ZIP 파일인 경우.
+  """
+  if not zipfile.is_zipfile(BytesIO(zip_data)):
+    raise ValueError("유효하지 않은 ZIP 파일입니다.")
+
+  result: dict[str, bytes] = {}
+
+  with zipfile.ZipFile(BytesIO(zip_data), "r") as zf:
+    for name in zf.namelist():
+      if name.endswith("/") or "__MACOSX" in name:
+        continue
+
+      data = zf.read(name)
+
+      # 내부 ZIP 파일 감지 → 재귀 추출
+      if name.lower().endswith(".zip") and zipfile.is_zipfile(BytesIO(data)):
+        inner = _flatten_zip(data)
+        result.update(inner)
+      else:
+        result[name] = data
+
+  return result
+
+
+def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
+  """Notion export ZIP 파일을 추출하고 파싱합니다.
+
+  HTML과 Markdown 양쪽 export 포맷을 자동 감지하여 처리합니다.
+  내부에 Part-N.zip이 포함된 이중 ZIP 구조도 자동 해제합니다.
+
+  ZIP 구조 예시:
+    Export-UUID.zip
+      └─ Export-UUID-Part-1.zip    ← 이중 ZIP (자동 해제)
+           └─ 루트폴더/
+                ├─ 페이지.md (또는 .html)
+                ├─ 페이지/
+                │    ├─ 하위페이지.md
+                │    ├─ image.png
+                │    └─ 데이터베이스.csv
+                └─ 데이터베이스.csv
 
   Args:
     zip_data: ZIP 파일의 바이트 데이터.
@@ -665,71 +719,104 @@ def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
     ImportResult 객체.
 
   Raises:
-    ValueError: ZIP 파일이 유효하지 않거나 HTML 파일이 없는 경우.
+    ValueError: ZIP 파일이 유효하지 않거나 콘텐츠 파일이 없는 경우.
   """
-  if not zipfile.is_zipfile(BytesIO(zip_data)):
-    raise ValueError("유효하지 않은 ZIP 파일입니다.")
+  all_files = _flatten_zip(zip_data)
 
   overall_report = ConversionReport()
   pages: list[dict[str, Any]] = []
   image_mappings: dict[str, bytes] = {}
 
-  with zipfile.ZipFile(BytesIO(zip_data), "r") as zf:
-    # ZIP 내부 파일 목록 분류
-    html_files: list[str] = []
-    asset_files: list[str] = []
+  # 파일 분류
+  html_files: list[str] = []
+  md_files: list[str] = []
+  csv_files: list[str] = []
 
-    for name in zf.namelist():
-      # 디렉터리 엔트리 및 __MACOSX 제외
-      if name.endswith("/") or "__MACOSX" in name:
-        continue
-      if name.lower().endswith(".html"):
-        html_files.append(name)
-      elif _is_image_file(name):
-        asset_files.append(name)
+  for name in all_files:
+    lower = name.lower()
+    if lower.endswith((".html", ".htm")):
+      html_files.append(name)
+    elif lower.endswith(".md"):
+      md_files.append(name)
+    elif lower.endswith(".csv"):
+      # _all.csv 는 동일 데이터의 중복이므로 제외
+      if not lower.endswith("_all.csv"):
+        csv_files.append(name)
+    elif _is_image_file(name):
+      image_mappings[name] = all_files[name]
 
-    if not html_files:
-      raise ValueError("ZIP 파일에 HTML 파일이 없습니다.")
+  # 포맷 자동 감지: HTML 우선, 없으면 Markdown
+  content_files = html_files if html_files else md_files
+  is_markdown = not html_files and bool(md_files)
 
-    # 이미지 파일 읽기
-    for asset_path in asset_files:
-      try:
-        image_mappings[asset_path] = zf.read(asset_path)
-      except Exception as exc:
-        logger.warning("이미지 읽기 실패: %s — %s", asset_path, exc)
-        overall_report.warnings.append(f"이미지 읽기 실패: {asset_path}")
+  if not content_files:
+    raise ValueError("ZIP 파일에 변환 가능한 파일(.html/.md)이 없습니다.")
 
-    # 페이지 계층 구조 결정: 경로 깊이 기준으로 정렬
-    html_files.sort(key=lambda p: p.count("/"))
+  # 경로 깊이 기준 정렬 (상위 페이지 먼저)
+  content_files.sort(key=lambda p: p.count("/"))
 
-    # 각 HTML 파일 파싱
-    for html_path in html_files:
-      try:
-        raw = zf.read(html_path)
-        content = raw.decode("utf-8", errors="replace")
+  # 각 콘텐츠 파일 파싱
+  for file_path in content_files:
+    try:
+      raw = all_files[file_path]
+      content = raw.decode("utf-8", errors="replace")
+
+      if is_markdown:
+        parsed = parse_notion_markdown(content)
+      else:
         parsed = parse_notion_html(content)
 
-        # 이미지 URL을 ZIP 내 절대 경로로 정규화
-        html_dir = str(PurePosixPath(html_path).parent)
-        _resolve_image_urls(parsed.blocks, html_dir, image_mappings)
+      # 이미지 URL을 ZIP 내 절대 경로로 정규화
+      file_dir = str(PurePosixPath(file_path).parent)
+      _resolve_image_urls(parsed.blocks, file_dir, image_mappings)
 
-        pages.append({
-          "path": html_path,
-          "title": parsed.title,
-          "blocks": parsed.blocks,
-          "sub_page_links": parsed.sub_page_links,
-        })
+      pages.append({
+        "path": file_path,
+        "title": parsed.title,
+        "blocks": parsed.blocks,
+        "sub_page_links": parsed.sub_page_links,
+      })
 
-        # 리포트 집계
-        overall_report.total_elements += parsed.report.total_elements
-        overall_report.converted += parsed.report.converted
-        overall_report.fallback += parsed.report.fallback
-        overall_report.skipped += parsed.report.skipped
-        overall_report.warnings.extend(parsed.report.warnings)
+      # 리포트 집계
+      overall_report.total_elements += parsed.report.total_elements
+      overall_report.converted += parsed.report.converted
+      overall_report.fallback += parsed.report.fallback
+      overall_report.skipped += parsed.report.skipped
+      overall_report.warnings.extend(parsed.report.warnings)
 
-      except Exception as exc:
-        logger.error("HTML 파싱 실패: %s — %s", html_path, exc)
-        overall_report.warnings.append(f"HTML 파싱 실패: {html_path}")
+    except Exception as exc:
+      logger.error("파일 파싱 실패: %s — %s", file_path, exc)
+      overall_report.warnings.append(f"파일 파싱 실패: {file_path}")
+
+  # CSV 파일 → 테이블 블록으로 변환하여 관련 페이지에 추가
+  for csv_path in csv_files:
+    try:
+      raw = all_files[csv_path]
+      csv_text = raw.decode("utf-8-sig", errors="replace")
+      csv_blocks = _parse_csv_to_blocks(csv_text)
+      if csv_blocks:
+        csv_dir = str(PurePosixPath(csv_path).parent)
+        csv_stem = PurePosixPath(csv_path).stem
+        # UUID 해시 제거 — Notion export는 "제목 UUID해시.csv" 패턴
+        csv_title = re.sub(r"\s+[0-9a-f]{32}$", "", csv_stem).strip() or csv_stem
+
+        # 동일 디렉터리의 부모 페이지를 찾아 블록 추가
+        parent_page = _find_parent_page_for_csv(csv_dir, csv_title, pages)
+        if parent_page:
+          parent_page["blocks"].extend(csv_blocks)
+        else:
+          # 부모를 못 찾으면 독립 페이지로 생성
+          pages.append({
+            "path": csv_path,
+            "title": csv_title,
+            "blocks": csv_blocks,
+            "sub_page_links": [],
+          })
+        overall_report.converted += len(csv_blocks)
+        overall_report.total_elements += len(csv_blocks)
+    except Exception as exc:
+      logger.warning("CSV 파싱 실패: %s — %s", csv_path, exc)
+      overall_report.warnings.append(f"CSV 파싱 실패: {csv_path}")
 
   return ImportResult(pages=pages, report=overall_report, image_mappings=image_mappings)
 
@@ -745,6 +832,32 @@ def parse_single_html(html_data: bytes) -> ImportResult:
   """
   content = html_data.decode("utf-8", errors="replace")
   parsed = parse_notion_html(content)
+
+  pages = [{
+    "path": "",
+    "title": parsed.title,
+    "blocks": parsed.blocks,
+    "sub_page_links": parsed.sub_page_links,
+  }]
+
+  return ImportResult(
+    pages=pages,
+    report=parsed.report,
+    image_mappings={},
+  )
+
+
+def parse_single_markdown(md_data: bytes) -> ImportResult:
+  """단일 Markdown 파일을 파싱합니다 (ZIP이 아닌 경우).
+
+  Args:
+    md_data: Markdown 파일의 바이트 데이터.
+
+  Returns:
+    ImportResult 객체 (이미지 매핑 없음).
+  """
+  content = md_data.decode("utf-8", errors="replace")
+  parsed = parse_notion_markdown(content)
 
   pages = [{
     "path": "",
@@ -797,3 +910,346 @@ def _is_image_file(filename: str) -> bool:
   """파일명이 이미지 확장자인지 판별합니다."""
   ext = PurePosixPath(filename).suffix.lower()
   return ext in {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"}
+
+
+# ── Notion Markdown 파서 ───────────────────────────────────────────────────────
+#
+# Notion Markdown export 포맷:
+#   - 제목: 파일 첫 줄 `# 제목`
+#   - 소제목: `## / ###`
+#   - 본문: 일반 텍스트 행
+#   - 리스트: `- item` (bulleted), `1. item` (numbered)
+#   - 할일: `- [ ] todo`, `- [x] done`
+#   - 코드: ``` 블록
+#   - 인용: `> text`
+#   - 구분선: `---`
+#   - 이미지: `![alt](path)`
+#   - 링크: `[text](url)` — 하위 페이지 링크 포함
+#   - 인라인: **bold**, *italic*, ~~strike~~, `code`
+#
+# Ref: https://www.notion.so/help/export-your-content
+
+# Markdown 인라인 서식 → formatted_text 변환 패턴
+_MD_INLINE_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+  # 순서 중요: bold(**) 를 italic(*) 보다 먼저 매칭
+  (re.compile(r"\*\*(.+?)\*\*"), "<b>", "</b>"),
+  (re.compile(r"__(.+?)__"), "<b>", "</b>"),
+  (re.compile(r"\*(.+?)\*"), "<i>", "</i>"),
+  (re.compile(r"_(.+?)_"), "<i>", "</i>"),
+  (re.compile(r"~~(.+?)~~"), "<s>", "</s>"),
+  (re.compile(r"`(.+?)`"), "<code>", "</code>"),
+]
+
+# Markdown 링크 패턴: [text](url)
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+# Markdown 이미지 패턴: ![alt](path)
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+
+
+def _md_convert_inline(text: str) -> tuple[str, str | None]:
+  """Markdown 인라인 서식을 plain text와 formatted_text로 변환합니다.
+
+  Args:
+    text: Markdown 인라인 서식이 포함된 문자열.
+
+  Returns:
+    (plain_text, formatted_text) 튜플. 서식이 없으면 formatted_text는 None.
+  """
+  # 이미지 패턴은 인라인 변환에서 제외 (별도 블록으로 처리)
+  formatted = text
+
+  # 링크 변환: [text](url) → <a href="url">text</a>
+  formatted = _MD_LINK_RE.sub(r'<a href="\2">\1</a>', formatted)
+
+  # 인라인 서식 변환
+  for pattern, open_tag, close_tag in _MD_INLINE_PATTERNS:
+    formatted = pattern.sub(rf"{open_tag}\1{close_tag}", formatted)
+
+  # plain text: 모든 마크업 제거
+  plain = text
+  plain = _MD_LINK_RE.sub(r"\1", plain)
+  for pattern, _, _ in _MD_INLINE_PATTERNS:
+    plain = pattern.sub(r"\1", plain)
+
+  if formatted == plain:
+    return plain, None
+  return plain, formatted
+
+
+def parse_notion_markdown(md_content: str) -> ParsedPage:
+  """단일 Notion Markdown 파일을 파싱하여 블록 구조로 변환합니다.
+
+  Args:
+    md_content: Notion에서 export한 Markdown 문자열.
+
+  Returns:
+    ParsedPage 객체 (제목, 블록 리스트, 하위 페이지 링크, 변환 리포트).
+  """
+  report = ConversionReport()
+  blocks: list[dict[str, Any]] = []
+  sub_page_links: list[str] = []
+  title = "Untitled"
+
+  lines = md_content.split("\n")
+  i = 0
+
+  while i < len(lines):
+    line = lines[i]
+    stripped = line.strip()
+
+    # 빈 줄 건너뜀
+    if not stripped:
+      i += 1
+      continue
+
+    report.total_elements += 1
+
+    # ── 제목: # / ## / ### ──────────────────────────────────────────────
+    heading_match = re.match(r"^(#{1,3})\s+(.+)$", stripped)
+    if heading_match:
+      level = len(heading_match.group(1))
+      heading_text = heading_match.group(2).strip()
+      plain, formatted = _md_convert_inline(heading_text)
+
+      # 파일의 첫 번째 h1은 페이지 제목으로 사용
+      if level == 1 and title == "Untitled":
+        title = plain
+        report.converted += 1
+        i += 1
+        continue
+
+      block = _make_block("text", text=plain, level=level)
+      if formatted:
+        block["formatted_text"] = formatted
+      blocks.append(block)
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 이미지: ![alt](path) ────────────────────────────────────────────
+    img_match = _MD_IMAGE_RE.match(stripped)
+    if img_match:
+      caption = img_match.group(1)
+      url = unquote(img_match.group(2))
+      blocks.append(_make_block("image", url=url, caption=caption))
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 코드 블록: ``` ──────────────────────────────────────────────────
+    if stripped.startswith("```"):
+      language = stripped[3:].strip() or "plain"
+      code_lines: list[str] = []
+      i += 1
+      while i < len(lines):
+        if lines[i].strip().startswith("```"):
+          i += 1
+          break
+        code_lines.append(lines[i])
+        i += 1
+      code_text = "\n".join(code_lines)
+      blocks.append(_make_block("code", code=code_text, language=language))
+      report.converted += 1
+      continue
+
+    # ── 구분선: --- / *** / ___ ────────────────────────────────────────
+    if re.match(r"^[-*_]{3,}\s*$", stripped):
+      blocks.append(_make_block("divider"))
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 인용문: > ───────────────────────────────────────────────────────
+    if stripped.startswith(">"):
+      quote_lines: list[str] = []
+      while i < len(lines) and lines[i].strip().startswith(">"):
+        # > 접두사 제거
+        quote_text = re.sub(r"^>\s?", "", lines[i].strip())
+        quote_lines.append(quote_text)
+        i += 1
+      full_quote = "\n".join(quote_lines)
+      plain, formatted = _md_convert_inline(full_quote)
+      child = _make_block("text", text=plain)
+      if formatted:
+        child["formatted_text"] = formatted
+      blocks.append(_make_block("quote", text=plain, children=[child]))
+      report.converted += 1
+      continue
+
+    # ── 할일 리스트: - [ ] / - [x] ─────────────────────────────────────
+    todo_match = re.match(r"^-\s+\[([ xX])\]\s*(.*)", stripped)
+    if todo_match:
+      checked = todo_match.group(1).lower() == "x"
+      item_text = todo_match.group(2)
+      plain, formatted = _md_convert_inline(item_text)
+      prefix = "☑ " if checked else "☐ "
+      block = _make_block("text", text=prefix + plain)
+      if formatted:
+        block["formatted_text"] = prefix + formatted
+      blocks.append(block)
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 글머리 기호 리스트: - item ──────────────────────────────────────
+    bullet_match = re.match(r"^[-*+]\s+(.+)", stripped)
+    if bullet_match:
+      item_text = bullet_match.group(1)
+      # 하위 페이지 링크 감지: [text](path.md) 또는 [text](path.csv)
+      link_match = _MD_LINK_RE.match(item_text)
+      if link_match:
+        href = unquote(link_match.group(2))
+        if href.endswith((".md", ".csv")):
+          sub_page_links.append(href)
+          # 링크 항목은 일반 텍스트 블록으로 표시
+          plain, formatted = _md_convert_inline(item_text)
+          block = _make_block("text", text="• " + plain)
+          if formatted:
+            block["formatted_text"] = "• " + formatted
+          blocks.append(block)
+          report.converted += 1
+          i += 1
+          continue
+
+      plain, formatted = _md_convert_inline(item_text)
+      block = _make_block("text", text="• " + plain)
+      if formatted:
+        block["formatted_text"] = "• " + formatted
+      blocks.append(block)
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 번호 리스트: 1. item ────────────────────────────────────────────
+    num_match = re.match(r"^(\d+)\.\s+(.+)", stripped)
+    if num_match:
+      num = num_match.group(1)
+      item_text = num_match.group(2)
+      plain, formatted = _md_convert_inline(item_text)
+      block = _make_block("text", text=f"{num}. " + plain)
+      if formatted:
+        block["formatted_text"] = f"{num}. " + formatted
+      blocks.append(block)
+      report.converted += 1
+      i += 1
+      continue
+
+    # ── 일반 단락 ──────────────────────────────────────────────────────
+    # 여러 줄이 빈 줄 없이 이어지면 하나의 단락으로 합침
+    para_lines: list[str] = []
+    while i < len(lines) and lines[i].strip():
+      current = lines[i].strip()
+      # 다음 블록 시작 패턴이면 단락 종료
+      if (re.match(r"^#{1,3}\s", current)
+          or current.startswith("```")
+          or re.match(r"^[-*_]{3,}\s*$", current)
+          or current.startswith(">")
+          or re.match(r"^[-*+]\s+", current)
+          or re.match(r"^\d+\.\s+", current)
+          or _MD_IMAGE_RE.match(current)
+          or re.match(r"^-\s+\[[ xX]\]", current)):
+        break
+      para_lines.append(current)
+      i += 1
+
+    if para_lines:
+      full_text = " ".join(para_lines)
+
+      # 단독 링크 행 → URL embed 또는 하위 페이지
+      link_only = _MD_LINK_RE.fullmatch(full_text.strip())
+      if link_only:
+        href = unquote(link_only.group(2))
+        if href.startswith(("http://", "https://")):
+          blocks.append(_make_block(
+            "url_embed",
+            url=href,
+            title=link_only.group(1),
+            description="",
+            logo="",
+            provider="",
+            fetched_at="",
+            status="pending",
+          ))
+          report.converted += 1
+          continue
+        if href.endswith((".md", ".csv")):
+          sub_page_links.append(href)
+
+      plain, formatted = _md_convert_inline(full_text)
+      block = _make_block("text", text=plain)
+      if formatted:
+        block["formatted_text"] = formatted
+      blocks.append(block)
+      report.converted += 1
+      continue
+
+    i += 1
+
+  return ParsedPage(
+    title=title,
+    blocks=blocks,
+    sub_page_links=sub_page_links,
+    report=report,
+  )
+
+
+# ── CSV 파서 ────────────────────────────────────────────────────────────────────
+
+def _parse_csv_to_blocks(csv_text: str) -> list[dict[str, Any]]:
+  """Notion export CSV 파일을 텍스트 기반 블록으로 변환합니다.
+
+  Notion 데이터베이스는 CSV로 export되며, 첫 행이 컬럼 헤더입니다.
+  각 행을 파이프(|) 구분 텍스트 블록으로 변환합니다.
+
+  Args:
+    csv_text: CSV 파일 내용 문자열.
+
+  Returns:
+    블록 dict 리스트. 빈 CSV이면 빈 리스트.
+  """
+  reader = csv.reader(io.StringIO(csv_text))
+  rows = list(reader)
+  if not rows:
+    return []
+
+  blocks: list[dict[str, Any]] = []
+
+  # 헤더 행
+  header = rows[0]
+  if any(cell.strip() for cell in header):
+    blocks.append(_make_block("text", text=" | ".join(header), level=3))
+    blocks.append(_make_block("divider"))
+
+  # 데이터 행
+  for row in rows[1:]:
+    if any(cell.strip() for cell in row):
+      blocks.append(_make_block("text", text=" | ".join(row)))
+
+  return blocks
+
+
+def _find_parent_page_for_csv(
+  csv_dir: str,
+  csv_title: str,
+  pages: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+  """CSV 파일의 부모 페이지를 찾습니다.
+
+  Notion export에서 CSV 파일은 이를 참조하는 .md 파일과
+  같은 디렉터리 또는 상위 디렉터리에 위치합니다.
+  """
+  # 같은 디렉터리의 페이지 중 이름이 유사한 것을 찾음
+  for page in pages:
+    page_dir = str(PurePosixPath(page["path"]).parent)
+    if page_dir == csv_dir:
+      return page
+
+  # 상위 디렉터리의 페이지에서 탐색
+  parent_dir = str(PurePosixPath(csv_dir).parent)
+  for page in pages:
+    page_dir = str(PurePosixPath(page["path"]).parent)
+    if page_dir == parent_dir:
+      return page
+
+  return None

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
-from app.routers import auth, blocks, database, documents, files, upload, url_embed
+from app.routers import auth, blocks, database, documents, files, notion_import, upload, url_embed
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -23,6 +23,7 @@ app.include_router(database.router)
 app.include_router(upload.router)
 app.include_router(files.router)
 app.include_router(url_embed.router)
+app.include_router(notion_import.router)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-multipart>=0.0.24",
     "sqlalchemy>=2.0.49",
     "uvicorn[standard]>=0.35.0",
+    "beautifulsoup4>=4.12.0",
 ]
 
 [dependency-groups]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -152,9 +152,11 @@ body.sidebar-collapsed .sidebar-tab-chevron {
   align-items: center;
   justify-content: space-between;
   padding: 0 0.1rem;
+  gap: 0.3rem;
 }
 
 .document-list-header h2 {
+  flex: 1;
   margin: 0;
   font-family: "Fraunces", serif;
   font-size: 1.08rem;
@@ -2921,10 +2923,252 @@ body.lightbox-open {
   color: var(--ink);
 }
 
+/* ── Notion Import 버튼 ────────────────────────────────────────────────── */
+
+.notion-import-btn {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.28rem 0.55rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.notion-import-btn:hover {
+  background: var(--accent-soft);
+  border-color: rgba(0, 112, 109, 0.45);
+}
+
+/* ── Notion Import 모달 ─────────────────────────────────────────────────── */
+
+.notion-import-dialog {
+  border: none;
+  border-radius: 12px;
+  padding: 0;
+  max-width: 480px;
+  width: 90vw;
+  box-shadow: 0 8px 32px var(--shadow);
+  background: var(--panel);
+}
+
+.notion-import-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.notion-import-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.notion-import-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.notion-import-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+
+.notion-import-dropzone {
+  border: 2px dashed var(--line);
+  border-radius: 8px;
+  padding: 2rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.notion-import-dropzone:hover,
+.notion-import-dropzone.is-dragover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.notion-import-dropzone-icon {
+  font-size: 2rem;
+}
+
+.notion-import-dropzone-text {
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+}
+
+.notion-import-selected {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--accent-soft);
+}
+
+.notion-import-filename {
+  flex: 1;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notion-import-clear {
+  border: none;
+  background: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--ink-soft);
+  padding: 0 0.2rem;
+}
+
+.notion-import-clear:hover {
+  color: var(--ink);
+}
+
+.notion-import-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.notion-import-progress-bar {
+  height: 6px;
+  background: var(--paper-deep);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.notion-import-progress-fill {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+.notion-import-progress-fill.is-error {
+  background: #d44;
+}
+
+.notion-import-progress-text {
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+}
+
+.notion-import-report {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.notion-import-report-header {
+  padding: 0.5rem 0.8rem;
+  background: var(--accent-soft);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.notion-import-report-body {
+  padding: 0.5rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.notion-import-report-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  color: var(--ink);
+}
+
+.notion-import-report-warn {
+  color: #a67c00;
+}
+
+.notion-import-report-skip {
+  color: var(--ink-soft);
+}
+
+.notion-import-report-warnings {
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+}
+
+.notion-import-report-warnings summary {
+  cursor: pointer;
+  color: #a67c00;
+  font-weight: 500;
+}
+
+.notion-import-report-warnings ul {
+  margin: 0.3rem 0 0;
+  padding-left: 1.2rem;
+  max-height: 120px;
+  overflow-y: auto;
+  color: var(--ink-soft);
+}
+
+.notion-import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.notion-import-cancel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+}
+
+.notion-import-cancel:hover {
+  background: var(--paper-deep);
+}
+
+.notion-import-submit {
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.4rem 1.2rem;
+  cursor: pointer;
+}
+
+.notion-import-submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.notion-import-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ── Viewer 모드: 쓰기 UI 숨김 ───────────────────────────────────────────── */
 /* 미인증(viewer) 상태에서 생성/수정/삭제 관련 UI 요소를 숨긴다. */
 
 body.viewer-mode .new-document-btn,
+body.viewer-mode .notion-import-btn,
 body.viewer-mode .block-actions,
 body.viewer-mode .block-palette,
 body.viewer-mode .block-delete-confirm,

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -191,3 +191,17 @@ export async function apiPatchDatabaseBlock(dbBlockId, fields) {
   _checkPermission(res);
   if (!res.ok) throw new Error('Failed to patch database block');
 }
+
+// ── Notion Import API ────────────────────────────────────────────────────────
+
+export async function apiImportNotion(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch('/api/import/notion', { method: 'POST', body: form });
+  _checkPermission(res);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail ?? 'Notion import에 실패했습니다.');
+  }
+  return res.json();
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -16,6 +16,7 @@ import { openPagePickerModal } from "./pagePickerModal.js";
 import { callbacks, renderBlock, renderDocument, focusBlock } from "./blockRenderers.js";
 import { addDocumentItem, closeAllMenus, setActiveItem, enterInlineEdit } from "./documentList.js";
 import { initSidebar } from "./sidebar.js";
+import { openNotionImportModal } from "./notionImportModal.js";
 
 async function initGallery() {
   // 인증 상태 확인 및 로그인 UI 초기화
@@ -465,6 +466,17 @@ async function initGallery() {
     p.className = 'error-state';
     p.textContent = `문서를 불러오지 못했습니다: ${err.message}`;
     root.replaceChildren(p);
+  }
+
+  // ── Notion Import button ─────────────────────────────────────────────────
+  const importBtn = document.getElementById('notion-import-btn');
+  if (importBtn) {
+    importBtn.addEventListener('click', () => {
+      openNotionImportModal(async (docId) => {
+        await reloadSidebar();
+        loadDocument(docId);
+      });
+    });
   }
 
   // ── + 새 문서 button ──────────────────────────────────────────────────────

--- a/static/js/notionImportModal.js
+++ b/static/js/notionImportModal.js
@@ -118,6 +118,65 @@ function ensureDialog() {
   return dialog;
 }
 
+/**
+ * 변환 리포트 영역의 DOM을 안전하게 구성합니다.
+ * 모든 동적 값은 textContent로 삽입되어 XSS 위험이 없습니다.
+ * @param {{title: string, total_pages: number}} result
+ * @param {{converted: number, total_elements: number, fallback: number, skipped: number, warnings: string[]}} r
+ * @returns {DocumentFragment}
+ */
+function buildReport(result, r) {
+  const frag = document.createDocumentFragment();
+
+  const header = document.createElement("div");
+  header.className = "notion-import-report-header";
+  header.textContent = "변환 완료";
+
+  const body = document.createElement("div");
+  body.className = "notion-import-report-body";
+
+  const row = (label, value, extraClass = "") => {
+    const div = document.createElement("div");
+    div.className = "notion-import-report-row" + (extraClass ? ` ${extraClass}` : "");
+    const labelEl = document.createElement("span");
+    labelEl.textContent = label;
+    const valueEl = document.createElement("strong");
+    valueEl.textContent = value;
+    div.append(labelEl, valueEl);
+    return div;
+  };
+
+  body.append(
+    row("생성된 문서", String(result.title ?? "")),
+    row("총 페이지", `${result.total_pages}개`),
+    row("변환 요소", `${r.converted} / ${r.total_elements}`),
+  );
+
+  if (r.fallback > 0) {
+    body.append(row("Fallback 처리", `${r.fallback}건`, "notion-import-report-warn"));
+  }
+  if (r.skipped > 0) {
+    body.append(row("건너뜀", `${r.skipped}건`, "notion-import-report-skip"));
+  }
+  if (r.warnings.length > 0) {
+    const details = document.createElement("details");
+    details.className = "notion-import-report-warnings";
+    const summary = document.createElement("summary");
+    summary.textContent = `경고 (${r.warnings.length}건)`;
+    const list = document.createElement("ul");
+    r.warnings.forEach((w) => {
+      const item = document.createElement("li");
+      item.textContent = String(w);
+      list.appendChild(item);
+    });
+    details.append(summary, list);
+    body.appendChild(details);
+  }
+
+  frag.append(header, body);
+  return frag;
+}
+
 /** @type {File|null} */
 let selectedFile = null;
 
@@ -215,41 +274,12 @@ async function handleSubmit() {
     progressFill.style.width = "100%";
     progressText.textContent = "완료!";
 
-    // 변환 리포트 표시
+    // 변환 리포트 표시 — DOM API로 구성하여 사용자 제어 콘텐츠로 인한 XSS 방지
+    // (Notion 페이지 제목 및 경고 메시지에 HTML 메타문자가 포함될 수 있음)
+    // Ref: OWASP DOM-based XSS Prevention Cheat Sheet
     const r = result.report;
     report.hidden = false;
-    report.innerHTML = `
-      <div class="notion-import-report-header">변환 완료</div>
-      <div class="notion-import-report-body">
-        <div class="notion-import-report-row">
-          <span>생성된 문서</span>
-          <strong>${result.title}</strong>
-        </div>
-        <div class="notion-import-report-row">
-          <span>총 페이지</span>
-          <strong>${result.total_pages}개</strong>
-        </div>
-        <div class="notion-import-report-row">
-          <span>변환 요소</span>
-          <strong>${r.converted} / ${r.total_elements}</strong>
-        </div>
-        ${r.fallback > 0 ? `
-        <div class="notion-import-report-row notion-import-report-warn">
-          <span>Fallback 처리</span>
-          <strong>${r.fallback}건</strong>
-        </div>` : ""}
-        ${r.skipped > 0 ? `
-        <div class="notion-import-report-row notion-import-report-skip">
-          <span>건너뜀</span>
-          <strong>${r.skipped}건</strong>
-        </div>` : ""}
-        ${r.warnings.length > 0 ? `
-        <details class="notion-import-report-warnings">
-          <summary>경고 (${r.warnings.length}건)</summary>
-          <ul>${r.warnings.map((w) => `<li>${w}</li>`).join("")}</ul>
-        </details>` : ""}
-      </div>
-    `;
+    report.replaceChildren(buildReport(result, r));
 
     // 버튼 상태 변경
     submitBtn.textContent = "문서 열기";

--- a/static/js/notionImportModal.js
+++ b/static/js/notionImportModal.js
@@ -27,13 +27,13 @@ function ensureDialog() {
     <div class="notion-import-content">
       <h3 class="notion-import-title">Notion Import</h3>
       <p class="notion-import-desc">
-        Notion에서 export한 HTML 또는 ZIP 파일을 선택하세요.
+        Notion에서 export한 HTML, Markdown 또는 ZIP 파일을 선택하세요.
       </p>
 
       <div class="notion-import-dropzone" id="notion-import-dropzone">
         <span class="notion-import-dropzone-icon">&#128196;</span>
-        <span class="notion-import-dropzone-text">.html 또는 .zip 파일을 드래그하거나 클릭하세요</span>
-        <input type="file" id="notion-import-file" accept=".html,.htm,.zip" hidden />
+        <span class="notion-import-dropzone-text">.html, .md 또는 .zip 파일을 드래그하거나 클릭하세요</span>
+        <input type="file" id="notion-import-file" accept=".html,.htm,.md,.zip" hidden />
       </div>
 
       <div class="notion-import-selected" id="notion-import-selected" hidden>
@@ -126,8 +126,8 @@ let onComplete = null;
 
 function selectFile(file) {
   const name = file.name.toLowerCase();
-  if (!name.endsWith(".html") && !name.endsWith(".htm") && !name.endsWith(".zip")) {
-    alert("지원하지 않는 파일 형식입니다. .html 또는 .zip 파일을 선택해주세요.");
+  if (!name.endsWith(".html") && !name.endsWith(".htm") && !name.endsWith(".md") && !name.endsWith(".zip")) {
+    alert("지원하지 않는 파일 형식입니다. .html, .md 또는 .zip 파일을 선택해주세요.");
     return;
   }
 

--- a/static/js/notionImportModal.js
+++ b/static/js/notionImportModal.js
@@ -1,0 +1,280 @@
+// ── Notion Import Modal ──────────────────────────────────────────────────────
+//
+// Notion export HTML/ZIP 파일을 업로드하여 프로젝트 페이지로 변환하는
+// 모달 UI를 제공합니다.
+//
+// 플로우:
+//   1. 사용자가 Import 버튼 클릭 → 모달 열림
+//   2. 파일 선택 (.html / .zip)
+//   3. 업로드 및 변환 진행 (프로그레스 표시)
+//   4. 완료 → 변환 리포트 표시, 생성된 문서로 이동
+
+import { apiImportNotion } from "./api.js";
+
+/** @type {HTMLDialogElement|null} */
+let dialog = null;
+
+/**
+ * 모달 DOM을 한 번만 생성하고 재사용합니다.
+ * @returns {HTMLDialogElement}
+ */
+function ensureDialog() {
+  if (dialog) return dialog;
+
+  dialog = document.createElement("dialog");
+  dialog.className = "notion-import-dialog";
+  dialog.innerHTML = `
+    <div class="notion-import-content">
+      <h3 class="notion-import-title">Notion Import</h3>
+      <p class="notion-import-desc">
+        Notion에서 export한 HTML 또는 ZIP 파일을 선택하세요.
+      </p>
+
+      <div class="notion-import-dropzone" id="notion-import-dropzone">
+        <span class="notion-import-dropzone-icon">&#128196;</span>
+        <span class="notion-import-dropzone-text">.html 또는 .zip 파일을 드래그하거나 클릭하세요</span>
+        <input type="file" id="notion-import-file" accept=".html,.htm,.zip" hidden />
+      </div>
+
+      <div class="notion-import-selected" id="notion-import-selected" hidden>
+        <span class="notion-import-filename" id="notion-import-filename"></span>
+        <button type="button" class="notion-import-clear" id="notion-import-clear">&times;</button>
+      </div>
+
+      <div class="notion-import-progress" id="notion-import-progress" hidden>
+        <div class="notion-import-progress-bar">
+          <div class="notion-import-progress-fill" id="notion-import-progress-fill"></div>
+        </div>
+        <span class="notion-import-progress-text" id="notion-import-progress-text">변환 중...</span>
+      </div>
+
+      <div class="notion-import-report" id="notion-import-report" hidden></div>
+
+      <div class="notion-import-actions">
+        <button type="button" class="notion-import-cancel" id="notion-import-cancel">취소</button>
+        <button type="button" class="notion-import-submit" id="notion-import-submit" disabled>Import</button>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(dialog);
+
+  // 이벤트 바인딩
+  const dropzone = dialog.querySelector("#notion-import-dropzone");
+  const fileInput = dialog.querySelector("#notion-import-file");
+  const selectedEl = dialog.querySelector("#notion-import-selected");
+  const filenameEl = dialog.querySelector("#notion-import-filename");
+  const clearBtn = dialog.querySelector("#notion-import-clear");
+  const cancelBtn = dialog.querySelector("#notion-import-cancel");
+  const submitBtn = dialog.querySelector("#notion-import-submit");
+
+  // 클릭으로 파일 선택
+  dropzone.addEventListener("click", () => fileInput.click());
+
+  // 드래그 앤 드롭
+  dropzone.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    dropzone.classList.add("is-dragover");
+  });
+  dropzone.addEventListener("dragleave", () => {
+    dropzone.classList.remove("is-dragover");
+  });
+  dropzone.addEventListener("drop", (e) => {
+    e.preventDefault();
+    dropzone.classList.remove("is-dragover");
+    const files = e.dataTransfer.files;
+    if (files.length > 0) selectFile(files[0]);
+  });
+
+  // 파일 선택 이벤트
+  fileInput.addEventListener("change", () => {
+    if (fileInput.files.length > 0) selectFile(fileInput.files[0]);
+  });
+
+  // 선택 해제
+  clearBtn.addEventListener("click", () => {
+    resetFileSelection();
+  });
+
+  // 취소
+  cancelBtn.addEventListener("click", () => {
+    dialog.close();
+    resetState();
+  });
+
+  // backdrop 클릭으로 닫기
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) {
+      dialog.close();
+      resetState();
+    }
+  });
+
+  // ESC 닫기
+  dialog.addEventListener("cancel", () => {
+    resetState();
+  });
+
+  return dialog;
+}
+
+/** @type {File|null} */
+let selectedFile = null;
+
+/** @type {((docId: string) => void)|null} */
+let onComplete = null;
+
+function selectFile(file) {
+  const name = file.name.toLowerCase();
+  if (!name.endsWith(".html") && !name.endsWith(".htm") && !name.endsWith(".zip")) {
+    alert("지원하지 않는 파일 형식입니다. .html 또는 .zip 파일을 선택해주세요.");
+    return;
+  }
+
+  selectedFile = file;
+
+  const dropzone = dialog.querySelector("#notion-import-dropzone");
+  const selectedEl = dialog.querySelector("#notion-import-selected");
+  const filenameEl = dialog.querySelector("#notion-import-filename");
+  const submitBtn = dialog.querySelector("#notion-import-submit");
+
+  dropzone.hidden = true;
+  selectedEl.hidden = false;
+  filenameEl.textContent = file.name;
+  submitBtn.disabled = false;
+}
+
+function resetFileSelection() {
+  selectedFile = null;
+  const dropzone = dialog.querySelector("#notion-import-dropzone");
+  const selectedEl = dialog.querySelector("#notion-import-selected");
+  const fileInput = dialog.querySelector("#notion-import-file");
+  const submitBtn = dialog.querySelector("#notion-import-submit");
+
+  dropzone.hidden = false;
+  selectedEl.hidden = true;
+  fileInput.value = "";
+  submitBtn.disabled = true;
+}
+
+function resetState() {
+  resetFileSelection();
+  const progress = dialog.querySelector("#notion-import-progress");
+  const report = dialog.querySelector("#notion-import-report");
+  const submitBtn = dialog.querySelector("#notion-import-submit");
+  const cancelBtn = dialog.querySelector("#notion-import-cancel");
+
+  progress.hidden = true;
+  report.hidden = true;
+  submitBtn.disabled = true;
+  submitBtn.textContent = "Import";
+  cancelBtn.textContent = "취소";
+}
+
+/**
+ * Notion Import 모달을 열고, import 완료 시 콜백을 실행합니다.
+ * @param {(docId: string) => void} onImportComplete - 생성된 문서 ID로 이동하는 콜백
+ */
+export function openNotionImportModal(onImportComplete) {
+  const dlg = ensureDialog();
+  resetState();
+  onComplete = onImportComplete;
+
+  const submitBtn = dlg.querySelector("#notion-import-submit");
+
+  // 기존 리스너 제거 후 재등록
+  const newSubmit = submitBtn.cloneNode(true);
+  submitBtn.replaceWith(newSubmit);
+  newSubmit.addEventListener("click", handleSubmit);
+
+  dlg.showModal();
+}
+
+async function handleSubmit() {
+  if (!selectedFile || !dialog) return;
+
+  const progress = dialog.querySelector("#notion-import-progress");
+  const progressFill = dialog.querySelector("#notion-import-progress-fill");
+  const progressText = dialog.querySelector("#notion-import-progress-text");
+  const report = dialog.querySelector("#notion-import-report");
+  const submitBtn = dialog.querySelector("#notion-import-submit");
+  const cancelBtn = dialog.querySelector("#notion-import-cancel");
+
+  // 진행 상태 표시
+  progress.hidden = false;
+  submitBtn.disabled = true;
+  progressFill.style.width = "30%";
+  progressText.textContent = "파일 업로드 중...";
+
+  try {
+    progressFill.style.width = "60%";
+    progressText.textContent = "변환 중...";
+
+    const result = await apiImportNotion(selectedFile);
+
+    progressFill.style.width = "100%";
+    progressText.textContent = "완료!";
+
+    // 변환 리포트 표시
+    const r = result.report;
+    report.hidden = false;
+    report.innerHTML = `
+      <div class="notion-import-report-header">변환 완료</div>
+      <div class="notion-import-report-body">
+        <div class="notion-import-report-row">
+          <span>생성된 문서</span>
+          <strong>${result.title}</strong>
+        </div>
+        <div class="notion-import-report-row">
+          <span>총 페이지</span>
+          <strong>${result.total_pages}개</strong>
+        </div>
+        <div class="notion-import-report-row">
+          <span>변환 요소</span>
+          <strong>${r.converted} / ${r.total_elements}</strong>
+        </div>
+        ${r.fallback > 0 ? `
+        <div class="notion-import-report-row notion-import-report-warn">
+          <span>Fallback 처리</span>
+          <strong>${r.fallback}건</strong>
+        </div>` : ""}
+        ${r.skipped > 0 ? `
+        <div class="notion-import-report-row notion-import-report-skip">
+          <span>건너뜀</span>
+          <strong>${r.skipped}건</strong>
+        </div>` : ""}
+        ${r.warnings.length > 0 ? `
+        <details class="notion-import-report-warnings">
+          <summary>경고 (${r.warnings.length}건)</summary>
+          <ul>${r.warnings.map((w) => `<li>${w}</li>`).join("")}</ul>
+        </details>` : ""}
+      </div>
+    `;
+
+    // 버튼 상태 변경
+    submitBtn.textContent = "문서 열기";
+    submitBtn.disabled = false;
+    cancelBtn.textContent = "닫기";
+
+    // 버튼 동작 변경: 문서로 이동
+    const newSubmit = submitBtn.cloneNode(true);
+    submitBtn.replaceWith(newSubmit);
+    newSubmit.addEventListener("click", () => {
+      dialog.close();
+      resetState();
+      if (onComplete) onComplete(result.document_id);
+    });
+
+  } catch (err) {
+    progressFill.style.width = "100%";
+    progressFill.classList.add("is-error");
+    progressText.textContent = `오류: ${err.message}`;
+    submitBtn.disabled = false;
+    submitBtn.textContent = "다시 시도";
+
+    // 에러 후 다시 시도 가능하도록 초기화
+    setTimeout(() => {
+      progressFill.classList.remove("is-error");
+    }, 3000);
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
   <div class="document-list-header">
     <h2>Documents</h2>
     <button id="new-document-btn" type="button" class="new-document-btn">+ 새 문서</button>
+    <button id="notion-import-btn" type="button" class="notion-import-btn" title="Notion Import">&#8615; Import</button>
   </div>
   <ul id="document-list" class="document-list" aria-label="document list"></ul>
 </aside>

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -3,9 +3,11 @@
 테스트 범위:
   1. HTML 파서 서비스 — 각 블록 타입 변환 정확도
   2. 인라인 서식 변환 — bold, italic, link 등
-  3. ZIP 아카이브 처리 — 다중 페이지 구조 변환
+  3. ZIP 아카이브 처리 — 다중 페이지 구조 변환, 이중 ZIP
   4. Import API 엔드포인트 — HTTP 상태 코드 및 응답 구조
   5. 에러 처리 — 잘못된 파일 형식, 빈 파일, 큰 파일
+  6. Markdown 파서 서비스 — 각 블록 타입 변환
+  7. CSV 데이터베이스 파싱
 """
 from __future__ import annotations
 
@@ -19,11 +21,16 @@ from app.services.notion_import import (
   ConversionReport,
   ImportResult,
   _extract_inline_text,
+  _flatten_zip,
   _is_image_file,
   _make_block,
+  _md_convert_inline,
+  _parse_csv_to_blocks,
   extract_and_parse_zip,
   parse_notion_html,
+  parse_notion_markdown,
   parse_single_html,
+  parse_single_markdown,
 )
 
 
@@ -429,9 +436,9 @@ class TestZipProcessing:
     with pytest.raises(ValueError, match="유효하지 않은 ZIP"):
       extract_and_parse_zip(b"not a zip file")
 
-  def test_rejects_zip_without_html(self):
-    zip_data = _make_zip({"readme.txt": "no html here"})
-    with pytest.raises(ValueError, match="HTML 파일이 없습니다"):
+  def test_rejects_zip_without_content(self):
+    zip_data = _make_zip({"readme.txt": "no content here"})
+    with pytest.raises(ValueError, match="변환 가능한 파일"):
       extract_and_parse_zip(zip_data)
 
   def test_ignores_macosx_folder(self):
@@ -696,3 +703,303 @@ class TestComplexScenarios:
     result = parse_notion_html(html)
     # Level 1 + Level 2 = 2 blocks
     assert len(result.blocks) >= 2
+
+
+# ── Markdown 파서 테스트 ─────────────────────────────────────────────────────
+
+class TestMarkdownTitle:
+  """Markdown 제목 추출 테스트."""
+
+  def test_extracts_h1_title(self):
+    result = parse_notion_markdown("# My Page\n\nSome text")
+    assert result.title == "My Page"
+
+  def test_untitled_when_no_h1(self):
+    result = parse_notion_markdown("Some text without heading")
+    assert result.title == "Untitled"
+
+
+class TestMarkdownHeadings:
+  """Markdown 제목 블록 변환 테스트."""
+
+  def test_h2_becomes_level_2(self):
+    result = parse_notion_markdown("# Title\n\n## Section")
+    h2_blocks = [b for b in result.blocks if b.get("level") == 2]
+    assert len(h2_blocks) == 1
+    assert h2_blocks[0]["text"] == "Section"
+
+  def test_h3_becomes_level_3(self):
+    result = parse_notion_markdown("# Title\n\n### Subsection")
+    h3_blocks = [b for b in result.blocks if b.get("level") == 3]
+    assert len(h3_blocks) == 1
+
+
+class TestMarkdownParagraph:
+  """Markdown 단락 변환 테스트."""
+
+  def test_plain_paragraph(self):
+    result = parse_notion_markdown("# Title\n\nHello world")
+    text_blocks = [b for b in result.blocks if b["type"] == "text" and not b.get("level")]
+    assert len(text_blocks) == 1
+    assert text_blocks[0]["text"] == "Hello world"
+
+
+class TestMarkdownLists:
+  """Markdown 리스트 변환 테스트."""
+
+  def test_bulleted_list(self):
+    result = parse_notion_markdown("# T\n\n- Apple\n- Banana")
+    bullets = [b for b in result.blocks if "•" in b.get("text", "")]
+    assert len(bullets) == 2
+    assert "Apple" in bullets[0]["text"]
+
+  def test_numbered_list(self):
+    result = parse_notion_markdown("# T\n\n1. First\n2. Second")
+    nums = [b for b in result.blocks if b.get("text", "").startswith(("1.", "2."))]
+    assert len(nums) == 2
+
+  def test_todo_checked(self):
+    result = parse_notion_markdown("# T\n\n- [x] Done task")
+    assert any("☑" in b.get("text", "") for b in result.blocks)
+
+  def test_todo_unchecked(self):
+    result = parse_notion_markdown("# T\n\n- [ ] Pending task")
+    assert any("☐" in b.get("text", "") for b in result.blocks)
+
+
+class TestMarkdownCodeBlock:
+  """Markdown 코드 블록 변환 테스트."""
+
+  def test_fenced_code_with_language(self):
+    md = "# T\n\n```python\nprint('hello')\n```"
+    result = parse_notion_markdown(md)
+    code_blocks = [b for b in result.blocks if b["type"] == "code"]
+    assert len(code_blocks) == 1
+    assert code_blocks[0]["language"] == "python"
+    assert "print('hello')" in code_blocks[0]["code"]
+
+  def test_fenced_code_without_language(self):
+    md = "# T\n\n```\nplain text\n```"
+    result = parse_notion_markdown(md)
+    code_blocks = [b for b in result.blocks if b["type"] == "code"]
+    assert code_blocks[0]["language"] == "plain"
+
+
+class TestMarkdownQuote:
+  """Markdown 인용문 변환 테스트."""
+
+  def test_blockquote(self):
+    result = parse_notion_markdown("# T\n\n> A wise saying")
+    quotes = [b for b in result.blocks if b["type"] == "quote"]
+    assert len(quotes) == 1
+    assert "A wise saying" in quotes[0]["text"]
+
+
+class TestMarkdownDivider:
+  """Markdown 구분선 변환 테스트."""
+
+  def test_hr(self):
+    result = parse_notion_markdown("# T\n\n---")
+    dividers = [b for b in result.blocks if b["type"] == "divider"]
+    assert len(dividers) == 1
+
+
+class TestMarkdownImage:
+  """Markdown 이미지 변환 테스트."""
+
+  def test_image(self):
+    result = parse_notion_markdown("# T\n\n![caption](images/photo.png)")
+    imgs = [b for b in result.blocks if b["type"] == "image"]
+    assert len(imgs) == 1
+    assert "photo.png" in imgs[0]["url"]
+    assert imgs[0]["caption"] == "caption"
+
+
+class TestMarkdownInline:
+  """Markdown 인라인 서식 변환 테스트."""
+
+  def test_bold(self):
+    plain, fmt = _md_convert_inline("**bold text**")
+    assert plain == "bold text"
+    assert fmt == "<b>bold text</b>"
+
+  def test_italic(self):
+    plain, fmt = _md_convert_inline("*italic*")
+    assert plain == "italic"
+    assert fmt == "<i>italic</i>"
+
+  def test_strikethrough(self):
+    plain, fmt = _md_convert_inline("~~deleted~~")
+    assert plain == "deleted"
+    assert fmt == "<s>deleted</s>"
+
+  def test_inline_code(self):
+    plain, fmt = _md_convert_inline("`code`")
+    assert plain == "code"
+    assert fmt == "<code>code</code>"
+
+  def test_link(self):
+    plain, fmt = _md_convert_inline("[click](https://x.com)")
+    assert plain == "click"
+    assert 'href="https://x.com"' in fmt
+
+  def test_no_formatting_returns_none(self):
+    plain, fmt = _md_convert_inline("plain text")
+    assert plain == "plain text"
+    assert fmt is None
+
+
+class TestMarkdownSubpageLinks:
+  """Markdown 하위 페이지 링크 수집 테스트."""
+
+  def test_collects_md_links(self):
+    md = "# T\n\n- [SubPage](SubPage%20UUID.md)"
+    result = parse_notion_markdown(md)
+    assert len(result.sub_page_links) == 1
+    assert "SubPage UUID.md" in result.sub_page_links[0]
+
+
+# ── 이중 ZIP 처리 테스트 ─────────────────────────────────────────────────────
+
+class TestNestedZip:
+  """이중 ZIP (ZIP 내부 ZIP) 추출 테스트."""
+
+  def test_flatten_nested_zip(self):
+    """내부 ZIP을 자동으로 해제합니다."""
+    inner_zip = _make_zip({"page.md": "# Hello\n\nWorld"})
+    outer_zip = _make_zip({"Export-Part-1.zip": inner_zip.decode("latin-1")})
+    # 바이너리로 직접 생성
+    inner_buf = io.BytesIO()
+    with zipfile.ZipFile(inner_buf, "w") as zf:
+      zf.writestr("page.md", "# Hello\n\nWorld")
+    outer_buf = io.BytesIO()
+    with zipfile.ZipFile(outer_buf, "w") as zf:
+      zf.writestr("Export-Part-1.zip", inner_buf.getvalue())
+
+    files = _flatten_zip(outer_buf.getvalue())
+    assert "page.md" in files
+    assert b"# Hello" in files["page.md"]
+
+  def test_extract_and_parse_nested_zip(self):
+    """이중 ZIP에서 Markdown 파일을 파싱합니다."""
+    inner_buf = io.BytesIO()
+    with zipfile.ZipFile(inner_buf, "w") as zf:
+      zf.writestr("Root/page.md", "# Test Page\n\nContent here")
+    outer_buf = io.BytesIO()
+    with zipfile.ZipFile(outer_buf, "w") as zf:
+      zf.writestr("Export-Part-1.zip", inner_buf.getvalue())
+
+    result = extract_and_parse_zip(outer_buf.getvalue())
+    assert len(result.pages) == 1
+    assert result.pages[0]["title"] == "Test Page"
+
+  def test_nested_zip_with_images(self):
+    """이중 ZIP에서 이미지를 추출합니다."""
+    fake_png = b"\x89PNG" + b"\x00" * 50
+    inner_buf = io.BytesIO()
+    with zipfile.ZipFile(inner_buf, "w") as zf:
+      zf.writestr("Root/page.md", "# T\n\n![img](page/image.png)")
+      zf.writestr("Root/page/image.png", fake_png)
+    outer_buf = io.BytesIO()
+    with zipfile.ZipFile(outer_buf, "w") as zf:
+      zf.writestr("Part-1.zip", inner_buf.getvalue())
+
+    result = extract_and_parse_zip(outer_buf.getvalue())
+    assert len(result.image_mappings) == 1
+
+
+# ── CSV 파싱 테스트 ──────────────────────────────────────────────────────────
+
+class TestCsvParsing:
+  """CSV 데이터베이스 파싱 테스트."""
+
+  def test_csv_to_blocks(self):
+    csv_text = "Name,Score\nAlice,100\nBob,95"
+    blocks = _parse_csv_to_blocks(csv_text)
+    # 헤더 + 구분선 + 2 데이터 행 = 4 블록
+    assert len(blocks) == 4
+    assert blocks[0]["type"] == "text"
+    assert blocks[0]["level"] == 3
+    assert "Name" in blocks[0]["text"]
+    assert blocks[1]["type"] == "divider"
+
+  def test_empty_csv(self):
+    blocks = _parse_csv_to_blocks("")
+    assert blocks == []
+
+  def test_csv_in_zip_attached_to_parent(self):
+    """ZIP 내 CSV가 부모 페이지에 블록으로 추가됩니다."""
+    md_content = "# Project\n\n- [DB](DB%20abc123.csv)"
+    csv_content = "Task,Status\nDo thing,Done"
+    zip_data = _make_zip({
+      "Root/page.md": md_content,
+      "Root/DB abc123.csv": csv_content,
+    })
+    result = extract_and_parse_zip(zip_data)
+    # CSV 블록이 페이지에 추가되었는지 확인
+    all_blocks = []
+    for page in result.pages:
+      all_blocks.extend(page["blocks"])
+    # CSV 헤더 텍스트가 포함된 블록이 있어야 함
+    assert any("Task" in b.get("text", "") for b in all_blocks)
+
+  def test_all_csv_excluded(self):
+    """_all.csv 파일은 중복이므로 제외됩니다."""
+    zip_data = _make_zip({
+      "Root/page.md": "# Title\n\nText",
+      "Root/DB abc123.csv": "A,B\n1,2",
+      "Root/DB abc123_all.csv": "A,B\n1,2",
+    })
+    result = extract_and_parse_zip(zip_data)
+    # _all.csv가 처리되지 않았으므로 CSV 블록은 한 세트만 존재
+    csv_headers = [b for page in result.pages
+                   for b in page["blocks"]
+                   if b.get("level") == 3 and "A" in b.get("text", "")]
+    assert len(csv_headers) == 1
+
+
+# ── Markdown ZIP import API 테스트 ──────────────────────────────────────────
+
+class TestMarkdownImportAPI:
+  """Markdown 관련 Import API 테스트."""
+
+  def test_import_single_md_returns_201(self, client):
+    md = "# MD Page\n\nSome content\n\n- Item 1\n- Item 2"
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("page.md", md.encode(), "text/markdown")},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "MD Page"
+    assert data["total_pages"] == 1
+
+  def test_import_md_zip_returns_201(self, client):
+    """Markdown ZIP import 테스트."""
+    inner_buf = io.BytesIO()
+    with zipfile.ZipFile(inner_buf, "w") as zf:
+      zf.writestr("Root/page.md", "# ZipMD\n\nContent")
+    outer_buf = io.BytesIO()
+    with zipfile.ZipFile(outer_buf, "w") as zf:
+      zf.writestr("Part-1.zip", inner_buf.getvalue())
+
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", outer_buf.getvalue(), "application/zip")},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "ZipMD"
+
+  def test_import_md_preserves_block_types(self, client):
+    md = "# Title\n\nParagraph\n\n---\n\n```js\nconsole.log()\n```"
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.md", md.encode(), "text/markdown")},
+    )
+    doc_id = resp.json()["document_id"]
+    doc = client.get(f"/api/documents/{doc_id}").json()
+    types = [b["type"] for b in doc["blocks"]]
+    assert "text" in types
+    assert "divider" in types
+    assert "code" in types

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -925,6 +925,39 @@ class TestNestedZip:
     assert len(result.pages) == 1
     assert result.pages[0]["title"] == "CRC Test"
 
+  def test_nested_zip_depth_limit(self):
+    """과도한 중첩 ZIP은 차단합니다 (ZIP Bomb 방어)."""
+    from app.services import notion_import as ni
+
+    # MAX_NESTED_ZIP_DEPTH + 2 단계의 중첩 ZIP 생성
+    payload = b"# Inner\n\nContent"
+    inner = io.BytesIO()
+    with zipfile.ZipFile(inner, "w") as zf:
+      zf.writestr("page.md", payload)
+    payload = inner.getvalue()
+
+    for _ in range(ni.MAX_NESTED_ZIP_DEPTH + 2):
+      buf = io.BytesIO()
+      with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("nested.zip", payload)
+      payload = buf.getvalue()
+
+    with pytest.raises(ValueError, match="중첩 깊이"):
+      ni._flatten_zip(payload)
+
+  def test_zip_compression_ratio_limit(self):
+    """비정상적인 압축비는 차단합니다 (ZIP Bomb 방어)."""
+    from app.services import notion_import as ni
+
+    # 1MB 영(0) 바이트 데이터를 ZIP — 매우 높은 압축비
+    huge_zeros = b"\x00" * (1024 * 1024)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+      zf.writestr("zeros.bin", huge_zeros)
+
+    with pytest.raises(ValueError, match="압축비"):
+      ni._flatten_zip(buf.getvalue())
+
   def test_nested_zip_with_images(self):
     """이중 ZIP에서 이미지를 추출합니다."""
     fake_png = b"\x89PNG" + b"\x00" * 50

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1,0 +1,698 @@
+"""Notion Import 기능 단위 테스트.
+
+테스트 범위:
+  1. HTML 파서 서비스 — 각 블록 타입 변환 정확도
+  2. 인라인 서식 변환 — bold, italic, link 등
+  3. ZIP 아카이브 처리 — 다중 페이지 구조 변환
+  4. Import API 엔드포인트 — HTTP 상태 코드 및 응답 구조
+  5. 에러 처리 — 잘못된 파일 형식, 빈 파일, 큰 파일
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from app.services.notion_import import (
+  ConversionReport,
+  ImportResult,
+  _extract_inline_text,
+  _is_image_file,
+  _make_block,
+  extract_and_parse_zip,
+  parse_notion_html,
+  parse_single_html,
+)
+
+
+# ── 테스트 HTML 헬퍼 ─────────────────────────────────────────────────────────
+
+def _wrap_notion_html(body: str, title: str = "Test Page") -> str:
+  """Notion export HTML 형식의 최소 구조를 반환합니다."""
+  return f"""<!DOCTYPE html>
+<html>
+<head><title>{title}</title></head>
+<body>
+<article>
+  <header><h1 class="page-title">{title}</h1></header>
+  <div class="page-body">
+    {body}
+  </div>
+</article>
+</body>
+</html>"""
+
+
+def _make_zip(files: dict[str, str]) -> bytes:
+  """파일명 → 내용 dict로 in-memory ZIP 파일을 생성합니다."""
+  buf = io.BytesIO()
+  with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+    for name, content in files.items():
+      zf.writestr(name, content)
+  return buf.getvalue()
+
+
+def _make_zip_with_image(html_files: dict[str, str], image_files: dict[str, bytes]) -> bytes:
+  """HTML과 이미지 파일을 포함하는 ZIP을 생성합니다."""
+  buf = io.BytesIO()
+  with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+    for name, content in html_files.items():
+      zf.writestr(name, content)
+    for name, data in image_files.items():
+      zf.writestr(name, data)
+  return buf.getvalue()
+
+
+# ── 파서 서비스: 제목 추출 ───────────────────────────────────────────────────
+
+class TestTitleExtraction:
+  """페이지 제목 추출 테스트."""
+
+  def test_extracts_page_title_from_header(self):
+    html = _wrap_notion_html("<p>content</p>", title="My Title")
+    result = parse_notion_html(html)
+    assert result.title == "My Title"
+
+  def test_falls_back_to_title_tag(self):
+    html = """<html><head><title>Fallback Title</title></head>
+    <body><div class="page-body"><p>text</p></div></body></html>"""
+    result = parse_notion_html(html)
+    assert result.title == "Fallback Title"
+
+  def test_uses_untitled_when_no_title(self):
+    html = """<html><body><div class="page-body"><p>text</p></div></body></html>"""
+    result = parse_notion_html(html)
+    assert result.title == "Untitled"
+
+
+# ── 파서 서비스: 블록 변환 ───────────────────────────────────────────────────
+
+class TestHeadingParsing:
+  """제목(heading) 블록 변환 테스트."""
+
+  def test_h1_becomes_text_level_1(self):
+    html = _wrap_notion_html("<h1>Heading 1</h1>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "text"
+    assert block["text"] == "Heading 1"
+    assert block["level"] == 1
+
+  def test_h2_becomes_text_level_2(self):
+    html = _wrap_notion_html("<h2>Heading 2</h2>")
+    result = parse_notion_html(html)
+    assert result.blocks[0]["level"] == 2
+
+  def test_h3_becomes_text_level_3(self):
+    html = _wrap_notion_html("<h3>Heading 3</h3>")
+    result = parse_notion_html(html)
+    assert result.blocks[0]["level"] == 3
+
+
+class TestParagraphParsing:
+  """문단(paragraph) 블록 변환 테스트."""
+
+  def test_paragraph_becomes_text_block(self):
+    html = _wrap_notion_html("<p>Hello World</p>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    assert result.blocks[0]["type"] == "text"
+    assert result.blocks[0]["text"] == "Hello World"
+
+  def test_empty_paragraph_is_skipped(self):
+    html = _wrap_notion_html("<p>   </p>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 0
+
+  def test_multiple_paragraphs(self):
+    html = _wrap_notion_html("<p>First</p><p>Second</p><p>Third</p>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 3
+
+
+class TestListParsing:
+  """리스트 블록 변환 테스트."""
+
+  def test_bulleted_list(self):
+    html = _wrap_notion_html(
+      '<ul class="bulleted-list"><li>Item A</li><li>Item B</li></ul>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 2
+    assert result.blocks[0]["text"].startswith("• ")
+    assert "Item A" in result.blocks[0]["text"]
+
+  def test_numbered_list(self):
+    html = _wrap_notion_html(
+      '<ol class="numbered-list"><li>First</li><li>Second</li></ol>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 2
+    assert result.blocks[0]["text"].startswith("1. ")
+    assert result.blocks[1]["text"].startswith("2. ")
+
+  def test_todo_list_checked(self):
+    html = _wrap_notion_html(
+      '<ul class="to-do-list"><li><div class="checkbox checkbox-on"></div>Done</li></ul>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    assert result.blocks[0]["text"].startswith("☑")
+
+  def test_todo_list_unchecked(self):
+    html = _wrap_notion_html(
+      '<ul class="to-do-list"><li><div class="checkbox checkbox-off"></div>Pending</li></ul>'
+    )
+    result = parse_notion_html(html)
+    assert result.blocks[0]["text"].startswith("☐")
+
+
+class TestToggleParsing:
+  """토글 블록 변환 테스트."""
+
+  def test_details_becomes_toggle(self):
+    html = _wrap_notion_html(
+      "<details><summary>Toggle Title</summary><p>Inner content</p></details>"
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "toggle"
+    assert block["text"] == "Toggle Title"
+    assert len(block["children"]) >= 1
+
+  def test_empty_toggle_has_default_child(self):
+    html = _wrap_notion_html(
+      "<details><summary>Empty</summary></details>"
+    )
+    result = parse_notion_html(html)
+    block = result.blocks[0]
+    assert len(block["children"]) == 1
+    assert block["children"][0]["type"] == "text"
+
+
+class TestQuoteParsing:
+  """인용문 블록 변환 테스트."""
+
+  def test_blockquote_becomes_quote(self):
+    html = _wrap_notion_html("<blockquote><p>A wise quote</p></blockquote>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "quote"
+    assert len(block["children"]) >= 1
+
+
+class TestCodeParsing:
+  """코드 블록 변환 테스트."""
+
+  def test_pre_code_becomes_code_block(self):
+    html = _wrap_notion_html(
+      '<pre class="code"><code class="language-python">print("hello")</code></pre>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "code"
+    assert 'print("hello")' in block["code"]
+    assert block["language"] == "python"
+
+  def test_code_without_language(self):
+    html = _wrap_notion_html(
+      '<pre class="code"><code>plain text</code></pre>'
+    )
+    result = parse_notion_html(html)
+    assert result.blocks[0]["language"] == "plain"
+
+
+class TestDividerParsing:
+  """구분선 블록 변환 테스트."""
+
+  def test_hr_becomes_divider(self):
+    html = _wrap_notion_html("<hr/>")
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    assert result.blocks[0]["type"] == "divider"
+
+
+class TestCalloutParsing:
+  """콜아웃 블록 변환 테스트."""
+
+  def test_callout_figure(self):
+    html = _wrap_notion_html(
+      '<figure class="callout"><span class="icon">⚠️</span>'
+      '<div class="callout-body"><p>Warning text</p></div></figure>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "callout"
+    assert block["emoji"] == "⚠️"
+    assert len(block["children"]) >= 1
+
+
+class TestImageParsing:
+  """이미지 블록 변환 테스트."""
+
+  def test_figure_img(self):
+    html = _wrap_notion_html(
+      '<figure><img src="images/photo.png"/>'
+      '<figcaption>A nice photo</figcaption></figure>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "image"
+    assert "photo.png" in block["url"]
+    assert block["caption"] == "A nice photo"
+
+  def test_standalone_img(self):
+    html = _wrap_notion_html('<img src="test.jpg"/>')
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    assert result.blocks[0]["type"] == "image"
+
+
+class TestBookmarkParsing:
+  """북마크(URL embed) 블록 변환 테스트."""
+
+  def test_bookmark_figure(self):
+    html = _wrap_notion_html(
+      '<figure class="bookmark source">'
+      '<a href="https://example.com">'
+      '<div class="bookmark-info">'
+      '<div class="bookmark-title">Example</div>'
+      '<div class="bookmark-description">A site</div>'
+      '</div></a></figure>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.blocks) == 1
+    block = result.blocks[0]
+    assert block["type"] == "url_embed"
+    assert block["url"] == "https://example.com"
+    assert block["title"] == "Example"
+
+
+class TestTableParsing:
+  """테이블 변환 테스트 (fallback 텍스트)."""
+
+  def test_table_becomes_text_blocks(self):
+    html = _wrap_notion_html(
+      '<table><thead><tr><th>Name</th><th>Value</th></tr></thead>'
+      '<tbody><tr><td>A</td><td>1</td></tr></tbody></table>'
+    )
+    result = parse_notion_html(html)
+    # 헤더 + 구분선 + 데이터 행 = 최소 3블록
+    assert len(result.blocks) >= 2
+    assert result.report.fallback >= 1
+
+
+# ── 인라인 서식 변환 ─────────────────────────────────────────────────────────
+
+class TestInlineFormatting:
+  """인라인 서식 태그 변환 테스트."""
+
+  def test_bold(self):
+    from bs4 import BeautifulSoup
+    tag = BeautifulSoup("<p><strong>bold</strong></p>", "html.parser").find("p")
+    plain, fmt = _extract_inline_text(tag)
+    assert plain == "bold"
+    assert "<b>bold</b>" in fmt
+
+  def test_italic(self):
+    from bs4 import BeautifulSoup
+    tag = BeautifulSoup("<p><em>italic</em></p>", "html.parser").find("p")
+    plain, fmt = _extract_inline_text(tag)
+    assert plain == "italic"
+    assert "<i>italic</i>" in fmt
+
+  def test_link(self):
+    from bs4 import BeautifulSoup
+    tag = BeautifulSoup(
+      '<p><a href="https://x.com">click</a></p>', "html.parser"
+    ).find("p")
+    plain, fmt = _extract_inline_text(tag)
+    assert plain == "click"
+    assert 'href="https://x.com"' in fmt
+
+  def test_mixed_formatting(self):
+    from bs4 import BeautifulSoup
+    tag = BeautifulSoup(
+      "<p>Plain <strong>bold</strong> and <em>italic</em></p>", "html.parser"
+    ).find("p")
+    plain, fmt = _extract_inline_text(tag)
+    assert plain == "Plain bold and italic"
+    assert "<b>bold</b>" in fmt
+    assert "<i>italic</i>" in fmt
+
+  def test_formatted_text_set_when_different(self):
+    """formatted_text는 plain text와 다를 때만 설정됩니다."""
+    html = _wrap_notion_html("<p><strong>bold text</strong></p>")
+    result = parse_notion_html(html)
+    block = result.blocks[0]
+    assert block.get("formatted_text") is not None
+    assert "<b>" in block["formatted_text"]
+
+  def test_formatted_text_not_set_for_plain(self):
+    """서식이 없는 텍스트에는 formatted_text가 설정되지 않습니다."""
+    html = _wrap_notion_html("<p>plain text</p>")
+    result = parse_notion_html(html)
+    block = result.blocks[0]
+    assert "formatted_text" not in block
+
+
+# ── 하위 페이지 링크 수집 ────────────────────────────────────────────────────
+
+class TestSubpageLinkCollection:
+  """하위 페이지 HTML 링크 수집 테스트."""
+
+  def test_collects_html_links(self):
+    html = _wrap_notion_html(
+      '<p><a href="SubPage%20UUID.html">SubPage</a></p>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.sub_page_links) == 1
+    assert "SubPage UUID.html" in result.sub_page_links[0]
+
+  def test_ignores_external_links(self):
+    html = _wrap_notion_html(
+      '<p><a href="https://example.com">External</a></p>'
+    )
+    result = parse_notion_html(html)
+    assert len(result.sub_page_links) == 0
+
+  def test_ignores_anchor_links(self):
+    html = _wrap_notion_html('<p><a href="#section">Anchor</a></p>')
+    result = parse_notion_html(html)
+    assert len(result.sub_page_links) == 0
+
+
+# ── ZIP 아카이브 처리 ────────────────────────────────────────────────────────
+
+class TestZipProcessing:
+  """ZIP 아카이브 파싱 테스트."""
+
+  def test_parses_single_html_in_zip(self):
+    html = _wrap_notion_html("<p>Content</p>", title="ZipPage")
+    zip_data = _make_zip({"Page.html": html})
+    result = extract_and_parse_zip(zip_data)
+    assert len(result.pages) == 1
+    assert result.pages[0]["title"] == "ZipPage"
+
+  def test_parses_multiple_html_files(self):
+    page1 = _wrap_notion_html("<p>Root</p>", title="Root")
+    page2 = _wrap_notion_html("<p>Child</p>", title="Child")
+    zip_data = _make_zip({
+      "Root.html": page1,
+      "Root/Child.html": page2,
+    })
+    result = extract_and_parse_zip(zip_data)
+    assert len(result.pages) == 2
+
+  def test_collects_images_from_zip(self):
+    html = _wrap_notion_html(
+      '<figure><img src="images/test.png"/></figure>',
+      title="WithImage",
+    )
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    zip_data = _make_zip_with_image(
+      {"Page.html": html},
+      {"images/test.png": fake_png},
+    )
+    result = extract_and_parse_zip(zip_data)
+    assert len(result.image_mappings) == 1
+
+  def test_rejects_non_zip(self):
+    with pytest.raises(ValueError, match="유효하지 않은 ZIP"):
+      extract_and_parse_zip(b"not a zip file")
+
+  def test_rejects_zip_without_html(self):
+    zip_data = _make_zip({"readme.txt": "no html here"})
+    with pytest.raises(ValueError, match="HTML 파일이 없습니다"):
+      extract_and_parse_zip(zip_data)
+
+  def test_ignores_macosx_folder(self):
+    html = _wrap_notion_html("<p>Content</p>")
+    zip_data = _make_zip({
+      "Page.html": html,
+      "__MACOSX/._Page.html": "junk",
+    })
+    result = extract_and_parse_zip(zip_data)
+    assert len(result.pages) == 1
+
+
+class TestSingleHtmlParsing:
+  """단일 HTML 파일 파싱 테스트."""
+
+  def test_parses_single_html_bytes(self):
+    html = _wrap_notion_html("<p>Solo page</p>", title="Solo")
+    result = parse_single_html(html.encode("utf-8"))
+    assert len(result.pages) == 1
+    assert result.pages[0]["title"] == "Solo"
+    assert len(result.image_mappings) == 0
+
+
+# ── 변환 리포트 ──────────────────────────────────────────────────────────────
+
+class TestConversionReport:
+  """변환 리포트 생성 테스트."""
+
+  def test_report_counts(self):
+    html = _wrap_notion_html(
+      "<h1>Title</h1><p>Text</p><hr/><p>  </p>"
+    )
+    result = parse_notion_html(html)
+    report = result.report
+    assert report.converted >= 3  # h1 + p + hr
+    assert report.skipped >= 1    # 빈 <p>
+
+  def test_report_to_dict(self):
+    report = ConversionReport(
+      total_elements=10, converted=7, fallback=2, skipped=1,
+      warnings=["warning1"],
+    )
+    d = report.to_dict()
+    assert d["total_elements"] == 10
+    assert d["converted"] == 7
+    assert d["warnings"] == ["warning1"]
+
+
+# ── 유틸리티 함수 ────────────────────────────────────────────────────────────
+
+class TestUtilities:
+  """유틸리티 함수 테스트."""
+
+  def test_make_block_has_uuid(self):
+    block = _make_block("text", text="hello")
+    assert "id" in block
+    assert len(block["id"]) == 36  # UUID v4 format
+
+  def test_is_image_file(self):
+    assert _is_image_file("photo.png") is True
+    assert _is_image_file("image.jpg") is True
+    assert _is_image_file("pic.JPEG") is True
+    assert _is_image_file("document.pdf") is False
+    assert _is_image_file("script.js") is False
+
+
+# ── API 엔드포인트 테스트 ────────────────────────────────────────────────────
+
+class TestImportAPI:
+  """Import API 엔드포인트 HTTP 테스트."""
+
+  def test_import_single_html_returns_201(self, client):
+    html = _wrap_notion_html("<p>API Test</p>", title="ImportedPage")
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.html", html.encode(), "text/html")},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "document_id" in data
+    assert data["title"] == "ImportedPage"
+    assert data["total_pages"] == 1
+    assert "report" in data
+
+  def test_import_zip_returns_201(self, client):
+    page1 = _wrap_notion_html("<p>Root</p>", title="ZipRoot")
+    page2 = _wrap_notion_html("<p>Child</p>", title="ZipChild")
+    zip_data = _make_zip({
+      "Root.html": page1,
+      "Root/Child.html": page2,
+    })
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", zip_data, "application/zip")},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["total_pages"] == 2
+
+  def test_import_unsupported_format_returns_415(self, client):
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.pdf", b"pdf data", "application/pdf")},
+    )
+    assert resp.status_code == 415
+
+  def test_import_empty_file_returns_422(self, client):
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.html", b"", "text/html")},
+    )
+    assert resp.status_code == 422
+
+  def test_import_invalid_zip_returns_422(self, client):
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("bad.zip", b"not a zip", "application/zip")},
+    )
+    assert resp.status_code == 422
+
+  def test_imported_document_is_accessible(self, client):
+    """Import된 문서가 문서 목록에서 조회 가능합니다."""
+    html = _wrap_notion_html(
+      "<h2>Heading</h2><p>Body text</p>",
+      title="Accessible",
+    )
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.html", html.encode(), "text/html")},
+    )
+    assert resp.status_code == 201
+    doc_id = resp.json()["document_id"]
+
+    # 문서 조회
+    doc_resp = client.get(f"/api/documents/{doc_id}")
+    assert doc_resp.status_code == 200
+    doc = doc_resp.json()
+    assert doc["title"] == "Accessible"
+    # 블록이 생성되어 있는지 확인
+    assert len(doc["blocks"]) >= 2
+
+  def test_import_preserves_block_types(self, client):
+    """Import 후 블록 타입이 올바르게 보존됩니다."""
+    html = _wrap_notion_html(
+      "<h1>Title</h1><p>Paragraph</p><hr/>"
+      '<pre class="code"><code class="language-js">code</code></pre>'
+    )
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("test.html", html.encode(), "text/html")},
+    )
+    doc_id = resp.json()["document_id"]
+    doc = client.get(f"/api/documents/{doc_id}").json()
+
+    types = [b["type"] for b in doc["blocks"]]
+    assert "text" in types
+    assert "divider" in types
+    assert "code" in types
+
+  def test_import_creates_child_page_blocks(self, client):
+    """ZIP import 시 하위 페이지가 PageBlock으로 연결됩니다."""
+    root_html = _wrap_notion_html("<p>Root</p>", title="MultiRoot")
+    child_html = _wrap_notion_html("<p>Child content</p>", title="ChildPage")
+    zip_data = _make_zip({
+      "Root.html": root_html,
+      "Root/Child.html": child_html,
+    })
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", zip_data, "application/zip")},
+    )
+    assert resp.status_code == 201
+    doc_id = resp.json()["document_id"]
+
+    # 루트 문서에 page 블록이 포함되어 있는지 확인
+    doc = client.get(f"/api/documents/{doc_id}").json()
+    page_blocks = [b for b in doc["blocks"] if b["type"] == "page"]
+    assert len(page_blocks) >= 1
+
+  def test_viewer_cannot_import(self, client, engine):
+    """미인증 사용자는 import할 수 없습니다."""
+    from fastapi.testclient import TestClient
+    from sqlalchemy.orm import Session
+
+    from main import app
+    from app.dependencies import get_repository
+    from app.repositories.sqlite_blocks import SQLiteBlockRepository
+
+    def _override():
+      with Session(engine) as s:
+        yield SQLiteBlockRepository(s)
+
+    app.dependency_overrides[get_repository] = _override
+    with TestClient(app) as anon_client:
+      html = _wrap_notion_html("<p>No auth</p>")
+      resp = anon_client.post(
+        "/api/import/notion",
+        files={"file": ("test.html", html.encode(), "text/html")},
+      )
+      assert resp.status_code == 403
+    app.dependency_overrides.clear()
+
+
+# ── 복합 시나리오 테스트 ─────────────────────────────────────────────────────
+
+class TestComplexScenarios:
+  """복합 변환 시나리오 테스트."""
+
+  def test_nested_toggle_with_code(self):
+    """토글 내부에 코드 블록이 있는 구조를 변환합니다."""
+    html = _wrap_notion_html(
+      '<details><summary>API 예제</summary>'
+      '<pre class="code"><code class="language-python">'
+      'import requests\nresp = requests.get("/")'
+      '</code></pre></details>'
+    )
+    result = parse_notion_html(html)
+    toggle = result.blocks[0]
+    assert toggle["type"] == "toggle"
+    code_children = [c for c in toggle["children"] if c["type"] == "code"]
+    assert len(code_children) == 1
+    assert "import requests" in code_children[0]["code"]
+
+  def test_mixed_content_page(self):
+    """다양한 블록 타입이 혼합된 페이지 변환."""
+    html = _wrap_notion_html("""
+      <h1>Main Title</h1>
+      <p>Introduction paragraph.</p>
+      <ul class="bulleted-list"><li>Point A</li><li>Point B</li></ul>
+      <hr/>
+      <blockquote><p>A quote from someone</p></blockquote>
+      <pre class="code"><code>console.log('hello')</code></pre>
+    """)
+    result = parse_notion_html(html)
+    types = [b["type"] for b in result.blocks]
+    assert "text" in types
+    assert "divider" in types
+    assert "quote" in types
+    assert "code" in types
+    assert result.report.converted >= 5
+
+  def test_callout_with_custom_emoji(self):
+    """커스텀 이모지가 있는 콜아웃 변환."""
+    html = _wrap_notion_html(
+      '<figure class="callout">'
+      '<span class="icon">🔥</span>'
+      '<div class="callout-body"><p>Important note</p></div>'
+      '</figure>'
+    )
+    result = parse_notion_html(html)
+    block = result.blocks[0]
+    assert block["type"] == "callout"
+    assert block["emoji"] == "🔥"
+
+  def test_deep_nested_list(self):
+    """중첩 리스트 변환."""
+    html = _wrap_notion_html(
+      '<ul class="bulleted-list">'
+      '<li>Level 1<ul><li>Level 2</li></ul></li>'
+      '</ul>'
+    )
+    result = parse_notion_html(html)
+    # Level 1 + Level 2 = 2 blocks
+    assert len(result.blocks) >= 2

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -893,6 +893,38 @@ class TestNestedZip:
     assert len(result.pages) == 1
     assert result.pages[0]["title"] == "Test Page"
 
+  def test_crc_corrupted_zip_entry_recovers(self, monkeypatch):
+    """CRC 검증 실패 엔트리도 우회해서 추출합니다.
+
+    Notion export ZIP에서 종종 발생하는 CRC mismatch 케이스에 대한 fallback.
+    """
+    import zipfile as zf_mod
+    from app.services import notion_import as ni
+
+    inner_buf = io.BytesIO()
+    with zipfile.ZipFile(inner_buf, "w") as zf:
+      zf.writestr("page.md", "# CRC Test\n\nContent")
+    outer_buf = io.BytesIO()
+    with zipfile.ZipFile(outer_buf, "w") as zf:
+      zf.writestr("Part-1.zip", inner_buf.getvalue())
+
+    # 첫 번째 zf.read() 호출에서 BadZipFile(CRC) 예외를 발생시킨다
+    original_read = zf_mod.ZipFile.read
+    call_count = {"n": 0}
+
+    def fake_read(self, name, pwd=None):
+      call_count["n"] += 1
+      if call_count["n"] == 1:
+        raise zf_mod.BadZipFile(f"Bad CRC-32 for file {name!r}")
+      return original_read(self, name, pwd)
+
+    monkeypatch.setattr(zf_mod.ZipFile, "read", fake_read)
+
+    # CRC 우회 경로가 발동되어도 정상 추출되어야 함
+    result = ni.extract_and_parse_zip(outer_buf.getvalue())
+    assert len(result.pages) == 1
+    assert result.pages[0]["title"] == "CRC Test"
+
   def test_nested_zip_with_images(self):
     """이중 ZIP에서 이미지를 추출합니다."""
     fake_png = b"\x89PNG" + b"\x00" * 50

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -373,6 +386,7 @@ name = "projects-display"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "pillow" },
@@ -391,6 +405,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "fastapi", specifier = ">=0.116.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pillow", specifier = ">=12.2.0" },
@@ -593,6 +608,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- 배경: Notion에서 Export한 콘텐츠(HTML, Markdown, ZIP)를 프로젝트 페이지 구조로 자동 변환하여 import할 수 있도록 합니다. 이로써 Notion과의 콘텐츠 호환성을 확보하고, 액자식 구성(토글/인용/콜아웃)과 페이지 계층을 그대로 재현합니다.
- 목적: 이슈 #35의 완료 기준 — 핵심 구조 자동 변환, 액자식 구성/서식 재현, 호환성 90%, fallback/리포트 안내 — 을 충족합니다. 실제 제공된 332.7MB Notion export ZIP에 대해 14,503개 요소를 100% 변환하며, 이중 ZIP 및 CRC mismatch 등 실전 케이스도 처리합니다.

## Changes

### 백엔드
- `app/services/notion_import.py` (신규) — Notion HTML/Markdown 파서 + ZIP 추출 서비스
  - HTML 파서: heading/paragraph/list/todo/toggle/quote/code/callout/divider/image/bookmark/table 매핑, 인라인 서식(bold/italic/strike/code/link)
  - Markdown 파서: 동일 블록 타입 + Notion Markdown 고유 패턴(서브 페이지 링크, 단독 URL → url_embed)
  - 이중 ZIP 자동 해제 (Notion `Part-N.zip` 구조 대응)
  - CSV(데이터베이스) → 텍스트 테이블 블록 변환 + 부모 페이지 자동 연결
  - CRC-32 검증 실패 엔트리 우회 fallback (Notion export 호환성 이슈 대응)
  - 변환 리포트(converted/fallback/skipped/warnings) 생성
- `app/routers/notion_import.py` (신규) — `POST /api/import/notion` 엔드포인트
  - `.html` / `.md` / `.zip` 업로드 지원, 청크 단위 읽기로 메모리 보호
  - 크기 제한 500MB, 415/413/422 상태 코드 처리
  - 페이지 계층을 PageBlock으로 연결하여 트리 복원
  - 이미지는 `process_image()`로 저장 후 블록 URL 갱신
- `main.py` — 라우터 등록
- `pyproject.toml` — `beautifulsoup4>=4.12.0` 의존성 추가

### 프론트엔드
- `static/js/notionImportModal.js` (신규) — 드래그앤드롭 / 진행 표시 / 변환 리포트 모달
- `static/js/api.js` — `apiImportNotion()` 추가
- `static/js/main.js` — 사이드바 Import 버튼 이벤트 바인딩
- `templates/index.html` — Import 버튼 추가
- `static/css/style.css` — 모달/버튼 스타일, viewer 모드에서 숨김 처리

### 테스트
- `tests/test_notion_import.py` (신규) — 88개 단위 테스트 (HTML/Markdown 파서, 이중 ZIP, CSV, CRC 우회, API)

## Test

- [x] 로컬 실행 확인 (`uvicorn main:app --reload`)
- [x] 주요 경로 확인 (`POST /api/import/notion`, `GET /`)
- [x] 브라우저 콘솔 에러 없음
- [x] 단위 테스트 88건 통과 (신규)
- [x] 전체 테스트 462건 통과 (회귀 없음)
- [x] 실제 Notion export ZIP(332.7MB) end-to-end 검증
  - 208개 페이지 / 992개 이미지 / 14,503 요소 — 변환률 100%

## Checklist

- [x] 코드 컨벤션 준수 (Python 2-space, double-quote, snake_case, type hint)
- [x] GitHub 컨벤션 준수 (브랜치/커밋/PR 제목)
- [x] 문서 업데이트 — 코드 주석에 OWASP/Notion/BeautifulSoup 출처 명시
- [x] 보안 — 관리자 인증(`require_admin`), 파일 크기/형식 검증, 청크 읽기

## Review Points

- **이중 ZIP & CRC 우회 처리** ([app/services/notion_import.py:660-688](app/services/notion_import.py#L660-L688)) — Notion export 환경별 호환성 이슈를 우회하는 로직. `_expected_crc` 비공개 속성 접근에 대한 대안 검토 의견 환영합니다.
- **페이지 계층 복원** ([app/routers/notion_import.py:138-188](app/routers/notion_import.py#L138-L188)) — 경로 기반 부모 추정 로직. 더 강건한 매칭 전략 제안 환영합니다.
- **CSV → 텍스트 블록 fallback 전략** — 향후 DatabaseBlock 매핑 확장 여지 (이슈 #35 부분 지원 항목)
- **블록 타입 매핑 누락 여부** — Notion 고유 블록(synced block, equation 등)은 텍스트 fallback 처리. 우선순위 의견 환영합니다.

Closes #35