### PR TITLE
[FEAT#69] Notion 데이터베이스 연계 정합성 개선 (CSV → DatabaseBlock)

### DIFF
--- a/app/repositories/sqlite_blocks.py
+++ b/app/repositories/sqlite_blocks.py
@@ -463,8 +463,53 @@ class SQLiteBlockRepository:
         block_type = block["type"]
         children = block.pop("children", None)
 
-        # content_json — id/type 컬럼은 제외
-        content = {k: v for k, v in block.items() if k not in ("id", "type")}
+        # ── db_row: 각 행은 독립 DocumentRow를 갖는 "페이지형 블록"이다.
+        #   (이슈 #69: Notion 데이터베이스의 레코드/페이지 개념 매핑)
+        #   - source_block_id로 DocumentRow ↔ db_row BlockRow를 연결해
+        #     `list_tree()`에서 가상 database 노드를 복원할 수 있게 한다.
+        #   - 행 본문(children)은 부모 database 문서가 아닌 해당 행의
+        #     자식 문서에 속하므로 스택 push 시 doc_id를 교체한다.
+        if block_type == "db_row":
+          row_title = (block.get("title") or "").strip() or "Untitled"
+          properties = block.get("properties", {}) or {}
+          child_doc_id = str(uuid.uuid4())
+          self._session.add(DocumentRow(
+            id=child_doc_id,
+            title=row_title,
+            subtitle="",
+            parent_id=doc_id,
+            source_block_id=block_id,
+          ))
+          content = {
+            "document_id": child_doc_id,
+            "is_reference": False,
+            "properties": properties,
+          }
+          next_pos = self._next_position(cursor_key, position_cursor)
+          self._session.add(BlockRow(
+            id=block_id,
+            document_id=doc_id,
+            parent_block_id=parent_block_id,
+            type=block_type,
+            position=next_pos,
+            content_json=json.dumps(content, ensure_ascii=False),
+          ))
+          if children:
+            stack.append((child_doc_id, None, children))
+          continue
+
+        # ── database: title/color/columns만 content_json에 저장. 행(db_row)은
+        #   children으로 전달되어 같은 database 블록의 자식으로 영속화된다.
+        if block_type == "database":
+          content = {
+            "title": block.get("title", ""),
+            "color": block.get("color", "default"),
+            "columns": block.get("columns", []),
+          }
+        else:
+          # content_json — id/type 컬럼은 제외
+          content = {k: v for k, v in block.items() if k not in ("id", "type")}
+
         next_pos = self._next_position(cursor_key, position_cursor)
 
         self._session.add(BlockRow(

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1343,11 +1343,17 @@ def _infer_column_type(values: list[str]) -> str:
   non_empty = [v.strip() for v in values if v and v.strip()]
   if not non_empty:
     return "text"
-  if all(_is_number_like(v) for v in non_empty):
-    return "number"
+  # checkbox 판정을 number 보다 먼저 수행한다.
+  # Notion 은 불리언을 "0"/"1" 로 export 하기도 하는데, 두 토큰은 숫자로도
+  # 파싱되어 number 로 오추론되는 문제가 있었다. 값 집합이 checkbox 토큰
+  # 안에 포함되는 경우에 한해 checkbox 로 판정한다.
+  # Ref: XML Schema Boolean canonical lexical form("0","1") —
+  #   https://www.w3.org/TR/xmlschema-2/#boolean
   lowered = {v.lower() for v in non_empty}
   if lowered <= (_CHECKBOX_TRUE_TOKENS | _CHECKBOX_FALSE_TOKENS):
     return "checkbox"
+  if all(_is_number_like(v) for v in non_empty):
+    return "number"
   return "text"
 
 

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -886,31 +886,38 @@ def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
       logger.error("파일 파싱 실패: %s — %s", file_path, exc)
       overall_report.warnings.append(f"파일 파싱 실패: {file_path}")
 
-  # CSV 파일 → 테이블 블록으로 변환하여 관련 페이지에 추가
+  # CSV 파일 → DatabaseBlock(+db_row)으로 변환하여 관련 페이지에 추가
+  # (이슈 #69: Notion DB 연계 정합성 — CSV는 Notion 데이터베이스의 export
+  # 산출물이므로 내부 DatabaseBlock 구조에 직접 매핑한다)
   for csv_path in csv_files:
     try:
       raw = all_files[csv_path]
       csv_text = raw.decode("utf-8-sig", errors="replace")
-      csv_blocks = _parse_csv_to_blocks(csv_text)
-      if csv_blocks:
-        csv_stem = PurePosixPath(csv_path).stem
-        # UUID 해시 제거 — Notion export는 "제목 UUID해시.csv" 패턴
-        csv_title = re.sub(r"\s+[0-9a-f]{32}$", "", csv_stem).strip() or csv_stem
+      csv_stem = PurePosixPath(csv_path).stem
+      # UUID 해시 제거 — Notion export는 "제목 UUID해시.csv" 패턴
+      csv_title = re.sub(r"\s+[0-9a-f]{32}$", "", csv_stem).strip() or csv_stem
 
-        # 부모 페이지 매칭: sub_page_links 우선 → 디렉터리 fallback
-        parent_page = _find_parent_page_for_csv(csv_path, pages)
-        if parent_page:
-          parent_page["blocks"].extend(csv_blocks)
-        else:
-          # 부모를 못 찾으면 독립 페이지로 생성
-          pages.append({
-            "path": csv_path,
-            "title": csv_title,
-            "blocks": csv_blocks,
-            "sub_page_links": [],
-          })
-        overall_report.converted += len(csv_blocks)
-        overall_report.total_elements += len(csv_blocks)
+      db_block = _parse_csv_to_database(csv_text, csv_title)
+      if db_block is None:
+        continue
+
+      # 부모 페이지 매칭: sub_page_links 우선 → 디렉터리 fallback
+      parent_page = _find_parent_page_for_csv(csv_path, pages)
+      if parent_page:
+        parent_page["blocks"].append(db_block)
+      else:
+        # 부모를 못 찾으면 독립 페이지로 생성
+        pages.append({
+          "path": csv_path,
+          "title": csv_title,
+          "blocks": [db_block],
+          "sub_page_links": [],
+        })
+
+      row_count = len(db_block["children"])
+      # database 블록 1개 + db_row N개
+      overall_report.converted += 1 + row_count
+      overall_report.total_elements += 1 + row_count
     except Exception as exc:
       logger.warning("CSV 파싱 실패: %s — %s", csv_path, exc)
       overall_report.warnings.append(f"CSV 파싱 실패: {csv_path}")
@@ -1295,37 +1302,129 @@ def parse_notion_markdown(md_content: str) -> ParsedPage:
 
 # ── CSV 파서 ────────────────────────────────────────────────────────────────────
 
-def _parse_csv_to_blocks(csv_text: str) -> list[dict[str, Any]]:
-  """Notion export CSV 파일을 텍스트 기반 블록으로 변환합니다.
+# Notion export CSV는 타입 메타데이터를 포함하지 않으므로, 값 샘플링 기반으로
+# 내부 DatabaseBlock 스키마의 컬럼 타입(number/checkbox/text)을 추론한다.
+# Ref: Notion Export — https://www.notion.so/help/export-your-content
 
-  Notion 데이터베이스는 CSV로 export되며, 첫 행이 컬럼 헤더입니다.
-  각 행을 파이프(|) 구분 텍스트 블록으로 변환합니다.
+_CHECKBOX_TRUE_TOKENS: frozenset[str] = frozenset(
+  {"yes", "y", "true", "1", "checked", "o", "v", "✓", "☑"}
+)
+_CHECKBOX_FALSE_TOKENS: frozenset[str] = frozenset(
+  {"no", "n", "false", "0", "unchecked", "x", "✗", "☐"}
+)
+
+
+def _is_number_like(raw: str) -> bool:
+  """숫자로 해석 가능한 문자열인지 판단한다 (천 단위 콤마 허용)."""
+  s = raw.strip().replace(",", "")
+  if not s:
+    return False
+  try:
+    float(s)
+    return True
+  except ValueError:
+    return False
+
+
+def _infer_column_type(values: list[str]) -> str:
+  """컬럼 값 샘플로부터 DatabaseBlock 컬럼 타입을 보수적으로 추론한다.
+
+  우선순위: 빈 컬럼 → text, 전부 숫자 → number, 전부 체크박스 토큰 → checkbox,
+  그 외 → text. 선택(select) 타입은 CSV만으로는 값과 단순 열거를 구분할 수
+  없어 오추론 위험이 크므로 본 MVP에서는 추론하지 않는다(이슈 #69 비호환
+  사항 항목: "스키마 차이" 표현 한계 명시).
+  """
+  non_empty = [v.strip() for v in values if v and v.strip()]
+  if not non_empty:
+    return "text"
+  if all(_is_number_like(v) for v in non_empty):
+    return "number"
+  lowered = {v.lower() for v in non_empty}
+  if lowered <= (_CHECKBOX_TRUE_TOKENS | _CHECKBOX_FALSE_TOKENS):
+    return "checkbox"
+  return "text"
+
+
+def _coerce_cell_value(raw: str, col_type: str) -> Any:
+  """원본 문자열을 컬럼 타입에 맞는 Python 값으로 변환한다.
+
+  변환 실패 시 원본 문자열을 그대로 반환하여 데이터 유실을 방지한다
+  (이슈 #69: "누락/불일치 데이터에 대한 폴백 정책").
+  """
+  s = (raw or "").strip()
+  if col_type == "number":
+    if not s:
+      return None
+    cleaned = s.replace(",", "")
+    try:
+      return int(cleaned) if cleaned.lstrip("-").isdigit() else float(cleaned)
+    except ValueError:
+      return s
+  if col_type == "checkbox":
+    return s.lower() in _CHECKBOX_TRUE_TOKENS
+  return s
+
+
+def _parse_csv_to_database(csv_text: str, title: str) -> dict[str, Any] | None:
+  """Notion export CSV를 내부 DatabaseBlock(+db_row) 트리로 변환한다.
+
+  변환 규칙:
+    - 첫 행을 컬럼 스키마로 사용하며, 각 컬럼에 고유 UUID를 부여한다.
+    - 컬럼 타입은 값 샘플로부터 추론한다 (`_infer_column_type`).
+    - 데이터 행은 각각 `db_row` 블록으로 만들며, `properties`는
+      `{column_id: coerced_value}` 형태로 저장한다.
+    - 첫 컬럼의 값을 해당 행(페이지)의 제목으로 사용한다
+      (Notion 데이터베이스의 Name 컬럼 관례를 따른다).
 
   Args:
-    csv_text: CSV 파일 내용 문자열.
+    csv_text: UTF-8로 디코딩된 CSV 본문.
+    title: 생성될 database 블록의 제목(파일명 기반).
 
   Returns:
-    블록 dict 리스트. 빈 CSV이면 빈 리스트.
+    database 블록 dict (children에 db_row 목록 포함). 빈 CSV이면 None.
   """
   reader = csv.reader(io.StringIO(csv_text))
   rows = list(reader)
-  if not rows:
-    return []
+  if not rows or not any(any(cell.strip() for cell in r) for r in rows):
+    return None
 
-  blocks: list[dict[str, Any]] = []
-
-  # 헤더 행
   header = rows[0]
-  if any(cell.strip() for cell in header):
-    blocks.append(_make_block("text", text=" | ".join(header), level=3))
-    blocks.append(_make_block("divider"))
+  data_rows = [r for r in rows[1:] if any(cell.strip() for cell in r)]
 
-  # 데이터 행
-  for row in rows[1:]:
-    if any(cell.strip() for cell in row):
-      blocks.append(_make_block("text", text=" | ".join(row)))
+  columns: list[dict[str, Any]] = []
+  for idx, name in enumerate(header):
+    col_values = [r[idx] if idx < len(r) else "" for r in data_rows]
+    col_type = _infer_column_type(col_values)
+    columns.append({
+      "id": str(uuid.uuid4()),
+      "name": (name or "").strip() or f"Column {idx + 1}",
+      "type": col_type,
+      "options": [],
+    })
 
-  return blocks
+  db_rows: list[dict[str, Any]] = []
+  for row in data_rows:
+    properties: dict[str, Any] = {}
+    for i, col in enumerate(columns):
+      raw = row[i] if i < len(row) else ""
+      properties[col["id"]] = _coerce_cell_value(raw, col["type"])
+    # 첫 컬럼의 원본 문자열이 페이지 제목이 된다(숫자로 강제 변환된 값이
+    # 제목에 노출되지 않도록 row 원본을 다시 참조).
+    row_title = (row[0] if row else "").strip() or "Untitled"
+    db_rows.append({
+      "type": "db_row",
+      "title": row_title,
+      "properties": properties,
+      "children": [],
+    })
+
+  return {
+    "type": "database",
+    "title": title,
+    "color": "default",
+    "columns": columns,
+    "children": db_rows,
+  }
 
 
 def _find_parent_page_for_csv(

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -901,6 +901,12 @@ def extract_and_parse_zip(zip_data: bytes) -> ImportResult:
       if db_block is None:
         continue
 
+      # 동반 row 페이지를 db_row children 으로 흡수 (이슈 #69: 중복 생성 방지)
+      # ※ 부모 매칭보다 먼저 수행해야 pages 리스트에서 row 페이지가 빠진
+      #   상태로 parent 후보를 평가한다 (동일 디렉터리 단일 페이지 fallback
+      #   로직이 row 페이지를 부모로 오판하지 않도록).
+      _absorb_row_pages_into_database(csv_path, db_block, pages)
+
       # 부모 페이지 매칭: sub_page_links 우선 → 디렉터리 fallback
       parent_page = _find_parent_page_for_csv(csv_path, pages)
       if parent_page:
@@ -1425,6 +1431,62 @@ def _parse_csv_to_database(csv_text: str, title: str) -> dict[str, Any] | None:
     "columns": columns,
     "children": db_rows,
   }
+
+
+def _absorb_row_pages_into_database(
+  csv_path: str,
+  db_block: dict[str, Any],
+  pages: list[dict[str, Any]],
+) -> None:
+  """CSV와 동반된 row .md 파일을 db_row children으로 흡수한다.
+
+  Notion은 데이터베이스를 두 가지 아티팩트로 export한다:
+    1. 요약 CSV — `Tasks <uuid>.csv`
+    2. 행 상세 페이지 — `Tasks <uuid>/<Row Title> <uuid>.md`
+
+  기존 import 로직은 두 아티팩트를 독립적으로 처리하여 동일 행이
+  (a) 부모 페이지의 하위 PageBlock 과 (b) database 블록의 db_row 로
+  중복 생성되는 문제가 있었다. 본 함수는 CSV 동반 디렉터리에 속한
+  row 페이지를 찾아 매칭된 db_row의 children 으로 이전하고,
+  `pages` 리스트에서 해당 row 페이지를 제거하여 중복을 제거한다.
+
+  매칭 규칙:
+    - CSV 경로의 stem(UUID 해시 포함)과 동일한 이름의 자매 디렉터리에
+      위치한 페이지만 후보로 한다.
+    - 후보 페이지의 title == db_row 의 title 일 때 매칭으로 본다
+      (Notion export 의 title 은 UUID 해시가 제거된 순수 제목).
+
+  Args:
+    csv_path: ZIP 내부의 CSV 경로 (예: "Root/Tasks abc...xyz.csv").
+    db_block: `_parse_csv_to_database` 결과 dict. 매칭된 db_row의
+      children 가 갱신된다.
+    pages: 현재까지 파싱된 페이지 리스트. 흡수된 페이지는 제거된다.
+  """
+  csv_pure = PurePosixPath(csv_path)
+  companion_dir = str(csv_pure.parent / csv_pure.stem)
+
+  # 후보: 동반 디렉터리 바로 아래에 있는 페이지만 (더 깊은 중첩은 제외)
+  # — title → page (중복 title이 있을 수 있으나 Notion UUID로 분리되므로 희귀)
+  title_to_page: dict[str, dict[str, Any]] = {}
+  for p in pages:
+    if str(PurePosixPath(p["path"]).parent) == companion_dir:
+      title_to_page.setdefault(p["title"], p)
+
+  if not title_to_page:
+    return
+
+  consumed_paths: set[str] = set()
+  for db_row in db_block["children"]:
+    matched = title_to_page.get(db_row["title"])
+    if matched is None:
+      continue
+    # row 페이지의 blocks 를 db_row 의 children 으로 이전한다.
+    # (db_row 는 PageBlock 파생이므로 자체 문서에 블록이 속한다)
+    db_row["children"] = matched["blocks"]
+    consumed_paths.add(matched["path"])
+
+  if consumed_paths:
+    pages[:] = [p for p in pages if p["path"] not in consumed_paths]
 
 
 def _find_parent_page_for_csv(

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1513,14 +1513,20 @@ def _absorb_row_pages_into_database(
   # Notion 의 뷰 필터/이동/삭제 등으로 CSV 와 상세 페이지 수가 어긋나는
   # 경우가 있는데, 이 페이지들도 DB 영역에 속하므로 외부에 방치하지 않고
   # database 블록 내부 row 로 흡수하여 트리 정합성을 유지한다 (이슈 #69).
-  empty_properties: dict[str, Any] = {col["id"]: "" for col in db_block.get("columns", [])}
+  # 합성 db_row 의 properties 는 컬럼 타입별 기본값으로 초기화한다.
+  # `_coerce_cell_value("", type)` 은 number → None, checkbox → False,
+  # text → "" 를 돌려주므로 기존 CSV coerce 규칙과 일관성을 유지한다.
+  default_properties: dict[str, Any] = {
+    col["id"]: _coerce_cell_value("", col["type"])
+    for col in db_block.get("columns", [])
+  }
   for p in companion_pages:
     if p["path"] in consumed_paths:
       continue
     db_block["children"].append({
       "type": "db_row",
       "title": p["title"] or "Untitled",
-      "properties": dict(empty_properties),  # 각 row 는 독립 dict 참조 유지
+      "properties": dict(default_properties),  # 각 row 는 독립 dict 참조 유지
       "children": p["blocks"],
     })
     consumed_paths.add(p["path"])

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1484,9 +1484,13 @@ def _absorb_row_pages_into_database(
   if not title_to_page:
     return
 
+  # 각 row 페이지는 정확히 하나의 db_row 에만 흡수되어야 한다.
+  # (같은 list 참조를 여러 db_row.children 에 할당하면, 영속화 시 동일한
+  #  block dict 들이 여러 번 INSERT 되어 `blocks.id` UNIQUE 제약이 깨진다.)
+  # `pop` 으로 매칭 후보에서 제거하여 중복 흡수를 방지한다.
   consumed_paths: set[str] = set()
   for db_row in db_block["children"]:
-    matched = title_to_page.get(db_row["title"])
+    matched = title_to_page.pop(db_row["title"], None)
     if matched is None:
       continue
     # row 페이지의 blocks 를 db_row 의 children 으로 이전한다.

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1474,29 +1474,50 @@ def _absorb_row_pages_into_database(
     str(csv_pure.parent / raw_stem),
   }
 
-  # 후보: 동반 디렉터리 바로 아래에 있는 페이지만 (더 깊은 중첩은 제외)
-  # — title → page (중복 title이 있을 수 있으나 Notion UUID로 분리되므로 희귀)
-  title_to_page: dict[str, dict[str, Any]] = {}
+  # 후보: 동반 디렉터리 바로 아래에 있는 페이지만 (더 깊은 중첩은 제외).
+  # Notion 은 동일 title 의 row 를 여러 개 허용하므로(예: "백엔드 정기
+  # 멘토링" 이 CSV 에 3번 등장) title 당 복수 페이지를 FIFO 로 관리한다.
+  # (기존 setdefault 방식은 첫 페이지만 매칭되어 나머지가 잔류했다.)
+  from collections import defaultdict, deque
+  title_bucket: dict[str, deque[dict[str, Any]]] = defaultdict(deque)
+  companion_pages: list[dict[str, Any]] = []
   for p in pages:
     if str(PurePosixPath(p["path"]).parent) in companion_dirs:
-      title_to_page.setdefault(p["title"], p)
+      title_bucket[p["title"]].append(p)
+      companion_pages.append(p)
 
-  if not title_to_page:
+  if not companion_pages:
     return
 
   # 각 row 페이지는 정확히 하나의 db_row 에만 흡수되어야 한다.
   # (같은 list 참조를 여러 db_row.children 에 할당하면, 영속화 시 동일한
   #  block dict 들이 여러 번 INSERT 되어 `blocks.id` UNIQUE 제약이 깨진다.)
-  # `pop` 으로 매칭 후보에서 제거하여 중복 흡수를 방지한다.
   consumed_paths: set[str] = set()
   for db_row in db_block["children"]:
-    matched = title_to_page.pop(db_row["title"], None)
-    if matched is None:
+    bucket = title_bucket.get(db_row["title"])
+    if not bucket:
       continue
+    matched = bucket.popleft()
     # row 페이지의 blocks 를 db_row 의 children 으로 이전한다.
     # (db_row 는 PageBlock 파생이므로 자체 문서에 블록이 속한다)
     db_row["children"] = matched["blocks"]
     consumed_paths.add(matched["path"])
+
+  # CSV 에 대응 row 가 없는 잔여 동반 페이지는 "합성 db_row" 로 승격한다.
+  # Notion 의 뷰 필터/이동/삭제 등으로 CSV 와 상세 페이지 수가 어긋나는
+  # 경우가 있는데, 이 페이지들도 DB 영역에 속하므로 외부에 방치하지 않고
+  # database 블록 내부 row 로 흡수하여 트리 정합성을 유지한다 (이슈 #69).
+  empty_properties: dict[str, Any] = {col["id"]: "" for col in db_block.get("columns", [])}
+  for p in companion_pages:
+    if p["path"] in consumed_paths:
+      continue
+    db_block["children"].append({
+      "type": "db_row",
+      "title": p["title"] or "Untitled",
+      "properties": dict(empty_properties),  # 각 row 는 독립 dict 참조 유지
+      "children": p["blocks"],
+    })
+    consumed_paths.add(p["path"])
 
   if consumed_paths:
     pages[:] = [p for p in pages if p["path"] not in consumed_paths]

--- a/app/services/notion_import.py
+++ b/app/services/notion_import.py
@@ -1451,8 +1451,9 @@ def _absorb_row_pages_into_database(
   `pages` 리스트에서 해당 row 페이지를 제거하여 중복을 제거한다.
 
   매칭 규칙:
-    - CSV 경로의 stem(UUID 해시 포함)과 동일한 이름의 자매 디렉터리에
-      위치한 페이지만 후보로 한다.
+    - Notion export 의 동반 디렉터리 이름은 CSV stem 에서 UUID 해시를
+      제거한 "깨끗한 제목"이다 (예: "자료 정리 <uuid>.csv" → "자료 정리/").
+      드물게 UUID 가 유지되는 export 도 있어 두 후보를 모두 시도한다.
     - 후보 페이지의 title == db_row 의 title 일 때 매칭으로 본다
       (Notion export 의 title 은 UUID 해시가 제거된 순수 제목).
 
@@ -1463,13 +1464,21 @@ def _absorb_row_pages_into_database(
     pages: 현재까지 파싱된 페이지 리스트. 흡수된 페이지는 제거된다.
   """
   csv_pure = PurePosixPath(csv_path)
-  companion_dir = str(csv_pure.parent / csv_pure.stem)
+  raw_stem = csv_pure.stem
+  clean_stem = re.sub(r"\s+[0-9a-f]{32}$", "", raw_stem).strip() or raw_stem
+
+  # UUID 가 제거된 이름을 우선하고, 원본 stem 도 허용한다 (Notion export
+  # 버전에 따라 달라지는 디렉터리 명명 차이에 대비).
+  companion_dirs = {
+    str(csv_pure.parent / clean_stem),
+    str(csv_pure.parent / raw_stem),
+  }
 
   # 후보: 동반 디렉터리 바로 아래에 있는 페이지만 (더 깊은 중첩은 제외)
   # — title → page (중복 title이 있을 수 있으나 Notion UUID로 분리되므로 희귀)
   title_to_page: dict[str, dict[str, Any]] = {}
   for p in pages:
-    if str(PurePosixPath(p["path"]).parent) == companion_dir:
+    if str(PurePosixPath(p["path"]).parent) in companion_dirs:
       title_to_page.setdefault(p["title"], p)
 
   if not title_to_page:

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1044,6 +1044,11 @@ class TestCsvParsing:
   def test_infer_column_type_checkbox(self):
     assert _infer_column_type(["Yes", "No", "yes"]) == "checkbox"
     assert _infer_column_type(["true", "false"]) == "checkbox"
+    # "0"/"1" 만 있는 컬럼은 숫자 파싱 가능하더라도 checkbox 로 우선 판정
+    assert _infer_column_type(["0", "1", "1", "0"]) == "checkbox"
+    assert _infer_column_type(["1", "1"]) == "checkbox"
+    # 2 이상의 숫자가 섞이면 checkbox 토큰 집합을 벗어나 number 유지
+    assert _infer_column_type(["0", "1", "2"]) == "number"
 
   def test_infer_column_type_text_default(self):
     assert _infer_column_type(["Alice", "Bob"]) == "text"

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -25,7 +25,9 @@ from app.services.notion_import import (
   _is_image_file,
   _make_block,
   _md_convert_inline,
-  _parse_csv_to_blocks,
+  _coerce_cell_value,
+  _infer_column_type,
+  _parse_csv_to_database,
   extract_and_parse_zip,
   parse_notion_html,
   parse_notion_markdown,
@@ -976,51 +978,120 @@ class TestNestedZip:
 # ── CSV 파싱 테스트 ──────────────────────────────────────────────────────────
 
 class TestCsvParsing:
-  """CSV 데이터베이스 파싱 테스트."""
+  """CSV → DatabaseBlock 파싱 테스트 (이슈 #69: Notion DB 연계 정합성)."""
 
-  def test_csv_to_blocks(self):
+  def test_csv_to_database_block(self):
+    """CSV가 database 블록(+ db_row children)으로 변환된다."""
     csv_text = "Name,Score\nAlice,100\nBob,95"
-    blocks = _parse_csv_to_blocks(csv_text)
-    # 헤더 + 구분선 + 2 데이터 행 = 4 블록
-    assert len(blocks) == 4
-    assert blocks[0]["type"] == "text"
-    assert blocks[0]["level"] == 3
-    assert "Name" in blocks[0]["text"]
-    assert blocks[1]["type"] == "divider"
+    db = _parse_csv_to_database(csv_text, title="Scores")
 
-  def test_empty_csv(self):
-    blocks = _parse_csv_to_blocks("")
-    assert blocks == []
+    assert db is not None
+    assert db["type"] == "database"
+    assert db["title"] == "Scores"
+    assert db["color"] == "default"
+    assert len(db["columns"]) == 2
+    assert db["columns"][0]["name"] == "Name"
+    assert db["columns"][1]["name"] == "Score"
+    # 각 컬럼에 고유 id가 부여되어야 한다
+    col_ids = [c["id"] for c in db["columns"]]
+    assert len(set(col_ids)) == 2
 
-  def test_csv_in_zip_attached_to_parent(self):
-    """ZIP 내 CSV가 부모 페이지에 블록으로 추가됩니다."""
-    md_content = "# Project\n\n- [DB](DB%20abc123.csv)"
+    rows = db["children"]
+    assert len(rows) == 2
+    assert all(r["type"] == "db_row" for r in rows)
+    # 제목은 첫 컬럼(Name) 값에서 파생
+    assert rows[0]["title"] == "Alice"
+    assert rows[1]["title"] == "Bob"
+    # properties는 column_id → 값 매핑
+    name_id, score_id = col_ids
+    assert rows[0]["properties"][name_id] == "Alice"
+    # Score는 숫자 컬럼으로 추론되어 int로 coerce
+    assert rows[0]["properties"][score_id] == 100
+
+  def test_empty_csv_returns_none(self):
+    assert _parse_csv_to_database("", title="X") is None
+    # 공백만 있는 CSV도 None
+    assert _parse_csv_to_database("\n,\n", title="X") is None
+
+  def test_header_only_csv(self):
+    """헤더만 있는 CSV도 빈 database로 생성된다(스키마만 유지)."""
+    db = _parse_csv_to_database("A,B", title="Empty")
+    assert db is not None
+    assert len(db["columns"]) == 2
+    assert db["children"] == []
+
+  def test_column_name_fallback(self):
+    """헤더가 비어있으면 Column N 으로 대체된다."""
+    db = _parse_csv_to_database(",Score\n,10", title="X")
+    assert db is not None
+    assert db["columns"][0]["name"] == "Column 1"
+    assert db["columns"][1]["name"] == "Score"
+
+  def test_ragged_rows_are_filled(self):
+    """열 수가 부족한 행은 빈 값으로 채워진다(데이터 유실 방지)."""
+    db = _parse_csv_to_database("A,B,C\n1,2\n3,4,5", title="X")
+    assert db is not None
+    row0 = db["children"][0]["properties"]
+    ids = [c["id"] for c in db["columns"]]
+    # 세 번째 컬럼은 빈 값
+    assert row0[ids[2]] in ("", None)
+
+  def test_infer_column_type_number(self):
+    assert _infer_column_type(["1", "2", "3.14"]) == "number"
+    # 천 단위 콤마 허용
+    assert _infer_column_type(["1,000", "2,500"]) == "number"
+
+  def test_infer_column_type_checkbox(self):
+    assert _infer_column_type(["Yes", "No", "yes"]) == "checkbox"
+    assert _infer_column_type(["true", "false"]) == "checkbox"
+
+  def test_infer_column_type_text_default(self):
+    assert _infer_column_type(["Alice", "Bob"]) == "text"
+    # 일부만 숫자면 text
+    assert _infer_column_type(["1", "two"]) == "text"
+    # 빈 값만 있는 경우도 text
+    assert _infer_column_type(["", ""]) == "text"
+
+  def test_coerce_cell_value(self):
+    assert _coerce_cell_value("42", "number") == 42
+    assert _coerce_cell_value("3.14", "number") == 3.14
+    assert _coerce_cell_value("", "number") is None
+    # 숫자로 변환 실패 시 원본 유지 (폴백)
+    assert _coerce_cell_value("N/A", "number") == "N/A"
+    assert _coerce_cell_value("Yes", "checkbox") is True
+    assert _coerce_cell_value("No", "checkbox") is False
+    assert _coerce_cell_value("Hello", "text") == "Hello"
+
+  def test_csv_in_zip_attached_as_database(self):
+    """ZIP 내 CSV가 부모 페이지에 database 블록으로 추가된다."""
+    md_content = "# Project\n\n- [DB](DB%20aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.csv)"
     csv_content = "Task,Status\nDo thing,Done"
     zip_data = _make_zip({
       "Root/page.md": md_content,
-      "Root/DB abc123.csv": csv_content,
+      "Root/DB aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.csv": csv_content,
     })
     result = extract_and_parse_zip(zip_data)
-    # CSV 블록이 페이지에 추가되었는지 확인
     all_blocks = []
     for page in result.pages:
       all_blocks.extend(page["blocks"])
-    # CSV 헤더 텍스트가 포함된 블록이 있어야 함
-    assert any("Task" in b.get("text", "") for b in all_blocks)
+    db_blocks = [b for b in all_blocks if b.get("type") == "database"]
+    assert len(db_blocks) == 1
+    assert db_blocks[0]["title"] == "DB"
+    assert [c["name"] for c in db_blocks[0]["columns"]] == ["Task", "Status"]
+    assert len(db_blocks[0]["children"]) == 1
 
   def test_all_csv_excluded(self):
-    """_all.csv 파일은 중복이므로 제외됩니다."""
+    """_all.csv 파일은 중복이므로 제외된다."""
     zip_data = _make_zip({
       "Root/page.md": "# Title\n\nText",
-      "Root/DB abc123.csv": "A,B\n1,2",
+      "Root/DB aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.csv": "A,B\n1,2",
       "Root/DB abc123_all.csv": "A,B\n1,2",
     })
     result = extract_and_parse_zip(zip_data)
-    # _all.csv가 처리되지 않았으므로 CSV 블록은 한 세트만 존재
-    csv_headers = [b for page in result.pages
-                   for b in page["blocks"]
-                   if b.get("level") == 3 and "A" in b.get("text", "")]
-    assert len(csv_headers) == 1
+    db_blocks = [b for page in result.pages
+                 for b in page["blocks"]
+                 if b.get("type") == "database"]
+    assert len(db_blocks) == 1
 
 
 # ── Markdown ZIP import API 테스트 ──────────────────────────────────────────
@@ -1068,3 +1139,64 @@ class TestMarkdownImportAPI:
     assert "text" in types
     assert "divider" in types
     assert "code" in types
+
+
+# ── CSV → DatabaseBlock 영속화 통합 테스트 ─────────────────────────────────────
+
+class TestCsvDatabasePersistence:
+  """import_pages가 database/db_row 블록을 올바르게 영속화하는지 검증한다.
+
+  이슈 #69 DoD: Notion 연계 시나리오에서 DB 동작이 기대값과 일치한다.
+  """
+
+  def _build_zip(self, csv_content: str) -> bytes:
+    """페이지 + CSV로 구성된 최소 Notion export ZIP을 생성한다."""
+    md_content = (
+      "# Project\n\n- [DB](DB%20aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.csv)"
+    )
+    return _make_zip({
+      "Root/page.md": md_content,
+      "Root/DB aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.csv": csv_content,
+    })
+
+  def test_import_creates_database_block_with_rows(self, client):
+    zip_data = self._build_zip("Name,Score\nAlice,100\nBob,95")
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", zip_data, "application/zip")},
+    )
+    assert resp.status_code == 201
+    doc_id = resp.json()["document_id"]
+    doc = client.get(f"/api/documents/{doc_id}").json()
+
+    db_blocks = [b for b in doc["blocks"] if b["type"] == "database"]
+    assert len(db_blocks) == 1
+    db = db_blocks[0]
+    assert db["title"] == "DB"
+    assert [c["name"] for c in db["columns"]] == ["Name", "Score"]
+    assert [c["type"] for c in db["columns"]] == ["text", "number"]
+    # db_row는 database의 자식으로 복원된다(DatabaseBlock.rows)
+    assert len(db["rows"]) == 2
+    row_titles = sorted(r["title"] for r in db["rows"])
+    assert row_titles == ["Alice", "Bob"]
+
+  def test_db_rows_have_child_documents(self, client):
+    """각 db_row는 자체 문서를 가지며 properties가 보존된다."""
+    zip_data = self._build_zip("Name,Done\nTask A,Yes\nTask B,No")
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", zip_data, "application/zip")},
+    )
+    doc_id = resp.json()["document_id"]
+    doc = client.get(f"/api/documents/{doc_id}").json()
+    db = next(b for b in doc["blocks"] if b["type"] == "database")
+    done_col_id = next(c["id"] for c in db["columns"] if c["name"] == "Done")
+
+    # checkbox 타입으로 추론되어 bool로 coerce
+    done_values = {r["title"]: r["properties"][done_col_id] for r in db["rows"]}
+    assert done_values == {"Task A": True, "Task B": False}
+
+    # 각 행은 독립 문서이므로 GET /api/documents/<row.document_id>이 200
+    for row in db["rows"]:
+      row_doc = client.get(f"/api/documents/{row['document_id']}")
+      assert row_doc.status_code == 200

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1080,6 +1080,69 @@ class TestCsvParsing:
     assert [c["name"] for c in db_blocks[0]["columns"]] == ["Task", "Status"]
     assert len(db_blocks[0]["children"]) == 1
 
+  def test_row_pages_absorbed_into_db_rows(self):
+    """CSV 동반 row .md 파일이 db_row의 children으로 흡수된다.
+
+    동일 행이 부모 페이지의 하위 PageBlock 과 database 의 db_row 로
+    중복 생성되면 안 된다 (이슈 #69).
+    """
+    uuid_hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    row_uuid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    md_parent = f"# Project\n\n- [Tasks](Tasks%20{uuid_hash}.csv)"
+    md_row_a = "# Task A\n\nDetail for A"
+    csv_content = "Name,Status\nTask A,Done\nTask B,Todo"
+    zip_data = _make_zip({
+      "Root/page.md": md_parent,
+      f"Root/Tasks {uuid_hash}.csv": csv_content,
+      f"Root/Tasks {uuid_hash}/Task A {row_uuid}.md": md_row_a,
+    })
+    result = extract_and_parse_zip(zip_data)
+
+    # row 페이지는 pages 리스트에서 제거되어 있어야 한다
+    remaining_paths = [p["path"] for p in result.pages]
+    assert not any("Task A" in path for path in remaining_paths)
+
+    # database 블록의 Task A 행 children 에 원본 블록이 흡수되어야 한다
+    db_blocks = [b for p in result.pages for b in p["blocks"]
+                 if b.get("type") == "database"]
+    assert len(db_blocks) == 1
+    rows_by_title = {r["title"]: r for r in db_blocks[0]["children"]}
+    assert set(rows_by_title) == {"Task A", "Task B"}
+    # 흡수된 Task A는 "Detail for A" 텍스트 블록을 children 으로 가진다
+    assert any(
+      b.get("type") == "text" and "Detail for A" in b.get("text", "")
+      for b in rows_by_title["Task A"]["children"]
+    )
+    # 매칭 페이지가 없는 Task B 는 children 이 비어있다 (신규 생성)
+    assert rows_by_title["Task B"]["children"] == []
+
+  def test_row_pages_merged_end_to_end(self, client):
+    """API 전체 플로우: row 페이지가 db_row 에만 존재하고 트리에 중복되지 않는다."""
+    uuid_hash = "cccccccccccccccccccccccccccccccc"
+    row_uuid = "dddddddddddddddddddddddddddddddd"
+    zip_data = _make_zip({
+      "Root/page.md": f"# Parent\n\n- [Tasks](Tasks%20{uuid_hash}.csv)",
+      f"Root/Tasks {uuid_hash}.csv": "Name,Score\nAlice,100",
+      f"Root/Tasks {uuid_hash}/Alice {row_uuid}.md": "# Alice\n\nhello",
+    })
+    resp = client.post(
+      "/api/import/notion",
+      files={"file": ("export.zip", zip_data, "application/zip")},
+    )
+    assert resp.status_code == 201
+    doc = client.get(f"/api/documents/{resp.json()['document_id']}").json()
+
+    # 루트 문서에는 page 블록(=row 페이지 참조)이 없어야 한다 — db 블록 하나만.
+    block_types = [b["type"] for b in doc["blocks"]]
+    assert "database" in block_types
+    assert "page" not in block_types
+
+    # db_row 는 있고, 그 문서를 조회하면 "hello" 블록이 존재한다.
+    db = next(b for b in doc["blocks"] if b["type"] == "database")
+    assert len(db["rows"]) == 1
+    row_doc = client.get(f"/api/documents/{db['rows'][0]['document_id']}").json()
+    assert any("hello" in b.get("text", "") for b in row_doc["blocks"])
+
   def test_all_csv_excluded(self):
     """_all.csv 파일은 중복이므로 제외된다."""
     zip_data = _make_zip({

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1153,6 +1153,39 @@ class TestCsvParsing:
       for b in rows_by_title["범진님이 주신 팁"]["children"]
     )
 
+  def test_duplicate_row_titles_do_not_share_block_ids(self):
+    """같은 title 의 db_row 가 여러 개여도 block id 가 중복되지 않는다.
+
+    각 row 페이지는 최대 하나의 db_row 에만 흡수되어야 한다
+    (pop 기반 1:1 매칭). list 참조 공유는 영속화 시 UNIQUE 제약 충돌을
+    일으키므로 block id 집합 중복이 없음을 검증한다.
+    """
+    from collections import Counter
+
+    uuid_hash = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    row_uuid_a = "11111111111111111111111111111111"
+    # CSV 에 같은 title 이 두 번 등장 (Notion 에서는 드물지만 가능)
+    csv_body = "Name,Status\nDup,Done\nDup,Todo"
+    zip_data = _make_zip({
+      "Root/page.md": f"# P\n\n- [T](T%20{uuid_hash}.csv)",
+      f"Root/T {uuid_hash}.csv": csv_body,
+      f"Root/T/Dup {row_uuid_a}.md": "# Dup\n\nOnly one detail page",
+    })
+    result = extract_and_parse_zip(zip_data)
+
+    ids: list[str] = []
+    def walk(bs):
+      for b in bs:
+        if b.get("id"):
+          ids.append(b["id"])
+        for c in b.get("children") or []:
+          walk([c])
+    for p in result.pages:
+      walk(p["blocks"])
+    assert not [k for k, v in Counter(ids).items() if v > 1], (
+      "파싱 결과에 동일 block id 가 중복 등장해선 안 된다"
+    )
+
   def test_row_pages_merged_end_to_end(self, client):
     """API 전체 플로우: row 페이지가 db_row 에만 존재하고 트리에 중복되지 않는다."""
     uuid_hash = "cccccccccccccccccccccccccccccccc"

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1243,9 +1243,12 @@ class TestCsvParsing:
     row_titles = [r["title"] for r in db["children"]]
     assert row_titles == ["Alice", "Bob"]  # Bob 은 끝에 추가된 합성 row
     bob = next(r for r in db["children"] if r["title"] == "Bob")
-    # 합성 row 의 properties 는 컬럼 id 를 키로, 빈 값으로 채워진다
+    # 합성 row 의 properties 는 컬럼 id 를 키로, 타입별 기본값으로 채워진다
+    # (_coerce_cell_value 와 동일 규칙: text→"", number→None, checkbox→False)
     assert set(bob["properties"].keys()) == {c["id"] for c in db["columns"]}
-    assert all(v == "" for v in bob["properties"].values())
+    for col in db["columns"]:
+      expected = {"text": "", "number": None, "checkbox": False}[col["type"]]
+      assert bob["properties"][col["id"]] == expected
     # 원본 상세 블록을 children 으로 가진다
     assert any("orphan body" in b.get("text", "") for b in bob["children"])
 

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1091,10 +1091,11 @@ class TestCsvParsing:
     md_parent = f"# Project\n\n- [Tasks](Tasks%20{uuid_hash}.csv)"
     md_row_a = "# Task A\n\nDetail for A"
     csv_content = "Name,Status\nTask A,Done\nTask B,Todo"
+    # Notion export 의 실제 레이아웃: 동반 디렉터리에는 UUID 해시가 없다.
     zip_data = _make_zip({
       "Root/page.md": md_parent,
       f"Root/Tasks {uuid_hash}.csv": csv_content,
-      f"Root/Tasks {uuid_hash}/Task A {row_uuid}.md": md_row_a,
+      f"Root/Tasks/Task A {row_uuid}.md": md_row_a,
     })
     result = extract_and_parse_zip(zip_data)
 
@@ -1116,6 +1117,42 @@ class TestCsvParsing:
     # 매칭 페이지가 없는 Task B 는 children 이 비어있다 (신규 생성)
     assert rows_by_title["Task B"]["children"] == []
 
+  def test_row_page_absorbed_with_korean_real_notion_layout(self):
+    """Notion 실제 export 레이아웃 회귀 테스트.
+
+    예: "범진님이 주신 팁" 페이지가 "자료 정리 <uuid>.csv" 데이터베이스에
+    속하는 형태. CSV 와 같은 디렉터리에 UUID 없는 이름의 자매 폴더가 있고,
+    그 안에 row 상세 md 가 위치한다.
+    """
+    csv_uuid = "2b7b6f198639811fa1c1de11af2a0139"
+    row_uuid = "2b7b6f1986398128874fe950e502335a"
+    csv_rel = f"자료 정리 {csv_uuid}.csv"
+    parent_md = f"# 푸항항\n\n- [자료 정리]({csv_rel.replace(' ', '%20')})"
+    row_md = "# 범진님이 주신 팁\n\n실전 팁 본문"
+    csv_body = "이름,카테고리\n범진님이 주신 팁,팁"
+
+    zip_data = _make_zip({
+      "푸항항.md": parent_md,
+      f"푸항항/{csv_rel}": csv_body,
+      f"푸항항/자료 정리/범진님이 주신 팁 {row_uuid}.md": row_md,
+    })
+    result = extract_and_parse_zip(zip_data)
+
+    # row 페이지는 독립 페이지로 남아있지 않아야 한다
+    remaining_titles = [p["title"] for p in result.pages]
+    assert "범진님이 주신 팁" not in remaining_titles
+
+    db_blocks = [b for p in result.pages for b in p["blocks"]
+                 if b.get("type") == "database"]
+    assert len(db_blocks) == 1
+    rows_by_title = {r["title"]: r for r in db_blocks[0]["children"]}
+    assert "범진님이 주신 팁" in rows_by_title
+    # 흡수된 행의 children 에 본문 텍스트가 포함된다
+    assert any(
+      "실전 팁 본문" in b.get("text", "")
+      for b in rows_by_title["범진님이 주신 팁"]["children"]
+    )
+
   def test_row_pages_merged_end_to_end(self, client):
     """API 전체 플로우: row 페이지가 db_row 에만 존재하고 트리에 중복되지 않는다."""
     uuid_hash = "cccccccccccccccccccccccccccccccc"
@@ -1123,7 +1160,7 @@ class TestCsvParsing:
     zip_data = _make_zip({
       "Root/page.md": f"# Parent\n\n- [Tasks](Tasks%20{uuid_hash}.csv)",
       f"Root/Tasks {uuid_hash}.csv": "Name,Score\nAlice,100",
-      f"Root/Tasks {uuid_hash}/Alice {row_uuid}.md": "# Alice\n\nhello",
+      f"Root/Tasks/Alice {row_uuid}.md": "# Alice\n\nhello",
     })
     resp = client.post(
       "/api/import/notion",

--- a/tests/test_notion_import.py
+++ b/tests/test_notion_import.py
@@ -1186,6 +1186,64 @@ class TestCsvParsing:
       "파싱 결과에 동일 block id 가 중복 등장해선 안 된다"
     )
 
+  def test_duplicate_title_pages_all_absorbed(self):
+    """CSV 에 동일 title 의 row 가 여러 개이면 해당 수만큼 페이지가 흡수된다.
+
+    기존 setdefault 로직은 첫 페이지만 매칭되어 나머지가 잔류했다.
+    Notion 회의록 DB 의 "백엔드 정기 멘토링" 처럼 반복되는 이름에 대응.
+    """
+    uuid_hash = "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
+    uuid_a = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+    uuid_b = "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2"
+    uuid_c = "a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3"
+    csv_body = "Name,When\nMtg,D1\nMtg,D2\nMtg,D3"
+    zip_data = _make_zip({
+      "Root/page.md": f"# P\n\n- [M](M%20{uuid_hash}.csv)",
+      f"Root/M {uuid_hash}.csv": csv_body,
+      f"Root/M/Mtg {uuid_a}.md": "# Mtg\n\nalpha",
+      f"Root/M/Mtg {uuid_b}.md": "# Mtg\n\nbravo",
+      f"Root/M/Mtg {uuid_c}.md": "# Mtg\n\ncharlie",
+    })
+    result = extract_and_parse_zip(zip_data)
+    # 잔류 없음
+    assert not [p for p in result.pages if p["title"] == "Mtg"]
+    # 세 db_row 모두 고유 상세 블록을 가진다
+    db = next(b for p in result.pages for b in p["blocks"] if b.get("type") == "database")
+    texts = []
+    for row in db["children"]:
+      for child in row["children"]:
+        if child.get("type") == "text":
+          texts.append(child.get("text", ""))
+    assert {"alpha", "bravo", "charlie"} <= set(texts)
+
+  def test_orphan_companion_pages_promoted_to_db_rows(self):
+    """CSV 에 대응 row 가 없는 동반 디렉터리 페이지도 합성 db_row 로 승격된다.
+
+    Notion 의 뷰 필터/이동 등으로 CSV 와 상세 페이지 수가 어긋날 수 있다.
+    이런 orphan 도 DB 영역 외부로 새지 않고 database 블록 내부 row 로 흡수해야 한다.
+    """
+    uuid_hash = "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+    orphan_uuid = "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+    csv_body = "Name,Tag\nAlice,x"  # Bob 없음
+    zip_data = _make_zip({
+      "Root/page.md": f"# P\n\n- [D](D%20{uuid_hash}.csv)",
+      f"Root/D {uuid_hash}.csv": csv_body,
+      f"Root/D/Alice {orphan_uuid}.md": "# Alice\n\nhello",
+      f"Root/D/Bob {orphan_uuid[::-1]}.md": "# Bob\n\norphan body",
+    })
+    result = extract_and_parse_zip(zip_data)
+    # 잔류 페이지 없음
+    assert not [p for p in result.pages if p["title"] in ("Alice", "Bob")]
+    db = next(b for p in result.pages for b in p["blocks"] if b.get("type") == "database")
+    row_titles = [r["title"] for r in db["children"]]
+    assert row_titles == ["Alice", "Bob"]  # Bob 은 끝에 추가된 합성 row
+    bob = next(r for r in db["children"] if r["title"] == "Bob")
+    # 합성 row 의 properties 는 컬럼 id 를 키로, 빈 값으로 채워진다
+    assert set(bob["properties"].keys()) == {c["id"] for c in db["columns"]}
+    assert all(v == "" for v in bob["properties"].values())
+    # 원본 상세 블록을 children 으로 가진다
+    assert any("orphan body" in b.get("text", "") for b in bob["children"])
+
   def test_row_pages_merged_end_to_end(self, client):
     """API 전체 플로우: row 페이지가 db_row 에만 존재하고 트리에 중복되지 않는다."""
     uuid_hash = "cccccccccccccccccccccccccccccccc"


### PR DESCRIPTION
## Summary

- 배경: Notion export 의 데이터베이스는 CSV 로 분리되지만, 기존 import 는 CSV 를 파이프(`|`) 구분 텍스트 블록으로 평탄화하여 DB 의 의미(컬럼 타입·레코드/페이지 관계)를 잃었다. 또한 동반 row 상세 `.md` 가 부모 페이지의 PageBlock 과 database 의 db_row 양쪽에 중복 생성되는 현상이 있었다.
- 목적: CSV 를 내부 `DatabaseBlock(+db_row)` 구조로 직접 매핑하고, 동반 row 페이지를 해당 db_row 로 흡수하여 Notion DB 경험과 일치시킨다. (이슈 #69)

Closes #69

## Changes

- `app/services/notion_import.py`
  - `_parse_csv_to_database`: 헤더 → 컬럼 스키마(UUID 부여), 값 샘플로 `number`/`checkbox`/`text` 보수적 타입 추론, 첫 컬럼 원본 값을 row 제목으로 사용, 변환 실패/빈 값은 원본 유지 폴백.
  - `_absorb_row_pages_into_database`: CSV 동반 디렉터리(UUID 제거 stem 우선, 원본 stem 도 허용)의 row `.md` 를 db_row.children 으로 이전.
    - 동일 title 다수 페이지를 deque FIFO 로 1:1 매칭.
    - CSV 에 없는 orphan 상세 페이지는 합성 db_row 로 승격.
  - ZIP 처리부에서 CSV → `database` 블록 하나를 생성해 부모 페이지에 append (부모 매칭 전에 흡수 수행).
- `app/repositories/sqlite_blocks.py`
  - `_persist_imported_blocks` 에 `database`/`db_row` 분기 추가.
  - `db_row` 는 각 행마다 child `DocumentRow` 를 만들고 `source_block_id` 로 연결, children 은 행 자체 문서에 속하도록 스택 push 시 doc_id 교체.
- `tests/test_notion_import.py`
  - 파서 단위: database 구조, 컬럼 타입 추론, 값 coerce, ragged row, 한글 실제 레이아웃, 중복 title / orphan 흡수, id 중복 방지.
  - 영속화 통합: db_row 별 독립 문서 조회, 중복 page 블록 미생성.

## Test

- [x] 로컬 테스트: `uv run pytest -q` → 479 passed
- [x] 실제 Notion export ZIP(27k blocks) 로 end-to-end 영속화 성공
- [x] 동반 디렉터리 잔류 row 페이지 10 → 0
- [x] 파싱 결과 블록 id 중복 0 (UNIQUE 제약 충돌 해소)
- [ ] 브라우저에서 가져온 DB 가 실제 Notion 뷰와 시각적으로 일치하는지 수동 확인

## Checklist

- [x] 코드 컨벤션 준수 (`docs/CODE_CONVENTION.md`)
- [x] GitHub 컨벤션 준수 (`.github/GITHUB_CONVENTION.md`)
- [ ] 문서 업데이트 필요 시 반영 (이슈 #69 DoD 의 "연계 규칙/제약 사항 문서화" 는 후속 PR 에서 진행 예정)

## Review Points

- **흡수 매칭 규칙**: 동반 디렉터리 이름을 UUID 제거 stem 과 원본 stem 두 후보로 평가. Notion export 버전에 따라 달라지는 명명 차이에 대한 안전성 확인 요망.
- **Orphan 승격 정책**: CSV 행이 없는 companion 페이지도 합성 db_row 로 흡수. 잔류 방지를 우선했으나, 이후 "뷰 필터로 숨긴 행" 과 "진짜 고아 페이지" 를 구분하는 정책이 필요할 수 있음.
- **타입 추론 보수성**: `select` 타입 추론은 CSV 만으로는 오추론 위험이 커 MVP 에서 제외. 필요 시 후속에서 확장 가능한 구조.
- **repository `import_pages` 분기**: `db_row` 가 자체 `DocumentRow` 를 생성하는 점, 자식 블록을 행 자체 문서에 귀속시키는 점이 의도대로인지 확인 요망.